### PR TITLE
Add support for reading SSE registers on x86 systems

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -299,7 +299,7 @@ bool DebuggerCore::has_extension(quint64 ext) const {
 	case edb::string_hash<'M', 'M', 'X'>::value:
 		return (edx & bit_MMX);
 	case edb::string_hash<'X', 'M', 'M'>::value:
-		//return (edx & bit_SSE);
+		return (edx & bit_SSE);
 	default:
 		return false;
 	}
@@ -746,8 +746,12 @@ void DebuggerCore::get_state(State *state) {
 			#endif
 			}
 
-			// floating point registers
+			// floating point and SSE registers
+#if defined(EDB_X86)
+			if(ptrace(PTRACE_GETFPXREGS, active_thread(), 0, &state_impl->fpregs_) != -1) {
+#elif defined(EDB_X86_64)
 			if(ptrace(PTRACE_GETFPREGS, active_thread(), 0, &state_impl->fpregs_) != -1) {
+#endif
 			}
 
 			// debug registers

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -56,7 +56,11 @@ public:
 	
 private:
 	struct user_regs_struct   regs_;
+#if defined(EDB_X86)
+	struct user_fpxregs_struct fpregs_;
+#elif defined(EDB_X86_64)
 	struct user_fpregs_struct fpregs_;
+#endif
 	edb::reg_t                dr_[8];
 #if defined(EDB_X86)
 	edb::address_t            fs_base;


### PR DESCRIPTION
Following GDB, this commit makes use of `PTRACE_GETFPXREGS` instead of `PTRACE_GETFPREGS` on x86 targets. This way we get 1) support for reading SSE registers and 2) common format of `st_space` between x86 and x86-64.
Although in GDB there's also some code to check whether `PTRACE_GETFPXREGS` is supported, that code dates back to 1999 and is likely to be not needed these days. I've checked on Ubuntu 12.04, and `PTRACE_GETFPXREGS` works there too. So I assume any modern system with necessary version of Qt does also support `PTRACE_GETFPXREGS`.