### PR TITLE
Improve defaults for installation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ default plugin path, here's how you would do that.
 	$ qmake -makefile DEFAULT_PLUGIN_PATH="/usr/lib/edb/"
 	$ make
 
+Also you can specify the install prefix like this:
+
+	$ qmake PREFIX=/usr/
+	$ make
+
 
 Installing
 ----------
@@ -49,13 +54,8 @@ Basic installation is simple, you may run
 
 	$ make install
 
-Or if you would like to specify where things should go, you probably want to 
-use something like this
-
-	make INSTALL_ROOT=/usr/ install
-
-In which case the plugins will be installed in /usr/lib/edb and the binaries 
-will be installed in /usr/bin/. Finally, if you are doing a make install, you 
-probably want to specify a default plugin path, this is done during the qmake 
-process.
+In which case the plugins will be installed in /usr/local/lib/edb and the binaries
+will be installed in /usr/local/bin/ or, if you've specified PREFIX, then it'll be
+used instead of /usr/local/. Finally, if you are doing a make install, you probably
+want to specify a default plugin path, this is done during the qmake process.
 

--- a/common.pri
+++ b/common.pri
@@ -1,0 +1,4 @@
+isEmpty(PREFIX) {
+	PREFIX=/usr/local
+}
+

--- a/debugger.pro
+++ b/debugger.pro
@@ -1,3 +1,5 @@
+include(common.pri)
+
 TEMPLATE = subdirs
 SUBDIRS  = src plugins
 

--- a/plugins/plugins-x86.pri
+++ b/plugins/plugins-x86.pri
@@ -1,4 +1,5 @@
-target.path = /lib/edb/
+include(../common.pri)
+target.path = $$PREFIX/lib/edb/
 INCLUDEPATH += $$LEVEL/include
 INCLUDEPATH += $$LEVEL/include/arch/x86
 INCLUDEPATH += $$LEVEL/src/edisassm/include

--- a/plugins/plugins-x86_64.pri
+++ b/plugins/plugins-x86_64.pri
@@ -1,4 +1,5 @@
-target.path = /lib64/edb/
+include(../common.pri)
+target.path = $$PREFIX/lib64/edb/
 INCLUDEPATH += $$LEVEL/include
 INCLUDEPATH += $$LEVEL/include/arch/x86_64
 INCLUDEPATH += $$LEVEL/src/edisassm/include

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Configuration.h"
 #include "Formatter.h"
 #include "edb.h"
+#include <QCoreApplication>
 #include <QtDebug>
 #include <QSettings>
 #include <QDir>
@@ -61,7 +62,11 @@ void Configuration::read_settings() {
 #ifdef DEFAULT_PLUGIN_PATH
 	const QString default_plugin_path = TOSTRING(DEFAULT_PLUGIN_PATH);
 #else
-	const QString default_plugin_path = QDir().absolutePath();
+	const QString edb_lib_dir=QCoreApplication::applicationDirPath()+(sizeof(void*)==8 ? "/../lib64/edb" : "/../lib/edb");
+	const QString edb_binary_dir=QCoreApplication::applicationDirPath();
+	// If the binary is in its installation directory, then look for plugins in their installation directory
+	// Otherwise assume that we are in build directory, so the plugins are in the same directory as the binary
+	const QString default_plugin_path = QRegExp(".*/bin/?$").exactMatch(edb_binary_dir) ? edb_lib_dir : edb_binary_dir;
 #endif
 
 	QSettings settings;

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,3 +1,4 @@
+include(../common.pri)
 LEVEL = ..
 
 include(../qmake/clean-objects.pri)
@@ -11,7 +12,7 @@ VPATH       += widgets $$LEVEL/include
 
 RESOURCES   = debugger.qrc
 DESTDIR     = ../
-target.path = /bin/
+target.path = $$PREFIX/bin/
 INSTALLS    += target
 QT          += xml xmlpatterns
 


### PR DESCRIPTION
These patches make it possible to specify installation prefix on `qmake` stage, rather than having to set `INSTALL_ROOT` every time you install EDB. Also the default plugin path is now set to `../lib{,64}/edb/` relative to `edb` binary location dir; `lib` vs `lib64` is chosen depending on current arch.

Thus, now it works out of the box when the user does `qmake; make; make install`, installing to `/usr/local/`, as is traditional for GNU packages, and allows to easily do thing similar to autotools' `--prefix=/usr/` option, namely `qmake PREFIX=/usr/` or similar.