### PR TITLE
Don't dereference NULL pointer on failure to create a breakpoint

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1708,6 +1708,7 @@ void Debugger::run_to_this_line(bool pass_signal) {
 	if(!bp) {
 		edb::v1::create_breakpoint(address);
 		bp = edb::v1::find_breakpoint(address);
+		if(!bp) return;
 		bp->set_one_time(true);
 		bp->set_internal(true);
 		bp->tag = run_to_cursor_tag;


### PR DESCRIPTION
This commit fixes a crash when e.g. you start a program and press `F4`, which gives you an error message and fails to create the breakpoint. The crash occured due to trying to set one-time mode of the breakpoint, not having checked validity of the pointer.