### PR TITLE
Fix some issues with FS & GS segment bases

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -752,21 +752,14 @@ void DebuggerCore::get_state(State *state) {
 					struct user_desc desc;
 					std::memset(&desc, 0, sizeof(desc));
 
-					bool fsBaseFilled=false, gsBaseFilled=false;
 					if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state_impl->x86.segRegs[PlatformState::X86::FS] / LDT_ENTRY_SIZE), &desc) != -1) {
 						state_impl->x86.fsBase = desc.base_addr;
-						fsBaseFilled=true;
-					} else {
-						state_impl->x86.fsBase = 0;
+						state_impl->x86.fsBaseFilled=true;
 					}
 					if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state_impl->x86.segRegs[PlatformState::X86::GS] / LDT_ENTRY_SIZE), &desc) != -1) {
 						state_impl->x86.gsBase = desc.base_addr;
-						gsBaseFilled=true;
-					} else {
-						state_impl->x86.gsBase = 0;
+						state_impl->x86.gsBaseFilled=true;
 					}
-					if(fsBaseFilled && gsBaseFilled)
-						state_impl->x86.segBasesFilled=true;
 				}
 			}
 			else

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -752,11 +752,15 @@ void DebuggerCore::get_state(State *state) {
 					struct user_desc desc;
 					std::memset(&desc, 0, sizeof(desc));
 
-					if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state_impl->x86.segRegs[PlatformState::X86::FS] / LDT_ENTRY_SIZE), &desc) != -1) {
+					const edb::seg_reg_t fs=state_impl->x86.segRegs[PlatformState::X86::FS];
+					bool fsFromGDT=!(fs&0x04); // otherwise the selector picks descriptor from LDT
+					if(fsFromGDT && ptrace(PTRACE_GET_THREAD_AREA, active_thread(), fs/LDT_ENTRY_SIZE, &desc) != -1) {
 						state_impl->x86.fsBase = desc.base_addr;
 						state_impl->x86.fsBaseFilled=true;
 					}
-					if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state_impl->x86.segRegs[PlatformState::X86::GS] / LDT_ENTRY_SIZE), &desc) != -1) {
+					const edb::seg_reg_t gs=state_impl->x86.segRegs[PlatformState::X86::GS];
+					bool gsFromGDT=!(gs&0x04); // otherwise the selector picks descriptor from LDT
+					if(gsFromGDT && ptrace(PTRACE_GET_THREAD_AREA, active_thread(), gs/LDT_ENTRY_SIZE, &desc) != -1) {
 						state_impl->x86.gsBase = desc.base_addr;
 						state_impl->x86.gsBaseFilled=true;
 					}

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -744,6 +744,9 @@ void DebuggerCore::get_state(State *state) {
 			user_regs_struct regs;
 			long ptraceStatus=0;
 			if((ptraceStatus=ptrace(PTRACE_GETREGS, active_thread(), 0, &regs)) != -1) {
+
+				state_impl->fillFrom(regs);
+
 				if(IS_X86_32_BIT)
 				{
 					struct user_desc desc;
@@ -765,8 +768,6 @@ void DebuggerCore::get_state(State *state) {
 					if(fsBaseFilled && gsBaseFilled)
 						state_impl->x86.segBasesFilled=true;
 				}
-
-				state_impl->fillFrom(regs);
 			}
 			else
 				perror("PTRACE_GETREGS failed");

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -260,8 +260,9 @@ void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	x86.segRegs[X86::GS] = regs.gs;
 	x86.filled=true;
 	x86.fsBase = regs.fs_base;
+	x86.fsBaseFilled=true;
 	x86.gsBase = regs.gs_base;
-	x86.segBasesFilled=true;
+	x86.gsBaseFilled=true;
 }
 void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
 	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
@@ -455,7 +456,8 @@ void PlatformState::AVX::setZMM(std::size_t index, edb::value512 value) {
 void PlatformState::X86::clear() {
 	util::markMemory(this,sizeof(*this));
 	filled=false;
-	segBasesFilled=false;
+	fsBaseFilled=false;
+	gsBaseFilled=false;
 }
 
 bool PlatformState::X86::empty() const {
@@ -562,9 +564,9 @@ Register PlatformState::value(const QString &reg) const {
 			return found;
 		if(!!(found=findRegisterValue(x86.segRegNames, x86.segRegs, regName, Register::TYPE_SEG)))
 			return found;
-		if(regName==x86.fsBaseName)
+		if(regName==x86.fsBaseName && x86.fsBaseFilled)
 			return make_Register(x86.fsBaseName, x86.fsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
-		if(regName==x86.gsBaseName)
+		if(regName==x86.gsBaseName && x86.gsBaseFilled)
 			return make_Register(x86.gsBaseName, x86.gsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
 		if(regName==x86.flagsName)
 			return make_Register(x86.flagsName, x86.flags, Register::TYPE_COND);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -314,7 +314,8 @@ private:
 		std::array<edb::seg_reg_t,SEG_REG_COUNT> segRegs;
 		edb::address_t fsBase;
 		edb::address_t gsBase;
-		bool segBasesFilled=false;
+		bool fsBaseFilled=false;
+		bool gsBaseFilled=false;
 		bool filled=false;
 
 		void clear();

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -151,22 +151,30 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state)
 				ret = base + index * op.expression().scale + op.displacement();
 
 				if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
-					ret += state["gs_base"].valueAsAddress();
+					const Register gsBase=state["gs_base"];
+					if(!gsBase) return ret; // no way to reliably compute address
+					ret += gsBase.valueAsAddress();
 				}
 
 				if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
-					ret += state["fs_base"].valueAsAddress();
+					const Register fsBase=state["fs_base"];
+					if(!fsBase) return ret; // no way to reliably compute address
+					ret += fsBase.valueAsAddress();
 				}
 			} while(0);
 			break;
 		case edb::Operand::TYPE_ABSOLUTE:
 			ret = op.absolute().offset;
 			if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
-				ret += state["gs_base"].valueAsAddress();
+				const Register gsBase=state["gs_base"];
+				if(!gsBase) return ret; // no way to reliably compute address
+				ret += gsBase.valueAsAddress();
 			}
 
 			if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
-				ret += state["fs_base"].valueAsAddress();
+				const Register fsBase=state["fs_base"];
+				if(!fsBase) return ret; // no way to reliably compute address
+				ret += fsBase.valueAsAddress();
 			}
 			break;
 		case edb::Operand::TYPE_IMMEDIATE:
@@ -1042,8 +1050,16 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	register_view_items_[itemNumber++]->setText(0, QString("CS: %1")     .arg(state["cs"].value<edb::seg_reg_t>().toHexString()));
 	register_view_items_[itemNumber++]->setText(0, QString("DS: %1")     .arg(state["ds"].value<edb::seg_reg_t>().toHexString()));
 	register_view_items_[itemNumber++]->setText(0, QString("ES: %1")     .arg(state["es"].value<edb::seg_reg_t>().toHexString()));
-	register_view_items_[itemNumber++]->setText(0, QString("FS: %1 (%2)").arg(state["fs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["fs_base"].value<edb::reg_t>())));
-	register_view_items_[itemNumber++]->setText(0, QString("GS: %1 (%2)").arg(state["gs"].value<edb::seg_reg_t>().toHexString()).arg(edb::v1::format_pointer(state["gs_base"].value<edb::reg_t>())));
+	QString fsStr=QString("FS: %1").arg(state["fs"].value<edb::seg_reg_t>().toHexString());
+	const Register fsBase=state["fs_base"];
+	if(fsBase)
+		fsStr+=QString(" (%1)").arg(fsBase.value<edb::reg_t>().toHexString());
+	QString gsStr=QString("GS: %1").arg(state["gs"].value<edb::seg_reg_t>().toHexString());
+	const Register gsBase=state["gs_base"];
+	if(gsBase)
+		gsStr+=QString(" (%1)").arg(gsBase.value<edb::reg_t>().toHexString());
+	register_view_items_[itemNumber++]->setText(0, fsStr);
+	register_view_items_[itemNumber++]->setText(0, gsStr);
 	register_view_items_[itemNumber++]->setText(0, QString("SS: %1")     .arg(state["ss"].value<edb::seg_reg_t>().toHexString()));
 
 	update_fpu_view(itemNumber,state,palette);

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -121,8 +121,9 @@ QTreeWidgetItem *create_register_item(QTreeWidgetItem *parent, const QString &na
 // Name: get_effective_address
 // Desc:
 //------------------------------------------------------------------------------
-edb::address_t get_effective_address(const edb::Operand &op, const State &state) {
+edb::address_t get_effective_address(const edb::Operand &op, const State &state, bool& ok) {
 	edb::address_t ret = 0;
+	ok=false;
 
 	// TODO: get registers by index, not string! too slow
 	
@@ -152,13 +153,13 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state)
 
 				if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
 					const Register gsBase=state["gs_base"];
-					if(!gsBase) return ret; // no way to reliably compute address
+					if(!gsBase) return 0; // no way to reliably compute address
 					ret += gsBase.valueAsAddress();
 				}
 
 				if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
 					const Register fsBase=state["fs_base"];
-					if(!fsBase) return ret; // no way to reliably compute address
+					if(!fsBase) return 0; // no way to reliably compute address
 					ret += fsBase.valueAsAddress();
 				}
 			} while(0);
@@ -167,13 +168,13 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state)
 			ret = op.absolute().offset;
 			if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
 				const Register gsBase=state["gs_base"];
-				if(!gsBase) return ret; // no way to reliably compute address
+				if(!gsBase) return 0; // no way to reliably compute address
 				ret += gsBase.valueAsAddress();
 			}
 
 			if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
 				const Register fsBase=state["fs_base"];
-				if(!fsBase) return ret; // no way to reliably compute address
+				if(!fsBase) return 0; // no way to reliably compute address
 				ret += fsBase.valueAsAddress();
 			}
 			break;
@@ -186,6 +187,7 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state)
 			break;
 		}
 	}
+	ok=true;
 	return ret;
 }
 
@@ -509,7 +511,9 @@ void analyze_call(const State &state, const edb::Instruction &inst, QStringList 
 
 		if(operand.valid()) {
 		
-			const edb::address_t effective_address = get_effective_address(operand, state);
+			bool ok;
+			const edb::address_t effective_address = get_effective_address(operand, state,ok);
+			if(!ok) return;
 			const QString temp_operand             = QString::fromStdString(edb::v1::formatter().to_string(operand));
 			QString temp;
 
@@ -611,7 +615,9 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 				case edb::Operand::TYPE_REL:
 					do {
 #if 0
-						const edb::address_t effective_address = get_effective_address(operand, state);
+						bool ok;
+						const edb::address_t effective_address = get_effective_address(operand, state,ok);
+						if(!ok) return;
 						ret << QString("%1 = %2").arg(temp_operand).arg(edb::v1::format_pointer(effective_address));
 #endif
 					} while(0);
@@ -651,7 +657,9 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 					}
 				case edb::Operand::TYPE_EXPRESSION:
 					do {
-						const edb::address_t effective_address = get_effective_address(operand, state);
+						bool ok;
+						const edb::address_t effective_address = get_effective_address(operand, state,ok);
+						if(!ok) return;
 						edb::value128 target;
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -695,6 +695,9 @@ address_t get_variable(const QString &s, bool *ok, ExpressionError *err) {
 		*err = ExpressionError(ExpressionError::UNKNOWN_VARIABLE);
 	}
 
+	// FIXME: should this really return segment base, not selector?
+	// FIXME: if it's really meant to return base, then need to check whether
+	//        State::operator[]() returned valid Register
 	if(reg.name() == "fs") {
 		return state["fs_base"].value<reg_t>();
 	} else if(reg.name() == "gs") {


### PR DESCRIPTION
This set of commits stops showing zeros in place of unknown segment bases for FS and GS registers, prevents using the wrong values in analysis and fixes my stupid bug of trying to use segment bases before they've been obtained.