### PR TITLE
Fix register editing after making QTreeWidgetItems for GPRs generically-named

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -835,7 +835,7 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 // Desc:
 //------------------------------------------------------------------------------
 Register ArchProcessor::value_from_item(const QTreeWidgetItem &item) {
-	const QString &name = item.data(0, Qt::UserRole).toString();
+	const QString name = item.text(0).split(':').front();
 	State state;
 	edb::v1::debugger_core->get_state(&state);
 	return state[name];


### PR DESCRIPTION
This fixes GPR editing after my recent commits where I made registers names more generic, breaking this functionality.