### PR TITLE
Deduplicate get/set debug register

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -799,6 +799,10 @@ bool DebuggerCore::fillStateFromSimpleRegs(PlatformState* state) {
 	}
 }
 
+long DebuggerCore::get_debug_register(std::size_t n) {
+	return ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[n]), 0);
+}
+
 //------------------------------------------------------------------------------
 // Name: get_state
 // Desc:

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -882,14 +882,8 @@ void DebuggerCore::set_state(const State &state) {
 			ptrace(PTRACE_SETREGS, active_thread(), 0, &regs);
 
 			// debug registers
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[0]), state_impl->x86.dbgRegs[0]);
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[1]), state_impl->x86.dbgRegs[1]);
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[2]), state_impl->x86.dbgRegs[2]);
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[3]), state_impl->x86.dbgRegs[3]);
-			//ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[4]), state_impl->x86.dbgRegs[4]);
-			//ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[5]), state_impl->x86.dbgRegs[5]);
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[6]), state_impl->x86.dbgRegs[6]);
-			ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[7]), state_impl->x86.dbgRegs[7]);
+			for(std::size_t i=0;i<8;++i)
+				set_debug_register(i,state_impl->x86.dbgRegs[i]);
 		}
 	}
 }

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -803,6 +803,10 @@ long DebuggerCore::get_debug_register(std::size_t n) {
 	return ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[n]), 0);
 }
 
+long DebuggerCore::set_debug_register(std::size_t n, long value) {
+	return ptrace(PTRACE_POKEUSER, active_thread(), offsetof(struct user, u_debugreg[n]), value);
+}
+
 //------------------------------------------------------------------------------
 // Name: get_state
 // Desc:

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -857,15 +857,8 @@ void DebuggerCore::get_state(State *state) {
 			}
 
 			// debug registers
-			state_impl->x86.dbgRegs[0] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[0]), 0);
-			state_impl->x86.dbgRegs[1] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[1]), 0);
-			state_impl->x86.dbgRegs[2] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[2]), 0);
-			state_impl->x86.dbgRegs[3] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[3]), 0);
-			state_impl->x86.dbgRegs[4] = 0;
-			state_impl->x86.dbgRegs[5] = 0;
-			state_impl->x86.dbgRegs[6] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[6]), 0);
-			state_impl->x86.dbgRegs[7] = ptrace(PTRACE_PEEKUSER, active_thread(), offsetof(struct user, u_debugreg[7]), 0);
-
+			for(std::size_t i=0;i<8;++i)
+				state_impl->x86.dbgRegs[i] = get_debug_register(i);
 		} else {
 			state_impl->clear();
 		}

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -114,6 +114,7 @@ private:
 	bool fillStateFromPrStatus(PlatformState* state);
 	bool fillStateFromSimpleRegs(PlatformState* state);
 	void fillFSGSBases(PlatformState* state);
+	long get_debug_register(std::size_t n);
 private:
 	struct thread_info {
 		int status;

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -115,6 +115,7 @@ private:
 	bool fillStateFromSimpleRegs(PlatformState* state);
 	void fillFSGSBases(PlatformState* state);
 	long get_debug_register(std::size_t n);
+	long set_debug_register(std::size_t n, long value);
 private:
 	struct thread_info {
 		int status;


### PR DESCRIPTION
These commits remove repeating code to get & set debug registers. Also they remove special-casing `DR4` and `DR5`. Although these registers are reserved/aliased to `DR6`&`DR7`, it's the responsibility of the kernel to avoid reading & writing them. EDB just peeks & pokes the `user` struct, so no need to worry.