### PR TITLE
Check that SIMD registers have been filled before returning values

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -888,7 +888,7 @@ Register PlatformState::mmx_register(size_t n) const {
 // Desc:
 //------------------------------------------------------------------------------
 Register PlatformState::xmm_register(size_t n) const {
-	if(!xmmIndexValid(n))
+	if(!xmmIndexValid(n) || !avx.xmmFilled)
 		return Register();
 	edb::value128 value(avx.xmm(n));
 	return make_Register(QString("xmm%1").arg(n),value,Register::TYPE_SIMD);
@@ -899,7 +899,7 @@ Register PlatformState::xmm_register(size_t n) const {
 // Desc:
 //------------------------------------------------------------------------------
 Register PlatformState::ymm_register(size_t n) const {
-	if(!ymmIndexValid(n))
+	if(!ymmIndexValid(n) || !avx.ymmFilled)
 		return Register();
 	edb::value256 value(avx.ymm(n));
 	return make_Register(QString("ymm%1").arg(n),value,Register::TYPE_SIMD);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -210,7 +210,7 @@ void PlatformState::fillFrom(const UserFPXRegsStructX86& regs) {
 	for(std::size_t n=0;n<IA32_XMM_REG_COUNT;++n)
 		avx.setXMM(n,edb::value128(regs.xmm_space,16*n));
 	avx.mxcsr=regs.mxcsr;
-	avx.xmmFilled=true;
+	avx.xmmFilledIA32=true;
 }
 void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	// On 32 bit OS this code would access beyond the length of the array, but it won't ever execute there
@@ -264,7 +264,8 @@ void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
 	avx.mxcsr=regs.mxcsr;
 	avx.mxcsrMask=regs.mxcr_mask;
 	avx.mxcsrMaskFilled=true;
-	avx.xmmFilled=true;
+	avx.xmmFilledIA32=true;
+	avx.xmmFilledAMD64=true;
 }
 
 void PlatformState::fillFrom(const PrStatus_X86& regs)
@@ -367,22 +368,26 @@ void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) 
 		avx.mxcsr=regs.mxcsr;
 		avx.mxcsrMask=regs.mxcsr_mask;
 		avx.mxcsrMaskFilled=true;
-		avx.xmmFilled=true;
+		avx.xmmFilledIA32=true;
+		avx.xmmFilledAMD64=true;
 		avx.ymmFilled=true;
 	} else if(statePresentSSE) {
 		// If AVX state management has been enabled by the OS,
 		// the state may be not present due to lazy saving,
 		// so initialize the space with zeros
-		if(avx.xcr0 & X86XState::FEATURE_AVX)
+		if(avx.xcr0 & X86XState::FEATURE_AVX) {
 			for(std::size_t n=0;n<MAX_YMM_REG_COUNT;++n)
 				avx.setYMM(n,edb::value256::fromZeroExtended(0));
+			avx.ymmFilled=true;
+		}
 		// Now we can fill in the XMM registers
 		for(std::size_t n=0;n<MAX_XMM_REG_COUNT;++n)
 			avx.setXMM(n,edb::value128(regs.xmm_space,16*n));
 		avx.mxcsr=regs.mxcsr;
 		avx.mxcsrMask=regs.mxcsr_mask;
 		avx.mxcsrMaskFilled=true;
-		avx.xmmFilled=true;
+		avx.xmmFilledIA32=true;
+		avx.xmmFilledAMD64=true;
 	} else {
 		avx.mxcsr=regs.mxcsr;
 		avx.mxcsrMask=regs.mxcsr_mask;
@@ -391,12 +396,14 @@ void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) 
 		if(avx.xcr0 & X86XState::FEATURE_AVX) { // If AVX state management has been enabled by the OS
 			for(std::size_t n=0;n<MAX_YMM_REG_COUNT;++n)
 				avx.setYMM(n,edb::value256::fromZeroExtended(0));
-			avx.xmmFilled=true;
+			avx.xmmFilledIA32=true;
+			avx.xmmFilledAMD64=true;
 			avx.ymmFilled=true;
 		} else if(avx.xcr0 & X86XState::FEATURE_SSE) { // If SSE state management has been enabled by the OS
 			for(std::size_t n=0;n<MAX_YMM_REG_COUNT;++n)
 				avx.setYMM(n,edb::value256::fromZeroExtended(0));
-			avx.xmmFilled=true;
+			avx.xmmFilledIA32=true;
+			avx.xmmFilledAMD64=true;
 		}
 	}
 }
@@ -514,13 +521,14 @@ bool PlatformState::X87::empty() const {
 
 void PlatformState::AVX::clear() {
 	util::markMemory(this,sizeof(*this));
-	xmmFilled=false;
+	xmmFilledIA32=false;
+	xmmFilledAMD64=false;
 	ymmFilled=false;
 	zmmFilled=false;
 }
 
 bool PlatformState::AVX::empty() const {
-	return !xmmFilled;
+	return !xmmFilledIA32;
 }
 
 //------------------------------------------------------------------------------
@@ -651,12 +659,14 @@ Register PlatformState::value(const QString &reg) const {
 			return make_Register(regName, x87.R[i].mantissa(), Register::TYPE_SIMD);
 		}
 	}
-	if(avx.xmmFilled) {
+	if(avx.xmmFilledIA32) {
 		QRegExp XMMx("^xmm([0-9]|1[0-5])$");
 		if(XMMx.indexIn(regName)!=-1) {
 			bool ok=false;
 			std::size_t i=XMMx.cap(1).toUShort(&ok);
 			assert(ok);
+			if(i>=IA32_XMM_REG_COUNT && !avx.xmmFilledAMD64)
+				return Register();
 			if(xmmIndexValid(i)) // May be invalid but legitimate for a disassembler: e.g. XMM13 but 32 bit mode
 				return make_Register(regName, avx.xmm(i), Register::TYPE_SIMD);
 		}
@@ -671,7 +681,7 @@ Register PlatformState::value(const QString &reg) const {
 				return make_Register(regName, avx.ymm(i), Register::TYPE_SIMD);
 		}
 	}
-	if(avx.xmmFilled && regName==avx.mxcsrName)
+	if(avx.xmmFilledIA32 && regName==avx.mxcsrName)
 		return make_Register(avx.mxcsrName, avx.mxcsr, Register::TYPE_COND);
 	return Register();
 }
@@ -888,7 +898,9 @@ Register PlatformState::mmx_register(size_t n) const {
 // Desc:
 //------------------------------------------------------------------------------
 Register PlatformState::xmm_register(size_t n) const {
-	if(!xmmIndexValid(n) || !avx.xmmFilled)
+	if(!xmmIndexValid(n) || !avx.xmmFilledIA32)
+		return Register();
+	if(n>=IA32_XMM_REG_COUNT && !avx.xmmFilledAMD64)
 		return Register();
 	edb::value128 value(avx.xmm(n));
 	return make_Register(QString("xmm%1").arg(n),value,Register::TYPE_SIMD);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -323,7 +323,8 @@ private:
 		edb::value32 mxcsr;
 		edb::value32 mxcsrMask;
 		edb::value64 xcr0;
-		bool xmmFilled=false;
+		bool xmmFilledIA32=false;
+		bool xmmFilledAMD64=false; // This can be false when filled from e.g. FPXregs
 		bool ymmFilled=false;
 		bool zmmFilled=false;
 		bool mxcsrMaskFilled=false;

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -48,14 +48,14 @@ namespace {
 using std::size_t;
 
 enum RegisterIndex {
-	Rax  = 0, Eax  = Rax,
-	Rcx  = 1, Ecx  = Rcx,
-	Rdx  = 2, Edx  = Rdx,
-	Rbx  = 3, Ebx  = Rbx,
-	Rsp  = 4, Esp  = Rsp,
-	Rbp  = 5, Ebp  = Rbp,
-	Rsi  = 6, Esi  = Rsi,
-	Rdi  = 7, Edi  = Rdi,
+	rAX  = 0,
+	rCX  = 1,
+	rDX  = 2,
+	rBX  = 3,
+	rSP  = 4,
+	rBP  = 5,
+	rSI  = 6,
+	rDI  = 7,
 	R8   = 8,
 	R9   = 9,
 	R10  = 10,
@@ -400,9 +400,9 @@ void resolve_function_parameters(const State &state, const QString &symname, int
 bool is_jcc_taken(const State &state, edb::Instruction::ConditionCode cond) {
 
 	if(cond==edb::Instruction::CC_UNCONDITIONAL) return true;
-	if(cond==edb::Instruction::CC_RCXZ) return state.gp_register(Rcx).value<edb::value64>() == 0;
-	if(cond==edb::Instruction::CC_ECXZ) return state.gp_register(Rcx).value<edb::value32>() == 0;
-	if(cond==edb::Instruction::CC_CXZ)  return state.gp_register(Rcx).value<edb::value16>() == 0;
+	if(cond==edb::Instruction::CC_RCXZ) return state.gp_register(rCX).value<edb::value64>() == 0;
+	if(cond==edb::Instruction::CC_ECXZ) return state.gp_register(rCX).value<edb::value32>() == 0;
+	if(cond==edb::Instruction::CC_CXZ)  return state.gp_register(rCX).value<edb::value16>() == 0;
 
 	const edb::reg_t efl = state.flags();
 	const bool cf = (efl & 0x0001) != 0;
@@ -725,8 +725,7 @@ void analyze_syscall(const State &state, const edb::Instruction &inst, QStringLi
 		QString res;
 		query.setFocus(&file);
 		const QString arch=debuggeeIs64Bit() ? "x86-64" : "x86";
-		// Index Eax is equal to Rax
-		query.setQuery(QString("syscalls[@version='1.0']/linux[@arch='"+arch+"']/syscall[index=%1]").arg(state.gp_register(Eax).value<edb::reg_t>()));
+		query.setQuery(QString("syscalls[@version='1.0']/linux[@arch='"+arch+"']/syscall[index=%1]").arg(state.gp_register(rAX).value<edb::reg_t>()));
 		if (query.isValid()) {
 			query.evaluateTo(&syscall_entry);
 		}

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -110,8 +110,13 @@ void Instruction::fillPrefix()
 
 Instruction& Instruction::operator=(const Instruction& other)
 {
-	static_assert(std::is_standard_layout<Instruction>::value,"Instruction should have standard layout");
-	std::memcpy(this,&other,sizeof other);
+	insn_=other.insn_;
+	detail_=other.detail_;
+	valid_=other.valid_;
+	rva_=other.rva_;
+	firstByte_=other.firstByte_;
+	prefix_=other.prefix_;
+	operands_=other.operands_;
 	// Update pointer after replacement
 	insn_.detail=&detail_;
 


### PR DESCRIPTION
These commits add some more checking of validity of data before returning them as valid `Register`.
Also one of them fixes my error in `Instruction::operator=`, which led Analyzer to crash after doing analysis and then scrolling up disassembly view.