### PR TITLE
Fix precision and range loss when printing long double

### DIFF
--- a/include/Util.h
+++ b/include/Util.h
@@ -19,6 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef UTIL_20061126_H_
 #define UTIL_20061126_H_
 
+#include <QString>
+#include <sstream>
+#include <iomanip>
+#include <type_traits>
+
 namespace util {
 
 //------------------------------------------------------------------------------
@@ -45,6 +50,13 @@ inline int percentage(int regions_finished, int regions_total, int bytes_done, i
 //------------------------------------------------------------------------------
 inline int percentage(int bytes_done, int bytes_total) {
 	return percentage(0, 1, bytes_done, bytes_total);
+}
+
+template<typename T> typename std::enable_if<std::is_floating_point<T>::value,
+QString>::type toString(T value, int precision) {
+	std::ostringstream ss;
+	ss << std::setprecision(precision) << value;
+	return QString::fromStdString(ss.str());
 }
 
 }

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -815,7 +815,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	for(int i = 0; i < 8; ++i) {
 		const long double current = state.fpu_register(i);
 		const long double prev    = last_state_.fpu_register(i);
-		register_view_items_[16 + i]->setText(0, QString("ST%1: %2").arg(i).arg(current, 0, 'g', 16));
+		register_view_items_[16 + i]->setText(0, QString("ST%1: %2").arg(i).arg(util::toString(current, 16)));
 		register_view_items_[16 + i]->setForeground(0, QBrush((current != prev && !(boost::math::isnan(prev) && boost::math::isnan(current))) ? Qt::red : palette.text()));
 	}
 

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -867,7 +867,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	for(int i = 0; i < 8; ++i) {
 		const long double current = state.fpu_register(i);
 		const long double prev    = last_state_.fpu_register(i);
-		register_view_items_[24 + i]->setText(0, QString("ST%1: %2").arg(i).arg(current, 0, 'g', 16));
+		register_view_items_[24 + i]->setText(0, QString("ST%1: %2").arg(i).arg(util::toString(current, 16)));
 		register_view_items_[24 + i]->setForeground(0, QBrush((current != prev && !(boost::math::isnan(prev) && boost::math::isnan(current))) ? Qt::red : palette.text()));
 	}
 


### PR DESCRIPTION
This fixes bug #159.
Please check that this builds on x86, I don't have access to such a system currently.