### PR TITLE
Add some functionality to `valueXX` types, use them in more places, including `reg_t` and `address_t`

### DIFF
--- a/include/Register.h
+++ b/include/Register.h
@@ -53,7 +53,7 @@ public:
 	QString name() const         { return name_; }
 	
 	template <class T>
-	T value() const              { return value_; }
+	T value() const              { return T(value_); }
 
 private:
 	bool valid() const { return type_ != TYPE_INVALID; }

--- a/include/Types.h
+++ b/include/Types.h
@@ -65,6 +65,14 @@ protected:
 		const char* const dataStart = reinterpret_cast<const char*>(&data);
 		std::memcpy(&value_, dataStart+offset, sizeof value_);
 	}
+	template<typename SmallData>
+	void copyZeroExtended(const SmallData& data) {
+		static_assert(sizeof(SmallData)<=sizeof(ValueType),"It doesn't make sense to expand a larger type into a smaller type");
+		const char* const dataStart = reinterpret_cast<const char*>(&data);
+		char* const target = reinterpret_cast<char*>(&value_);
+		std::memcpy(target, dataStart, sizeof data);
+		std::memset(target+sizeof data, 0, sizeof(value_)-sizeof(data));
+	}
 	ValueBase() = default;
 public:
 	QString toHexString() const {
@@ -88,6 +96,13 @@ struct SizedValue : public ValueBase<N,1> {
 	template<typename Data>
 	explicit SizedValue (const Data& data, std::size_t offset=0) : ValueBase<N,1>(data,offset)
 	{ static_assert(sizeof(SizedValue)*8==N,"Size is broken!"); }
+
+	template<typename SmallData>
+	static SizedValue fromZeroExtended(const SmallData& data) {
+		SizedValue created;
+		created.copyZeroExtended(data);
+		return created;
+	}
 
 	QString toString() const { return QString("%1").arg(this->value_); }
 	using ValueBase<N,1>::operator==;
@@ -138,6 +153,13 @@ struct Value80 : public ValueBase<16,5> {
 	template<typename Data>
 	explicit Value80 (const Data& data, std::size_t offset=0) : ValueBase<16,5>(data,offset)
 	{ static_assert(sizeof(Value80)*8==80,"Size is broken!"); }
+
+	template<typename SmallData>
+	static Value80 fromZeroExtended(const SmallData& data) {
+		Value80 created;
+		created.copyZeroExtended(data);
+		return created;
+	}
 
 	enum class FloatType {
 		Zero,
@@ -239,6 +261,13 @@ struct LargeSizedValue : public ValueBase<LARGE_SIZED_VALUE_ELEMENT_WIDTH,N/LARG
 	template<typename Data>
 	explicit LargeSizedValue (const Data& data, std::size_t offset=0) : BaseClass(data,offset)
 	{ static_assert(sizeof(LargeSizedValue)*8==N,"Size is broken!"); }
+
+	template<typename SmallData>
+	static LargeSizedValue fromZeroExtended(const SmallData& data) {
+		LargeSizedValue created;
+		created.copyZeroExtended(data);
+		return created;
+	}
 };
 }
 

--- a/include/Types.h
+++ b/include/Types.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "OSTypes.h"
 #include <cstdint>
 #include <QString>
+#include <QVariant>
 #include <type_traits>
 #include <cstring>
 #include <array>
@@ -107,6 +108,11 @@ struct SizedValue : public ValueBase<N,1> {
 		created.copyZeroExtended(data);
 		return created;
 	}
+
+	operator InnerValueType() const { return this->value_[0]; }
+	operator QVariant() const { return QVariant::fromValue(this->value_[0]); }
+	template<int M=0> typename std::enable_if<sizeof(void*)>=sizeof(InnerValueType) && M==0,
+	void*>::type toPointer() const { return reinterpret_cast<void*>(this->value_[0]); }
 
 	QString toString() const { return QString("%1").arg(this->value_); }
 	using ValueBase<N,1>::operator==;

--- a/include/Types.h
+++ b/include/Types.h
@@ -306,4 +306,24 @@ static_assert(std::is_standard_layout<value8>::value &&
 			  std::is_standard_layout<value512>::value,"Fixed-sized values are intended to have standard layout");
 }
 
+template<class T> typename std::enable_if<std::is_same<T,edb::value8 >::value ||
+										  std::is_same<T,edb::value16>::value ||
+										  std::is_same<T,edb::value32>::value ||
+										  std::is_same<T,edb::value64>::value,
+std::istream&>::type operator>>(std::istream& os, T& val)
+{
+	os >> val.asUint();
+	return os;
+}
+
+template<class T> typename std::enable_if<std::is_same<T,edb::value8 >::value ||
+										  std::is_same<T,edb::value16>::value ||
+										  std::is_same<T,edb::value32>::value ||
+										  std::is_same<T,edb::value64>::value,
+std::ostream&>::type operator<<(std::ostream& os, T val)
+{
+	os << val.toUint();
+	return os;
+}
+
 #endif

--- a/include/Types.h
+++ b/include/Types.h
@@ -132,7 +132,9 @@ struct SizedValue : public ValueBase<N,1> {
 	template<int M=0> typename std::enable_if<sizeof(void*)>=sizeof(InnerValueType) && M==0,
 	void*>::type toPointer() const { return reinterpret_cast<void*>(this->value_[0]); }
 
-	QString toString() const { return QString("%1").arg(this->value_); }
+	QString toString() const { return QString("%1").arg(this->value_[0]); }
+	QString unsignedToString() const { return toString(); }
+	QString signedToString() const { return QString("%1").arg(typename std::make_signed<InnerValueType>::type(this->value_[0])); }
 	using ValueBase<N,1>::operator==;
 	using ValueBase<N,1>::operator!=;
 	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator == (RHS rhs) const { return this->value_[0] == rhs; }

--- a/include/Types.h
+++ b/include/Types.h
@@ -183,8 +183,8 @@ struct Value80 : public ValueBase<16,5> {
 		Unsupported
 	};
 	FloatType floatType() const {
-		uint16_t exponent=this->exponent();
-		uint64_t mantissa=this->mantissa();
+		auto exponent=this->exponent();
+		auto mantissa=this->mantissa();
 		bool negative=value_[4] & 0x8000;
 		static constexpr uint64_t integerBitOnly=0x8000000000000000ULL;
 		static constexpr uint64_t QNaN_mask=0xc000000000000000ULL;
@@ -258,8 +258,8 @@ struct Value80 : public ValueBase<16,5> {
 		return QString::fromStdString(ss.str());
 	}
 
-	uint16_t exponent() const { return value_[4] & 0x7fff; }
-	uint64_t mantissa() const { return SizedValue<64>(value_).value()[0]; }
+	SizedValue<16> exponent() const { return value_[4] & 0x7fff; }
+	SizedValue<64> mantissa() const { return SizedValue<64>(value_); }
 };
 
 static constexpr int LARGE_SIZED_VALUE_ELEMENT_WIDTH=64;

--- a/include/Types.h
+++ b/include/Types.h
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef TYPES_20071127_H_
 #define TYPES_20071127_H_
 
-#include "ArchTypes.h"
 #include "OSTypes.h"
 #include <cstdint>
 #include <QString>
@@ -346,4 +345,5 @@ std::ostream&>::type operator<<(std::ostream& os, T val)
 	return os;
 }
 
+#include "ArchTypes.h"
 #endif

--- a/include/Types.h
+++ b/include/Types.h
@@ -109,6 +109,24 @@ struct SizedValue : public ValueBase<N,1> {
 		return created;
 	}
 
+	static SizedValue fromString(const QString& str, bool* ok=nullptr, int base=10, bool Signed=false) {
+		qulonglong v;
+		if(Signed)
+			v=str.toLongLong(ok, base);
+		else
+			v=str.toULongLong(ok, base);
+		if(!*ok)
+			return SizedValue(0);
+		// Check that the result fits into InnerValueType
+		SizedValue result(v);
+		if(result==v) return result;
+		if(ok!=nullptr) *ok=false;
+		return SizedValue(0);
+	}
+	static SizedValue fromHexString(const QString& str, bool* ok=nullptr) { return fromString(str,ok,16); }
+	static SizedValue fromSignedString(const QString& str, bool* ok=nullptr) { return fromString(str,ok,10,true); }
+	static SizedValue fromCString(const QString& str, bool* ok=nullptr) { return fromString(str,ok,0); }
+
 	operator InnerValueType() const { return this->value_[0]; }
 	operator QVariant() const { return QVariant::fromValue(this->value_[0]); }
 	template<int M=0> typename std::enable_if<sizeof(void*)>=sizeof(InnerValueType) && M==0,

--- a/include/Types.h
+++ b/include/Types.h
@@ -93,9 +93,13 @@ struct SizedValue : public ValueBase<N,1> {
 	typedef typename sized_uint<N>::type InnerValueType;
 	static_assert(N%8==0,"SizedValue must have multiple of 8 bits in size");
 	SizedValue() = default;
-	template<typename Data>
+	template<typename Data, typename = typename std::enable_if<!std::is_floating_point<Data>::value && !std::is_integral<Data>::value>::type>
 	explicit SizedValue (const Data& data, std::size_t offset=0) : ValueBase<N,1>(data,offset)
 	{ static_assert(sizeof(SizedValue)*8==N,"Size is broken!"); }
+	template<typename Float, typename dummy=void, typename check=typename std::enable_if<std::is_floating_point<Float>::value>::type>
+	explicit SizedValue(Float floatVal) { this->value_[0]=floatVal; }
+	template<typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value>::type>
+	SizedValue(Integer integer) { this->value_[0]=integer; }
 
 	template<typename SmallData>
 	static SizedValue fromZeroExtended(const SmallData& data) {

--- a/include/Types.h
+++ b/include/Types.h
@@ -90,6 +90,46 @@ struct SizedValue : public ValueBase<N,1> {
 	{ static_assert(sizeof(SizedValue)*8==N,"Size is broken!"); }
 
 	QString toString() const { return QString("%1").arg(this->value_); }
+	using ValueBase<N,1>::operator==;
+	using ValueBase<N,1>::operator!=;
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator == (RHS rhs) const { return this->value_[0] == rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator != (RHS rhs) const { return this->value_[0] != rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator >  (RHS rhs) const { return this->value_[0] >  rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator <  (RHS rhs) const { return this->value_[0] <  rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator >= (RHS rhs) const { return this->value_[0] >= rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, bool>::type operator <= (RHS rhs) const { return this->value_[0] <= rhs; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator + (RHS rhs) const { return SizedValue(this->value_[0] + rhs); }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator - (RHS rhs) const { return SizedValue(this->value_[0] - rhs); }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator & (RHS rhs) const { return SizedValue(this->value_[0] & rhs); }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator % (RHS rhs) const { return SizedValue(this->value_[0] % rhs); }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator += (RHS rhs) { this->value_[0] += rhs; return *this; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator -= (RHS rhs) { this->value_[0] -= rhs; return *this; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator ^= (RHS rhs) { this->value_[0] ^= rhs; return *this; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator &= (RHS rhs) { this->value_[0] &= rhs; return *this; }
+	template<typename RHS> typename std::enable_if<std::is_integral<RHS>::value, SizedValue>::type operator |= (RHS rhs) { this->value_[0] |= rhs; return *this; }
+	bool operator >  (SizedValue other) const { return this->value_[0] >  other.value_[0]; }
+	bool operator <  (SizedValue other) const { return this->value_[0] <  other.value_[0]; }
+	bool operator >= (SizedValue other) const { return this->value_[0] >= other.value_[0]; }
+	bool operator <= (SizedValue other) const { return this->value_[0] <= other.value_[0]; }
+	SizedValue operator + (const SizedValue& other) const { return SizedValue(this->value_[0] + other.value_[0]); }
+	SizedValue operator - (const SizedValue& other) const { return SizedValue(this->value_[0] - other.value_[0]); }
+	SizedValue operator >> (int rhs) const { return SizedValue(this->value_[0] >> rhs); }
+	SizedValue operator << (int rhs) const { return SizedValue(this->value_[0] << rhs); }
+	SizedValue operator += (SizedValue other) { this->value_[0] += other.value_[0]; return *this; }
+	SizedValue operator -= (SizedValue other) { this->value_[0] -= other.value_[0]; return *this; }
+	SizedValue operator ^= (SizedValue other) { this->value_[0] ^= other.value_[0]; return *this; }
+	SizedValue operator &= (SizedValue other) { this->value_[0] &= other.value_[0]; return *this; }
+	SizedValue operator |= (SizedValue other) { this->value_[0] |= other.value_[0]; return *this; }
+	SizedValue operator <<=(SizedValue other) { this->value_[0] <<=other.value_[0]; return *this; }
+	SizedValue operator >>=(SizedValue other) { this->value_[0] >>=other.value_[0]; return *this; }
+	SizedValue operator *= (SizedValue other) { this->value_[0] *= other.value_[0]; return *this; }
+	SizedValue operator /= (SizedValue other) { this->value_[0] /= other.value_[0]; return *this; }
+	SizedValue operator %= (SizedValue other) { this->value_[0] %= other.value_[0]; return *this; }
+	SizedValue operator ++ (int) { SizedValue copy(*this); ++this->value_[0]; return copy; }
+	SizedValue operator ++ () { ++this->value_[0]; return *this; }
+	SizedValue operator + () const { return *this; }
+	InnerValueType toUint() const { return this->value_[0]; }
+	InnerValueType& asUint() { return this->value_[0]; }
 };
 
 // Not using long double because for e.g. x86_64 it has 128 bits.

--- a/include/arch/x86/ArchTypes.h
+++ b/include/arch/x86/ArchTypes.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EDB_X86
 
 namespace edb {
+	typedef value16                              seg_reg_t;
 	typedef value32                              reg_t;
 	typedef value32                              address_t;
 	typedef edisassm::Instruction<edisassm::x86> Instruction;

--- a/include/arch/x86/ArchTypes.h
+++ b/include/arch/x86/ArchTypes.h
@@ -25,8 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EDB_X86
 
 namespace edb {
-	typedef quint32                              reg_t;
-	typedef quint32                              address_t;
+	typedef value32                              reg_t;
+	typedef value32                              address_t;
 	typedef edisassm::Instruction<edisassm::x86> Instruction;
 	typedef Instruction::operand_type            Operand;
 }

--- a/include/arch/x86_64/ArchTypes.h
+++ b/include/arch/x86_64/ArchTypes.h
@@ -25,8 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EDB_X86_64
 
 namespace edb {
-	typedef quint64                                 reg_t;
-	typedef quint64                                 address_t;
+	typedef value64                                 reg_t;
+	typedef value64                                 address_t;
 	typedef edisassm::Instruction<edisassm::x86_64> Instruction;
 	typedef Instruction::operand_type               Operand;
 }

--- a/include/arch/x86_64/ArchTypes.h
+++ b/include/arch/x86_64/ArchTypes.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EDB_X86_64
 
 namespace edb {
+	typedef value16                                 seg_reg_t;
 	typedef value64                                 reg_t;
 	typedef value64                                 address_t;
 	typedef edisassm::Instruction<edisassm::x86_64> Instruction;

--- a/plugins/Analyzer/Analyzer.cpp
+++ b/plugins/Analyzer/Analyzer.cpp
@@ -184,7 +184,7 @@ void Analyzer::mark_function_start() {
 
 	const edb::address_t address = edb::v1::cpu_selected_address();
 	if(IRegion::pointer region = edb::v1::memory_regions().find_region(address)) {
-		qDebug("Added %p to the list of known functions", reinterpret_cast<void *>(address));
+		qDebug("Added %p to the list of known functions", address.toPointer());
 		specified_functions_.insert(address);
 		invalidate_dynamic_analysis(region);
 	}
@@ -300,7 +300,7 @@ void Analyzer::bonus_symbols(RegionData *data) {
 		const edb::address_t addr = sym->address;
 
 		if(data->region->contains(addr) && sym->is_code()) {
-			qDebug("[Analyzer] adding: %s <%p>", qPrintable(sym->name), reinterpret_cast<void *>(addr));
+			qDebug("[Analyzer] adding: %s <%p>", qPrintable(sym->name), addr.toPointer());
 			data->known_functions.insert(addr);
 		}
 	}
@@ -316,7 +316,7 @@ void Analyzer::bonus_marked_functions(RegionData *data) {
 
 	for(const edb::address_t addr: specified_functions_) {
 		if(data->region->contains(addr)) {
-			qDebug("[Analyzer] adding user marked function: <%p>", reinterpret_cast<void *>(addr));
+			qDebug("[Analyzer] adding user marked function: <%p>", addr.toPointer());
 			data->known_functions.insert(addr);
 		}
 	}
@@ -521,7 +521,7 @@ void Analyzer::collect_functions(Analyzer::RegionData *data) {
 
 	qDebug() << "----------Basic Blocks----------";
 	for(auto it = basic_blocks.begin(); it != basic_blocks.end(); ++it) {
-		qDebug("%p:", reinterpret_cast<void *>(it.key()));
+		qDebug("%p:", it.key().toPointer());
 
 		for(auto j = it.value().begin(); j != it.value().end(); ++j) {
 			const instruction_pointer &inst = *j;
@@ -735,7 +735,7 @@ void Analyzer::bonus_entry_point(RegionData *data) const {
 			entry += data->region->start();
 		}
 
-		qDebug("[Analyzer] found entry point: %p", reinterpret_cast<void*>(entry));
+		qDebug("[Analyzer] found entry point: %p", entry.toPointer());
 
 		if(data->region->contains(entry)) {
 			data->known_functions.insert(entry);

--- a/plugins/Analyzer/AnalyzerWidget.cpp
+++ b/plugins/Analyzer/AnalyzerWidget.cpp
@@ -135,7 +135,7 @@ void AnalyzerWidget::mousePressEvent(QMouseEvent *event) {
 		const IAnalyzer::FunctionMap functions = edb::v1::analyzer()->functions(region);
 		if(region->size() != 0 && !functions.empty()) {
 			const auto byte_width = static_cast<float>(width()) / region->size();
-			const edb::address_t address = qBound(region->start(), region->start() + static_cast<edb::address_t>(event->x() / byte_width), region->end() - 1);
+			const edb::address_t address = qBound(region->start(), region->start() + edb::address_t(event->x() / byte_width), region->end() - 1);
 			edb::v1::jump_to_address(address);
 		}
 	}

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -981,14 +981,14 @@ QList<Module> DebuggerCore::loaded_modules() const {
 				if(process->read_bytes(debug_pointer, &dynamic_info, sizeof(dynamic_info))) {
 					if(dynamic_info.r_map) {
 
-						auto link_address = reinterpret_cast<edb::address_t>(dynamic_info.r_map);
+						auto link_address = edb::address_t(dynamic_info.r_map);
 
 						while(link_address) {
 
 							struct link_map map;
 							if(process->read_bytes(link_address, &map, sizeof(map))) {
 								char path[PATH_MAX];
-								if(!process->read_bytes(reinterpret_cast<edb::address_t>(map.l_name), &path, sizeof(path))) {
+								if(!process->read_bytes(edb::address_t(map.l_name), &path, sizeof(path))) {
 									path[0] = '\0';
 								}
 
@@ -999,7 +999,7 @@ QList<Module> DebuggerCore::loaded_modules() const {
 									ret.push_back(module);
 								}
 
-								link_address = reinterpret_cast<edb::address_t>(map.l_next);
+								link_address = edb::address_t(map.l_next);
 							} else {
 								break;
 							}

--- a/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
@@ -41,7 +41,7 @@ PlatformEvent *PlatformEvent::clone() const {
 IDebugEvent::Message PlatformEvent::error_description() const {
 	Q_ASSERT(is_error());
 
-	auto fault_address = reinterpret_cast<edb::address_t>(siginfo_.si_addr);
+	auto fault_address = edb::address_t(siginfo_.si_addr);
 
 	switch(code()) {
 	case SIGSEGV:

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -179,11 +179,11 @@ IRegion::pointer process_map_line(const QString &line) {
 		bool ok;
 		const QStringList bounds = items[0].split("-");
 		if(bounds.size() == 2) {
-			start = bounds[0].toULongLong(&ok, 16);
+			start = edb::address_t::fromHexString(bounds[0],&ok);
 			if(ok) {
-				end = bounds[1].toULongLong(&ok, 16);
+				end = edb::address_t::fromHexString(bounds[1],&ok);
 				if(ok) {
-					base = items[2].toULongLong(&ok, 16);
+					base = edb::address_t::fromHexString(items[2],&ok);
 					if(ok) {
 						const QString perms = items[1];
 						permissions = 0;

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -632,7 +632,7 @@ edb::address_t Debugger::get_goto_expression(bool *ok) {
 
 	edb::address_t address;
 	*ok = edb::v1::get_expression_from_user(tr("Goto Address"), tr("Address:"), &address);
-	return *ok ? address : 0;
+	return *ok ? address : edb::address_t(0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/DialogInputValue.cpp
+++ b/src/DialogInputValue.cpp
@@ -25,14 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ui_DialogInputValue.h"
 
-#if defined(EDB_X86)
-	#define SNUM_FMT "%d"
-	#define UNUM_FMT "%u"
-#elif defined(EDB_X86_64)
-	#define SNUM_FMT "%lld"
-	#define UNUM_FMT "%llu"
-#endif
-
 //------------------------------------------------------------------------------
 // Name: DialogInputValue
 // Desc:
@@ -69,10 +61,9 @@ edb::reg_t DialogInputValue::value() const {
 // Desc:
 //------------------------------------------------------------------------------
 void DialogInputValue::set_value(edb::reg_t value) {
-	QString temp;
 	ui->hexInput->setText(edb::v1::format_pointer(value));
-	ui->signedInput->setText(temp.sprintf(SNUM_FMT, value));
-	ui->unsignedInput->setText(temp.sprintf(UNUM_FMT, value));
+	ui->signedInput->setText(value.signedToString());
+	ui->unsignedInput->setText(value.unsignedToString());
 }
 
 //------------------------------------------------------------------------------
@@ -87,9 +78,8 @@ void DialogInputValue::on_hexInput_textEdited(const QString &s) {
 		value = 0;
 	}
 
-	QString temp;
-	ui->signedInput->setText(temp.sprintf(SNUM_FMT, value));
-	ui->unsignedInput->setText(temp.sprintf(UNUM_FMT, value));
+	ui->signedInput->setText(value.signedToString());
+	ui->unsignedInput->setText(value.unsignedToString());
 
 }
 
@@ -105,9 +95,8 @@ void DialogInputValue::on_signedInput_textEdited(const QString &s) {
 		value = 0;
 	}
 
-	QString temp;
 	ui->hexInput->setText(edb::v1::format_pointer(value));
-	ui->unsignedInput->setText(temp.sprintf(UNUM_FMT, value));
+	ui->unsignedInput->setText(value.unsignedToString());
 }
 
 //------------------------------------------------------------------------------
@@ -121,7 +110,6 @@ void DialogInputValue::on_unsignedInput_textEdited(const QString &s) {
 	if(!ok) {
 		value = 0;
 	}
-	QString temp;
 	ui->hexInput->setText(edb::v1::format_pointer(value));
-	ui->signedInput->setText(temp.sprintf(SNUM_FMT, value));
+	ui->signedInput->setText(value.signedToString());
 }

--- a/src/DialogInputValue.cpp
+++ b/src/DialogInputValue.cpp
@@ -53,7 +53,7 @@ DialogInputValue::~DialogInputValue() {
 //------------------------------------------------------------------------------
 edb::reg_t DialogInputValue::value() const {
 	bool ok;
-	return ui->hexInput->text().toULongLong(&ok, 16);
+	return edb::reg_t::fromHexString(ui->hexInput->text(),&ok);
 }
 
 //------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ void DialogInputValue::set_value(edb::reg_t value) {
 //------------------------------------------------------------------------------
 void DialogInputValue::on_hexInput_textEdited(const QString &s) {
 	bool ok;
-	edb::reg_t value = s.toULongLong(&ok, 16);
+	edb::reg_t value = edb::reg_t::fromHexString(s,&ok);
 
 	if(!ok) {
 		value = 0;
@@ -89,7 +89,7 @@ void DialogInputValue::on_hexInput_textEdited(const QString &s) {
 //------------------------------------------------------------------------------
 void DialogInputValue::on_signedInput_textEdited(const QString &s) {
 	bool ok;
-	edb::reg_t value = s.toLongLong(&ok, 10);
+	edb::reg_t value = edb::reg_t::fromSignedString(s,&ok);
 
 	if(!ok) {
 		value = 0;
@@ -105,7 +105,7 @@ void DialogInputValue::on_signedInput_textEdited(const QString &s) {
 //------------------------------------------------------------------------------
 void DialogInputValue::on_unsignedInput_textEdited(const QString &s) {
 	bool ok;
-	edb::reg_t value = s.toULongLong(&ok, 10);
+	edb::reg_t value = edb::reg_t::fromString(s,&ok);
 
 	if(!ok) {
 		value = 0;

--- a/src/RegionBuffer.h
+++ b/src/RegionBuffer.h
@@ -34,7 +34,7 @@ public:
 public:
 	virtual qint64 readData(char * data, qint64 maxSize);
 	virtual qint64 writeData(const char*, qint64);
-	virtual qint64 size() const       { return region_ ? region_->size() : 0; }
+	virtual qint64 size() const       { return region_ ? region_->size().toUint() : 0; }
 	virtual bool isSequential() const { return false; }
 
 private:

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -882,7 +882,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	register_view_items_[itemNumber++]->setText(0, QString("Tag Word: 0x%1").arg(state.fpu_tag_word().toHexString()));
 
 	for(int i = 0; i < 8; ++i) {
-		register_view_items_[itemNumber]->setText(0, QString("DR%1: %2").arg(i).arg(state.debug_register(i), 0, 16));
+		register_view_items_[itemNumber]->setText(0, QString("DR%1: %2").arg(i).arg(state.debug_register(i).toHexString()));
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state.debug_register(i) != last_state_.debug_register(i)) ? Qt::red : palette.text()));
 	}
 
@@ -903,10 +903,9 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 			register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 		}
 
-		// TODO(10110111): switch to edb::value32
-		const quint32 current = state["mxcsr"].value<edb::reg_t>();
-		const quint32 prev    = last_state_["mxcsr"].value<edb::reg_t>();
-		register_view_items_[itemNumber]->setText(0, QString("MXCSR: %1").arg(current, 0, 16));
+		const edb::value32 current = state["mxcsr"].value<edb::value32>();
+		const edb::value32 prev    = last_state_["mxcsr"].value<edb::value32>();
+		register_view_items_[itemNumber]->setText(0, QString("MXCSR: %1").arg(current.toHexString()));
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 	}
 

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -806,12 +806,12 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	}
 	register_view_items_[itemNumber++]->setText(0, QString("EFLAGS: %1").arg(edb::v1::format_pointer(state.flags())));
 
-	register_view_items_[itemNumber++]->setText(0, QString("CS: %1")     .arg(state["cs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("DS: %1")     .arg(state["ds"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("ES: %1")     .arg(state["es"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("FS: %1 (%2)").arg(state["fs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')).arg(edb::v1::format_pointer(state["fs_base"].value<edb::reg_t>())));
-	register_view_items_[itemNumber++]->setText(0, QString("GS: %1 (%2)").arg(state["gs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')).arg(edb::v1::format_pointer(state["gs_base"].value<edb::reg_t>())));
-	register_view_items_[itemNumber++]->setText(0, QString("SS: %1")     .arg(state["ss"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
+	register_view_items_[itemNumber++]->setText(0, QString("CS: %1")     .arg(state["cs"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("DS: %1")     .arg(state["ds"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("ES: %1")     .arg(state["es"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("FS: %1 (%2)").arg(state["fs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["fs_base"].value<edb::reg_t>())));
+	register_view_items_[itemNumber++]->setText(0, QString("GS: %1 (%2)").arg(state["gs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["gs_base"].value<edb::reg_t>())));
+	register_view_items_[itemNumber++]->setText(0, QString("SS: %1")     .arg(state["ss"].value<edb::seg_reg_t>().toHexString()));
 
 	const int fpuTop=state.fpu_stack_pointer();
 	for(int i = 0; i < 8; ++i) {

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -835,7 +835,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 	}
 	edb::value16 controlWord=state.fpu_control_word();
-	int controlWordValue=controlWord.value()[0];
+	int controlWordValue=controlWord;
 	QString roundingMode;
 	QString precisionMode;
 	switch((controlWordValue>>10)&3) {

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -862,12 +862,12 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	}
 	register_view_items_[itemNumber++]->setText(0, QString("RFLAGS: %1").arg(edb::v1::format_pointer(state.flags())));
 
-	register_view_items_[itemNumber++]->setText(0, QString("CS: %1")     .arg(state["cs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("DS: %1")     .arg(state["ds"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("ES: %1")     .arg(state["es"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
-	register_view_items_[itemNumber++]->setText(0, QString("FS: %1 (%2)").arg(state["fs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')).arg(edb::v1::format_pointer(state["fs_base"].value<edb::reg_t>())));
-	register_view_items_[itemNumber++]->setText(0, QString("GS: %1 (%2)").arg(state["gs"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')).arg(edb::v1::format_pointer(state["gs_base"].value<edb::reg_t>())));
-	register_view_items_[itemNumber++]->setText(0, QString("SS: %1")     .arg(state["ss"].value<edb::reg_t>() & 0xffff, 4, 16, QChar('0')));
+	register_view_items_[itemNumber++]->setText(0, QString("CS: %1")     .arg(state["cs"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("DS: %1")     .arg(state["ds"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("ES: %1")     .arg(state["es"].value<edb::seg_reg_t>().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("FS: %1 (%2)").arg(state["fs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["fs_base"].value<edb::reg_t>())));
+	register_view_items_[itemNumber++]->setText(0, QString("GS: %1 (%2)").arg(state["gs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["gs_base"].value<edb::reg_t>())));
+	register_view_items_[itemNumber++]->setText(0, QString("SS: %1")     .arg(state["ss"].value<edb::seg_reg_t>().toHexString()));
 
 	const int fpuTop=state.fpu_stack_pointer();
 	for(int i = 0; i < 8; ++i) {

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -938,7 +938,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	register_view_items_[itemNumber++]->setText(0, QString("Tag Word: 0x%1").arg(state.fpu_tag_word().toHexString()));
 
 	for(int i = 0; i < 8; ++i) {
-		register_view_items_[itemNumber]->setText(0, QString("DR%1: %2").arg(i).arg(state.debug_register(i), 0, 16));
+		register_view_items_[itemNumber]->setText(0, QString("DR%1: %2").arg(i).arg(state.debug_register(i).toHexString()));
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state.debug_register(i) != last_state_.debug_register(i)) ? Qt::red : palette.text()));
 	}
 
@@ -959,10 +959,9 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 			register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 		}
 
-		// TODO(10110111): switch to edb::value32
-		const quint32 current = state["mxcsr"].value<edb::reg_t>();
-		const quint32 prev    = last_state_["mxcsr"].value<edb::reg_t>();
-		register_view_items_[itemNumber]->setText(0, QString("MXCSR: %1").arg(current, 0, 16));
+		const edb::value32 current = state["mxcsr"].value<edb::value32>();
+		const edb::value32 prev    = last_state_["mxcsr"].value<edb::value32>();
+		register_view_items_[itemNumber]->setText(0, QString("MXCSR: %1").arg(current.toHexString()));
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 
 	}

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -891,7 +891,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 	}
 	edb::value16 controlWord=state.fpu_control_word();
-	int controlWordValue=controlWord.value()[0];
+	int controlWordValue=controlWord;
 	QString roundingMode;
 	QString precisionMode;
 	switch((controlWordValue>>10)&3) {

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1129,11 +1129,7 @@ QStringList parse_command_line(const QString &cmdline) {
 // Desc:
 //------------------------------------------------------------------------------
 address_t string_to_address(const QString &s, bool *ok) {
-#if defined(EDB_X86)
-	return s.left(8).toULongLong(ok, 16);
-#elif defined(EDB_X86_64)
-	return s.left(16).toULongLong(ok, 16);
-#endif
+	return s.left(2*sizeof(edb::address_t)).toULongLong(ok, 16);
 }
 
 //------------------------------------------------------------------------------

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1129,7 +1129,7 @@ QStringList parse_command_line(const QString &cmdline) {
 // Desc:
 //------------------------------------------------------------------------------
 address_t string_to_address(const QString &s, bool *ok) {
-	return s.left(2*sizeof(edb::address_t)).toULongLong(ok, 16);
+	return edb::address_t::fromHexString(s.left(2*sizeof(edb::address_t)),ok);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This set of patches allows to use generic functions like `toHexString()` or `signedFromString()` instead of hand-coding width, filling char etc. in much more places. Also it prepares the `valueXX` types to usage in a future X86 platform state, where it'll be useful to e.g. load value of XMM register from storage space of ZMM registers etc.
Also there are some minor cleanups like removing unnecessary conditional compilation, removing uses of deprecated `QString::sprintf()` functions, and a bit more.