### PR TITLE
Add keyboard shortcuts for Toggle Breakpoint and Run To This Line actions

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -298,6 +298,9 @@ Debugger::Debugger(QWidget *parent) : QMainWindow(parent),
 	connect(new QShortcut(QKeySequence(tr(";")), this), SIGNAL(activated()), this, SLOT(mnuCPUEditComment()));
 	connect(new QShortcut(QKeySequence(tr("Ctrl+E")), this), SIGNAL(activated()), this, SLOT(mnuCPUModify()));
 
+	// Connect the toggle breakpoing feature
+	connect(new QShortcut(QKeySequence(tr("F2")), this), SIGNAL(activated()), this, SLOT(mnuCPUToggleBreakpoint()));
+
 	setAcceptDrops(true);
 
 	// setup the list model for instruction details list
@@ -1480,7 +1483,7 @@ void Debugger::on_cpuView_customContextMenuRequested(const QPoint &pos) {
 	menu.addAction(tr("&Fill with 00's"), this, SLOT(mnuCPUFillZero()));
 	menu.addAction(tr("Fill with &NOPs"), this, SLOT(mnuCPUFillNop()));
 	menu.addSeparator();
-	menu.addAction(tr("&Add Breakpoint"), this, SLOT(mnuCPUAddBreakpoint()));
+	menu.addAction(tr("&Toggle Breakpoint"), this, SLOT(mnuCPUToggleBreakpoint()), QKeySequence(tr("F2")));
 	menu.addAction(tr("Add &Conditional Breakpoint"), this, SLOT(mnuCPUAddConditionalBreakpoint()));
 	menu.addAction(tr("&Remove Breakpoint"), this, SLOT(mnuCPURemoveBreakpoint()));
 
@@ -1688,12 +1691,12 @@ void Debugger::mnuCPURemoveComment() {
 }
 
 //------------------------------------------------------------------------------
-// Name: mnuCPUAddBreakpoint
+// Name: mnuCPUToggleBreakpoint
 // Desc:
 //------------------------------------------------------------------------------
-void Debugger::mnuCPUAddBreakpoint() {
+void Debugger::mnuCPUToggleBreakpoint() {
 	const edb::address_t address = ui.cpuView->selectedAddress();
-	edb::v1::create_breakpoint(address);
+	edb::v1::toggle_breakpoint(address);
 }
 
 //------------------------------------------------------------------------------

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -147,7 +147,7 @@ private Q_SLOTS:
 	// the manually connected CPU slots
 	void mnuCPUEditComment();
 	void mnuCPURemoveComment();
-	void mnuCPUAddBreakpoint();
+	void mnuCPUToggleBreakpoint();
 	void mnuCPUAddConditionalBreakpoint();
 	void mnuCPUFillNop();
 	void mnuCPUFillZero();

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -147,6 +147,7 @@ private Q_SLOTS:
 	// the manually connected CPU slots
 	void mnuCPUEditComment();
 	void mnuCPURemoveComment();
+	void mnuCPURunToThisLine();
 	void mnuCPUToggleBreakpoint();
 	void mnuCPUAddConditionalBreakpoint();
 	void mnuCPUFillNop();

--- a/src/Debugger.ui
+++ b/src/Debugger.ui
@@ -330,17 +330,6 @@
     <string>F1</string>
    </property>
   </action>
-  <action name="action_Toggle_Breakpoint">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Toggle Breakpoint</string>
-   </property>
-   <property name="shortcut">
-    <string>F2</string>
-   </property>
-  </action>
   <action name="action_Configure_Debugger">
    <property name="text">
     <string>&amp;Preferences</string>


### PR DESCRIPTION
This two patches the lack of Toggle Breakpoint and Run To This Line actions and shortcuts for them. I've removed the "Add Breakpoint" action and replaced it with Toggle Breakpoint as a more general one and making more sense since it'd be strange to add multiple breakpoints at the same place (unless they are conditional, but for that there's a separate menu item).