### PR TITLE
Properly show memory expressions of sizes larger than ptrdiff_t

### DIFF
--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -515,19 +515,34 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 				case edb::Operand::TYPE_EXPRESSION:
 					do {
 						const edb::address_t effective_address = get_effective_address(operand, state);
-						edb::address_t target;
+						edb::address_t target[4]={0}; // up to size of xmmword
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {
 							switch(operand.complete_type()) {
 							case edb::Operand::TYPE_EXPRESSION8:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xff, 2, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xff, 2, 16, QChar('0'));
 								break;
 							case edb::Operand::TYPE_EXPRESSION16:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xffff, 4, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xffff, 4, 16, QChar('0'));
+								break;
+							case edb::Operand::TYPE_EXPRESSION64:
+								ret << QString("%1 = [%2] = 0x%3%4").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[1], 8, 16, QChar('0'))
+																																	  .arg(target[0], 8, 16, QChar('0'));
+								break;
+							case edb::Operand::TYPE_EXPRESSION80:
+								ret << QString("%1 = [%2] = 0x%3%4%5").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[2] & 0xffff, 4, 16, QChar('0'))
+																																		.arg(target[1], 8, 16, QChar('0'))
+																																		.arg(target[0], 8, 16, QChar('0'));
+								break;
+							case edb::Operand::TYPE_EXPRESSION128:
+								ret << QString("%1 = [%2] = 0x%3%4%5%6").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[3], 8, 16, QChar('0'))
+																																		  .arg(target[2], 8, 16, QChar('0'))
+																																		  .arg(target[1], 8, 16, QChar('0'))
+																																		  .arg(target[0], 8, 16, QChar('0'));
 								break;
 							case edb::Operand::TYPE_EXPRESSION32:
 							default:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xffffffff, 8, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xffffffff, 8, 16, QChar('0'));
 								break;
 							}
 						} else {

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -515,7 +515,7 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 				case edb::Operand::TYPE_EXPRESSION:
 					do {
 						const edb::address_t effective_address = get_effective_address(operand, state);
-						edb::address_t target[4]={0}; // up to size of xmmword
+						uint32_t target[4]={0}; // up to size of xmmword
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {
 							switch(operand.complete_type()) {

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -547,22 +547,30 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 				case edb::Operand::TYPE_EXPRESSION:
 					do {
 						const edb::address_t effective_address = get_effective_address(operand, state);
-						edb::address_t target;
+						edb::address_t target[2]={0}; // up to size of xmmword
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {
 							switch(operand.complete_type()) {
 							case edb::Operand::TYPE_EXPRESSION8:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xff, 2, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xff, 2, 16, QChar('0'));
 								break;
 							case edb::Operand::TYPE_EXPRESSION16:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xffff, 4, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xffff, 4, 16, QChar('0'));
 								break;
 							case edb::Operand::TYPE_EXPRESSION32:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target & 0xffffffff, 8, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0] & 0xffffffff, 8, 16, QChar('0'));
+								break;
+							case edb::Operand::TYPE_EXPRESSION80:
+								ret << QString("%1 = [%2] = 0x%3%4").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[1] & 0xffff, 4, 16, QChar('0'))
+																																	  .arg(target[0], 16, 16, QChar('0'));
+								break;
+							case edb::Operand::TYPE_EXPRESSION128:
+								ret << QString("%1 = [%2] = 0x%3%4").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[1], 16, 16, QChar('0'))
+																																	  .arg(target[0], 16, 16, QChar('0'));
 								break;
 							case edb::Operand::TYPE_EXPRESSION64:
 							default:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target, 16, 16, QChar('0'));
+								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(target[0], 16, 16, QChar('0'));
 								break;
 							}
 						} else {

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -547,7 +547,7 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 				case edb::Operand::TYPE_EXPRESSION:
 					do {
 						const edb::address_t effective_address = get_effective_address(operand, state);
-						edb::address_t target[2]={0}; // up to size of xmmword
+						uint64_t target[2]={0}; // up to size of xmmword
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {
 							switch(operand.complete_type()) {


### PR DESCRIPTION
This set of patches makes analysis view of instructions like `fld tbyte ptr [...]` and `movaps xmm0,xmmword ptr [...]` (and on x86 also `movq mm0, qword ptr [...]`) show correct values referred by the instructions.

I'm not sure though whether it's a good idea to use `uint32_t` for target on x86 and `uint64_t` on x86_64 — maybe use `uint64_t` on both, then the code would be identical (up to ordering of `switch` cases). But at least, the current way does work, so it's the matter of future changes.