### PR TITLE
Do show ST(i), MMi and XMMi registers in analysis view

### DIFF
--- a/include/Register.h
+++ b/include/Register.h
@@ -36,9 +36,18 @@ public:
 		TYPE_SIMD    = 0x0020
 	};
 
+	// Expand when AVX instructions are supported
+	typedef edb::value128 StoredType;
+
 public:
 	Register();
-	Register(const QString &name, edb::reg_t value, Type type);
+	template<typename ValueType>
+	Register(const QString &name, ValueType value, Type type)
+		: name_(name),
+		  value_(StoredType::fromZeroExtended(value)),
+		  type_(type) {
+	}
+
 	Register(const Register &other);
 	Register &operator=(const Register &rhs);
 	
@@ -60,7 +69,7 @@ private:
 
 private:
 	QString    name_;
-	edb::reg_t value_;
+	StoredType value_;
 	Type       type_;
 };
 

--- a/include/Register.h
+++ b/include/Register.h
@@ -21,7 +21,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Types.h"
 #include "API.h"
+#include "Util.h"
+#include <cstring>
 #include <QString>
+#include <type_traits>
+
+class Register;
+
+template<std::size_t bitSize=0, typename ValueType, typename Type>
+Register make_Register(const QString &name, ValueType value, Type type);
 
 class EDB_EXPORT Register {
 public:
@@ -41,13 +49,6 @@ public:
 
 public:
 	Register();
-	template<typename ValueType>
-	Register(const QString &name, ValueType value, Type type)
-		: name_(name),
-		  value_(StoredType::fromZeroExtended(value)),
-		  type_(type) {
-	}
-
 	Register(const Register &other);
 	Register &operator=(const Register &rhs);
 	
@@ -60,6 +61,7 @@ public:
 
 	Type type() const            { return type_; }
 	QString name() const         { return name_; }
+	std::size_t bitSize() const  { return bitSize_; }
 	
 	template <class T>
 	T value() const              { return T(value_); }
@@ -71,6 +73,30 @@ private:
 	QString    name_;
 	StoredType value_;
 	Type       type_;
+	std::size_t bitSize_;
+
+	template<std::size_t bitSize, typename ValueType, typename Type>
+	friend Register make_Register(const QString &name, ValueType value, Type type);
 };
+
+template<std::size_t bitSize_, typename ValueType, typename Type>
+Register make_Register(const QString &name, ValueType value, Type type)
+{
+	static_assert(std::is_same<Type,Register::Type>::value,"type must be Register::Type");
+	constexpr std::size_t bitSize=(bitSize_ ? bitSize_ : BIT_LENGTH(value));
+	static_assert(bitSize_%8==0,"Strange bit size");
+
+	Register reg;
+	reg.name_=name;
+	reg.type_=type;
+	reg.bitSize_=bitSize;
+
+	constexpr std::size_t size=bitSize/8;
+	static_assert(size<=sizeof(ValueType),"ValueType appears smaller than size specified");
+	util::markMemory(&reg.value_,sizeof reg.value_);
+	std::memcpy(&reg.value_,&value,size);
+
+	return reg;
+}
 
 #endif

--- a/include/Util.h
+++ b/include/Util.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <sstream>
 #include <iomanip>
 #include <type_traits>
+#include <cstddef>
 
 namespace util {
 
@@ -68,5 +69,7 @@ inline void markMemory(void* memory, std::size_t size)
 }
 
 }
+
+#define BIT_LENGTH(expr) (8*sizeof(expr))
 
 #endif

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -1099,13 +1099,7 @@ quint64 DebuggerCore::cpu_type() const {
 // Desc:
 //------------------------------------------------------------------------------
 QString DebuggerCore::format_pointer(edb::address_t address) const {
-	char buf[32];
-#ifdef EDB_X86
-	qsnprintf(buf, sizeof(buf), "%08x", address);
-#elif defined(EDB_X86_64)
-	qsnprintf(buf, sizeof(buf), "%016llx", address);
-#endif
-	return buf;
+	return address.toHexString();
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "PlatformState.h"
 #include "Util.h"
 #include <unordered_map>
+#include <QRegExp>
 #include <QDebug>
 
 namespace DebuggerCore {
@@ -562,6 +563,17 @@ Register PlatformState::value(const QString &reg) const {
 			return make_Register(x86.flagsName, x86.flags, Register::TYPE_COND);
 		if(regName==x86.IPName)
 			return make_Register(x86.IPName, x86.IP, Register::TYPE_IP);
+	}
+	if(x87.filled) {
+		QRegExp STx("^st\\(?([0-7])\\)?$");
+		if(STx.indexIn(regName)!=-1) {
+			QChar digit=STx.cap(1).at(0);
+			assert(digit.isDigit());
+			char digitChar=digit.toLatin1();
+			std::size_t i=digitChar-'0';
+			assert(fpuIndexValid(i));
+			return make_Register(regName, x87.st(i), Register::TYPE_FPU);
+		}
 	}
 	if(avx.xmmFilled && regName==avx.mxcsrName)
 		return make_Register(avx.mxcsrName, avx.mxcsr, Register::TYPE_COND);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -154,7 +154,7 @@ std::size_t PlatformState::X87::stackPointer() const {
 	return (statusWord&0x3800)>>11;
 }
 
-std::size_t PlatformState::X87::stIndexToRIndex(std::size_t n) const {
+std::size_t PlatformState::X87::RIndexToSTIndex(std::size_t n) const {
 
 	n=(n+8-stackPointer()) % 8;
 	return n;
@@ -189,9 +189,9 @@ edb::value16 PlatformState::X87::restoreTagWord(uint16_t twd) const {
 }
 
 void PlatformState::fillFrom(const UserFPRegsStructX86& regs) {
-	x87.statusWord=regs.swd; // should be first for stIndexToRIndex() to work
+	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
 	for(std::size_t n=0;n<FPU_REG_COUNT;++n)
-		x87.R[n]=edb::value80(regs.st_space,10*x87.stIndexToRIndex(n));
+		x87.R[n]=edb::value80(regs.st_space,10*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=regs.twd; // This is the true tag word, unlike in FPX regs and x86-64 FP regs structs
 	x87.instPtrOffset=regs.fip;
@@ -202,9 +202,9 @@ void PlatformState::fillFrom(const UserFPRegsStructX86& regs) {
 	x87.filled=true;
 }
 void PlatformState::fillFrom(const UserFPXRegsStructX86& regs) {
-	x87.statusWord=regs.swd; // should be first for stIndexToRIndex() to work
+	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
 	for(std::size_t n=0;n<FPU_REG_COUNT;++n)
-		x87.R[n]=edb::value80(regs.st_space,16*x87.stIndexToRIndex(n));
+		x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=x87.restoreTagWord(regs.twd);
 	x87.instPtrOffset=regs.fip;
@@ -253,9 +253,9 @@ void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	x86.segBasesFilled=true;
 }
 void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
-	x87.statusWord=regs.swd; // should be first for stIndexToRIndex() to work
+	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
 	for(std::size_t n=0;n<FPU_REG_COUNT;++n)
-		x87.R[n]=edb::value80(regs.st_space,16*x87.stIndexToRIndex(n));
+		x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=x87.restoreTagWord(regs.ftw);
 	x87.instPtrOffset=regs.rip; // FIXME
@@ -292,9 +292,9 @@ void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) 
 	// it looks as if the registers have always been zero. Thus we should provide the same
 	// illusion to the user.
 	if(statePresentX87) {
-		x87.statusWord=regs.swd; // should be first for stIndexToRIndex() to work
+		x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
 		for(std::size_t n=0;n<FPU_REG_COUNT;++n)
-			x87.R[n]=edb::value80(regs.st_space,16*x87.stIndexToRIndex(n));
+			x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 		x87.controlWord=regs.cwd;
 		x87.tagWord=x87.restoreTagWord(regs.twd);
 		x87.instPtrOffset=regs.fioff; // FIXME: x86_64 has different meaning of these?

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -178,6 +178,10 @@ int PlatformState::X87::recreateTag(edb::value80 value) const {
 	}
 }
 
+edb::value80 PlatformState::X87::st(std::size_t n) const {
+	return R[STIndexToRIndex(n)];
+}
+
 int PlatformState::X87::makeTag(std::size_t n, uint16_t twd) const {
 	int minitag=(twd>>n)&0x1;
 	return minitag ? recreateTag(R[n]) : TAG_EMPTY;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -575,6 +575,17 @@ Register PlatformState::value(const QString &reg) const {
 			return make_Register(regName, x87.st(i), Register::TYPE_FPU);
 		}
 	}
+	if(x87.filled) {
+		QRegExp MMx("^mm([0-7])$");
+		if(MMx.indexIn(regName)!=-1) {
+			QChar digit=MMx.cap(1).at(0);
+			assert(digit.isDigit());
+			char digitChar=digit.toLatin1();
+			std::size_t i=digitChar-'0';
+			assert(mmxIndexValid(i));
+			return make_Register(regName, x87.R[i].mantissa(), Register::TYPE_SIMD);
+		}
+	}
 	if(avx.xmmFilled && regName==avx.mxcsrName)
 		return make_Register(avx.mxcsrName, avx.mxcsr, Register::TYPE_COND);
 	return Register();

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -331,6 +331,13 @@ void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) 
 		avx.xmmFilled=true;
 		avx.ymmFilled=true;
 	} else if(statePresentSSE) {
+		// If AVX state management has been enabled by the OS,
+		// the state may be not present due to lazy saving,
+		// so initialize the space with zeros
+		if(avx.xcr0 & X86XState::FEATURE_AVX)
+			for(std::size_t n=0;n<YMM_REG_COUNT;++n)
+				avx.setYMM(n,edb::value256::fromZeroExtended(0));
+		// Now we can fill in the XMM registers
 		for(std::size_t n=0;n<XMM_REG_COUNT;++n)
 			avx.setXMM(n,edb::value128(regs.xmm_space,16*n));
 		avx.mxcsr=regs.mxcsr;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -160,6 +160,12 @@ std::size_t PlatformState::X87::RIndexToSTIndex(std::size_t n) const {
 	return n;
 }
 
+std::size_t PlatformState::X87::STIndexToRIndex(std::size_t n) const {
+
+	n=(n+stackPointer()) % 8;
+	return n;
+}
+
 int PlatformState::X87::recreateTag(edb::value80 value) const {
 	switch(value.floatType())
 	{

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -586,6 +586,16 @@ Register PlatformState::value(const QString &reg) const {
 			return make_Register(regName, x87.R[i].mantissa(), Register::TYPE_SIMD);
 		}
 	}
+	if(avx.xmmFilled) {
+		QRegExp XMMx("^xmm([0-9]|1[0-5])$");
+		if(XMMx.indexIn(regName)!=-1) {
+			bool ok=false;
+			std::size_t i=XMMx.cap(1).toUShort(&ok);
+			assert(ok);
+			if(xmmIndexValid(i)) // May be invalid but legitimate for a disassembler: e.g. XMM13 but 32 bit mode
+				return make_Register(regName, avx.xmm(i), Register::TYPE_SIMD);
+		}
+	}
 	if(avx.xmmFilled && regName==avx.mxcsrName)
 		return make_Register(avx.mxcsrName, avx.mxcsr, Register::TYPE_COND);
 	return Register();

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -287,7 +287,7 @@ private:
 		bool empty() const;
 		std::size_t stackPointer() const;
 		// Convert from ST(n) index n to Rx index x
-		std::size_t stIndexToRIndex(std::size_t index) const;
+		std::size_t RIndexToSTIndex(std::size_t index) const;
 		// Restore the full FPU Tag Word from the ptrace-filtered version
 		edb::value16 restoreTagWord(uint16_t twd) const;
 		int tag(std::size_t n) const;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -288,6 +288,7 @@ private:
 		std::size_t stackPointer() const;
 		// Convert from ST(n) index n to Rx index x
 		std::size_t RIndexToSTIndex(std::size_t index) const;
+		std::size_t STIndexToRIndex(std::size_t index) const;
 		// Restore the full FPU Tag Word from the ptrace-filtered version
 		edb::value16 restoreTagWord(uint16_t twd) const;
 		int tag(std::size_t n) const;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -292,6 +292,7 @@ private:
 		// Restore the full FPU Tag Word from the ptrace-filtered version
 		edb::value16 restoreTagWord(uint16_t twd) const;
 		int tag(std::size_t n) const;
+		edb::value80 st(std::size_t n) const;
 		enum Tag {
 			TAG_VALID=0,
 			TAG_ZERO=1,

--- a/src/Register.cpp
+++ b/src/Register.cpp
@@ -31,7 +31,11 @@ Register::Register() : type_(TYPE_INVALID) {
 // Name: Register
 // Desc:
 //------------------------------------------------------------------------------
-Register::Register(const Register &other) : name_(other.name_), value_(other.value_), type_(other.type_) {
+Register::Register(const Register &other)
+	: name_(other.name_),
+	  value_(other.value_),
+	  type_(other.type_),
+	  bitSize_(other.bitSize_) {
 }
 
 //------------------------------------------------------------------------------
@@ -43,6 +47,7 @@ Register &Register::operator=(const Register &rhs) {
 		name_         = rhs.name_;
 		value_        = rhs.value_;
 		type_         = rhs.type_;
+		bitSize_      = rhs.bitSize_;
 	}
 	return *this;
 }
@@ -55,7 +60,7 @@ bool Register::operator==(const Register &rhs) const {
 	if(!valid() && !rhs.valid()) {
 		return true;
 	} else {
-		return name_ == rhs.name_ && value_ == rhs.value_ && type_ == rhs.type_;
+		return name_ == rhs.name_ && value_ == rhs.value_ && type_ == rhs.type_ && bitSize_ == rhs.bitSize_;
 	}
 }
 

--- a/src/Register.cpp
+++ b/src/Register.cpp
@@ -31,13 +31,6 @@ Register::Register() : type_(TYPE_INVALID) {
 // Name: Register
 // Desc:
 //------------------------------------------------------------------------------
-Register::Register(const QString &name, edb::reg_t value, Type type) : name_(name), value_(value), type_(type) {
-}
-
-//------------------------------------------------------------------------------
-// Name: Register
-// Desc:
-//------------------------------------------------------------------------------
 Register::Register(const Register &other) : name_(other.name_), value_(other.value_), type_(other.type_) {
 }
 

--- a/src/arch/x86/ArchProcessor.cpp
+++ b/src/arch/x86/ArchProcessor.cpp
@@ -897,7 +897,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 				valueString=" "+current.toString();
 		}
 
-		register_view_items_[itemNumber]->setText(0, QString("%1R%2: %3 0x%4%5%6").arg(fpuTop==i?"=>":"  ").arg(i).arg(tag.leftJustified(8)).arg(current.toHexString()).arg(valueString).arg(typeString));
+		register_view_items_[itemNumber]->setText(0, QString("%1R%2: %3 %4%5%6").arg(fpuTop==i?"=>":"  ").arg(i).arg(tag.leftJustified(8)).arg(current.toHexString()).arg(valueString).arg(typeString));
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 	}
 	edb::value16 controlWord=state.fpu_control_word();
@@ -945,7 +945,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	register_view_items_[itemNumber++]->setText(0, QString("  RC: %1").arg(roundingMode));
 	register_view_items_[itemNumber++]->setText(0, QString("Status Word: %1").arg(state.fpu_status_word().toHexString()));
 	register_view_items_[itemNumber++]->setText(0, QString("  TOP: %1").arg(fpuTop));
-	register_view_items_[itemNumber++]->setText(0, QString("Tag Word: 0x%1").arg(state.fpu_tag_word().toHexString()));
+	register_view_items_[itemNumber++]->setText(0, QString("Tag Word: %1").arg(state.fpu_tag_word().toHexString()));
 
 	for(int i = 0; i < 8; ++i) {
 		register_view_items_[itemNumber]->setText(0, QString("DR%1: %2").arg(i).arg(state.debug_register(i).toHexString()));

--- a/src/arch/x86_64/ArchProcessor.cpp
+++ b/src/arch/x86_64/ArchProcessor.cpp
@@ -526,37 +526,6 @@ void analyze_call(const State &state, const edb::Instruction &inst, QStringList 
 	}
 }
 
-// XXX: complete duplicate of that in x86 ArchProcessor
-std::size_t operand_size(edb::Operand::Register reg)
-{
-	if(edb::Operand::REG_RAX <= reg && reg <= edb::Operand::REG_R15)
-		return 64;
-	if(edb::Operand::REG_EAX <= reg && reg <= edb::Operand::REG_R15D)
-		return 32;
-	if(edb::Operand::REG_AX <= reg && reg <= edb::Operand::REG_R15W)
-		return 16;
-	if(edb::Operand::REG_AL <= reg && reg <= edb::Operand::REG_DIL)
-		return 8;
-	if(edb::Operand::REG_ES <= reg && reg <= edb::Operand::REG_SEG8)
-		return 16;
-	if((edb::Operand::REG_CR0 <= reg && reg <= edb::Operand::REG_CR15)||
-	   (edb::Operand::REG_DR0 <= reg && reg <= edb::Operand::REG_DR15))
-		return sizeof(edb::reg_t)*8;
-	// FIXME: what are REG_TR[0-9]?
-	if(edb::Operand::REG_MM0 <= reg && reg <= edb::Operand::REG_MM7)
-		return 64;
-	if(edb::Operand::REG_XMM0 <= reg && reg <= edb::Operand::REG_XMM15)
-		return 128;
-	if(edb::Operand::REG_ST <= reg && reg <= edb::Operand::REG_ST7)
-		return 80;
-	if(reg == edb::Operand::REG_RIP)
-	   return 64;
-	if(reg == edb::Operand::REG_EIP)
-		return 32;
-
-	return 0;
-}
-
 //------------------------------------------------------------------------------
 // Name: analyze_operands
 // Desc:
@@ -583,24 +552,34 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 					break;
 				case edb::Operand::TYPE_REGISTER:
 					{
+						// XXX: complete duplicate of the code in x86 ArchProcessor
+						Register reg=state[QString::fromStdString(edb::v1::formatter().to_string(operand))];
 						QString valueString;
-						switch(operand_size(operand.reg()))
-						{
-						case 8:
-							valueString=state[QString::fromStdString(edb::v1::formatter().to_string(operand))].value<edb::value8>().toHexString();
-							break;
-						case 16:
-							valueString=state[QString::fromStdString(edb::v1::formatter().to_string(operand))].value<edb::value16>().toHexString();
-							break;
-						case 32:
-							valueString=state[QString::fromStdString(edb::v1::formatter().to_string(operand))].value<edb::value32>().toHexString();
-							break;
-						case 64:
-							valueString=state[QString::fromStdString(edb::v1::formatter().to_string(operand))].value<edb::value64>().toHexString();
-							break;
-						// TODO: Register currently doesn't have anything larger than reg_t. Need to implement this and then add support for larger values here
-						default:
-							valueString=state[QString::fromStdString(edb::v1::formatter().to_string(operand))].value<edb::reg_t>().toHexString();
+						if(!reg) {
+							valueString="(Error: obtained invalid register value from State)";
+						} else {
+							switch(reg.bitSize()) {
+							case 8:
+								valueString=reg.value<edb::value8>().toHexString();
+								break;
+							case 16:
+								valueString=reg.value<edb::value16>().toHexString();
+								break;
+							case 32:
+								valueString=reg.value<edb::value32>().toHexString();
+								break;
+							case 64:
+								valueString=reg.value<edb::value64>().toHexString();
+								break;
+							case 80:
+								valueString=reg.value<edb::value80>().toHexString();
+								break;
+							case 128:
+								valueString=reg.value<edb::value128>().toHexString();
+								break;
+							default:
+								valueString=QString("(Error: unexpected register size %1)").arg(reg.bitSize());
+							}
 						}
 						ret << QString("%1 = %2").arg(temp_operand).arg(valueString);
 						break;


### PR DESCRIPTION
This set of patches fixes both #156 and #161 (until the disassembler supports AVX and other ISA extensions which introduce new/expand old registers).

In any case, even when the new extensions are supported, we'll no longer see wrong zeros or incorrectly-sized values in analysis view. Instead we'll get `(Error: error description)` in place of the value, which is much more useful than wrong value.