### PR TITLE
Update README.md to add info section about cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**NOTE:** When cloning the repo, please use git's `--recursive` flag to ensure that the sub-modules will be properly cloned and updated to the correct versions.
-
 edb is a cross platform x86/x86-64 debugger. It was inspired by [Ollydbg](http://www.ollydbg.de/ "Ollydbg"), but aims to function on x86 and x86-64 as well as multiple OS's. Linux is the only officially supported platform at the moment, but FreeBSD, OpenBSD, OSX and Windows ports are underway with varying degrees of functionality.
 
 ![Screenshot](http://codef00.com/img/debugger.png)
@@ -8,6 +6,16 @@ edb is available under the GPL 2 license, see the COPYING for details.
 
 NOTE: This README now only covers the most essential documentation, for more
 complete documentation see the [wiki](https://github.com/eteran/edb-debugger/wiki)
+
+
+Cloning
+-------
+
+When cloning the repo, please use git's `--recursive` flag to ensure that the sub-modules will be properly cloned and updated to the correct versions. Here is an example:
+
+`git clone --recursive git@github.com:eteran/edb-debugger.git`
+
+Also please note that the `QHexView` and `edissasm` submodules are setup to use SSH and not HTTPS. This means you need to setup a SSH key to your GitHub account. More information about GitHub SSH keys can be found on [GitHub Help page about GitHub SSH keys](https://help.github.com/articles/generating-ssh-keys/).
 
 Compiling
 ---------


### PR DESCRIPTION
Based on our last discussion about the issue #139 `Build fails under Fedora 21 using Qt4` and your [last commit](https://github.com/eteran/edb-debugger/commit/d789bea6f2c246dc250e208cf89b0329f6e87b55) I propose you to add a section `Cloning` to the README.md file.

With respect,
~ Cristian "Dr.Optix" Dinu