### PR TITLE
Gradual preparation for dynamic bitness, part three

### DIFF
--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -48,7 +48,7 @@ public:
 public:
 	// system properties
 	virtual edb::address_t      page_size() const = 0;
-	virtual int                 pointer_size() const = 0;
+	virtual std::size_t         pointer_size() const = 0;
 	virtual quint64             cpu_type() const = 0;
 	virtual bool                has_extension(quint64 ext) const = 0;
 	virtual QMap<long, QString> exceptions() const = 0;

--- a/include/arch/x86-generic/ArchTypes.h
+++ b/include/arch/x86-generic/ArchTypes.h
@@ -26,14 +26,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if INTPTR_MAX==INT32_MAX
 
 #define EDB_X86
-static constexpr const bool IS_X86_64_BIT=false;
-static constexpr const bool IS_X86_32_BIT=true;
+static constexpr const bool EDB_IS_64_BIT=false;
+static constexpr const bool EDB_IS_32_BIT=true;
 
 #elif INTPTR_MAX==INT64_MAX
 
 #define EDB_X86_64
-static constexpr const bool IS_X86_64_BIT=true;
-static constexpr const bool IS_X86_32_BIT=false;
+static constexpr const bool EDB_IS_64_BIT=true;
+static constexpr const bool EDB_IS_32_BIT=false;
 
 #endif
 

--- a/include/edb.h
+++ b/include/edb.h
@@ -200,6 +200,8 @@ EDB_EXPORT QVector<quint8> read_pages(address_t address, size_t page_count);
 
 EDB_EXPORT CapstoneEDB::Formatter &formatter();
 
+EDB_EXPORT bool debuggeeIs32Bit();
+EDB_EXPORT bool debuggeeIs64Bit();
 }
 }
 

--- a/plugins/Assembler/DialogAssembler.cpp
+++ b/plugins/Assembler/DialogAssembler.cpp
@@ -259,17 +259,7 @@ void DialogAssembler::on_buttonBox_accepted() {
 				return;
 			}		
 			
-			switch(edb::v1::debugger_core->cpu_type()) {
-			case edb::string_hash("x86"):
-				asm_code.replace("%BITS%", "32");
-				break;
-			case edb::string_hash("x86-64"):
-				asm_code.replace("%BITS%", "64");
-				break;
-			default:
-				Q_ASSERT(0);
-			}			
-			
+			asm_code.replace("%BITS%", std::to_string(edb::v1::debugger_core->pointer_size()*8).c_str());
 			asm_code.replace("%ADDRESS%", edb::v1::format_pointer(address_));
 			asm_code.replace("%INSTRUCTION%",  nasm_syntax);
 						

--- a/plugins/DebuggerCore/unix/DebuggerCoreUNIX.cpp
+++ b/plugins/DebuggerCore/unix/DebuggerCoreUNIX.cpp
@@ -241,7 +241,7 @@ void DebuggerCoreUNIX::execute_process(const QString &path, const QString &cwd, 
 // Name: pointer_size
 // Desc: returns the size of a pointer on this arch
 //------------------------------------------------------------------------------
-int DebuggerCoreUNIX::pointer_size() const {
+std::size_t DebuggerCoreUNIX::pointer_size() const {
 	return EDB_WORDSIZE;
 }
 

--- a/plugins/DebuggerCore/unix/DebuggerCoreUNIX.h
+++ b/plugins/DebuggerCore/unix/DebuggerCoreUNIX.h
@@ -44,7 +44,7 @@ protected:
 	void execute_process(const QString &path, const QString &cwd, const QList<QByteArray> &args);
 
 public:
-	virtual int pointer_size() const;
+	virtual std::size_t pointer_size() const override;
 	virtual QMap<long, QString> exceptions() const;
 
 protected:

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -824,7 +824,7 @@ void DebuggerCore::get_state(State *state) {
 		state_impl->clear();
 		if(attached()) {
 
-			if(sizeof(void*)==8)
+			if(EDB_IS_64_BIT)
 				fillStateFromSimpleRegs(state_impl); // 64-bit GETREGS call always returns 64-bit state, so use it
 			else if(!fillStateFromPrStatus(state_impl)) // if EDB is 32 bit, use GETREGSET so that we get 64-bit state for 64-bit debuggee
 				fillStateFromSimpleRegs(state_impl); // failing that, try to just get what we can

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -1162,14 +1162,13 @@ QList<Module> DebuggerCore::loaded_modules() const {
 
 //------------------------------------------------------------------------------
 // Name:
-// Desc:
+// Desc: Returns EDB's native CPU type
 //------------------------------------------------------------------------------
 quint64 DebuggerCore::cpu_type() const {
-#ifdef EDB_X86
-	return edb::string_hash("x86");
-#elif defined(EDB_X86_64)
-	return edb::string_hash("x86-64");
-#endif
+	if(EDB_IS_32_BIT)
+		return edb::string_hash("x86");
+	else
+		return edb::string_hash("x86-64");
 }
 
 
@@ -1186,11 +1185,10 @@ QString DebuggerCore::format_pointer(edb::address_t address) const {
 // Desc:
 //------------------------------------------------------------------------------
 QString DebuggerCore::stack_pointer() const {
-#ifdef EDB_X86
-	return "esp";
-#elif defined(EDB_X86_64)
-	return "rsp";
-#endif
+	if(edb::v1::debuggeeIs32Bit())
+		return "esp";
+	else
+		return "rsp";
 }
 
 //------------------------------------------------------------------------------
@@ -1198,11 +1196,10 @@ QString DebuggerCore::stack_pointer() const {
 // Desc:
 //------------------------------------------------------------------------------
 QString DebuggerCore::frame_pointer() const {
-#ifdef EDB_X86
-	return "ebp";
-#elif defined(EDB_X86_64)
-	return "rbp";
-#endif
+	if(edb::v1::debuggeeIs32Bit())
+		return "ebp";
+	else
+		return "rbp";
 }
 
 //------------------------------------------------------------------------------
@@ -1210,11 +1207,10 @@ QString DebuggerCore::frame_pointer() const {
 // Desc:
 //------------------------------------------------------------------------------
 QString DebuggerCore::instruction_pointer() const {
-#ifdef EDB_X86
-	return "eip";
-#elif defined(EDB_X86_64)
-	return "rip";
-#endif
+	if(edb::v1::debuggeeIs32Bit())
+		return "eip";
+	else
+		return "rip";
 }
 
 //------------------------------------------------------------------------------
@@ -1222,11 +1218,10 @@ QString DebuggerCore::instruction_pointer() const {
 // Desc: Returns the name of the flag register as a QString.
 //------------------------------------------------------------------------------
 QString DebuggerCore::flag_register() const {
-#ifdef EDB_X86
-	return "eflags";
-#elif defined(EDB_X86_64)
-	return "rflags";
-#endif
+	if(edb::v1::debuggeeIs32Bit())
+		return "eflags";
+	else
+		return "rflags";
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -294,7 +294,7 @@ bool DebuggerCore::has_extension(quint64 ext) const {
 	const auto mmxHash=edb::string_hash("MMX");
 	const auto xmmHash=edb::string_hash("XMM");
 	const auto ymmHash=edb::string_hash("YMM");
-	if(IS_X86_64_BIT && (ext==xmmHash || ext==mmxHash))
+	if(EDB_IS_64_BIT && (ext==xmmHash || ext==mmxHash))
 		return true;
 
 	quint32 eax;
@@ -836,7 +836,7 @@ void DebuggerCore::get_state(State *state) {
 			} else {
 
 				// No XSTATE available, get just floating point and SSE registers
-				static bool getFPXRegsSupported=(IS_X86_32_BIT ? true : false);
+				static bool getFPXRegsSupported=(EDB_IS_32_BIT ? true : false);
 				UserFPXRegsStructX86 fpxregs;
 				// This should be automatically optimized out on amd64. If not, not a big deal.
 				// Avoiding conditional compilation to facilitate syntax error checking

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -275,7 +275,7 @@ int get_user_stat(edb::pid_t pid, struct user_stat *user_stat) {
 // Name: DebuggerCore
 // Desc: constructor
 //------------------------------------------------------------------------------
-DebuggerCore::DebuggerCore() : binary_info_(0), process_(0) {
+DebuggerCore::DebuggerCore() : binary_info_(0), process_(0), pointer_size_(sizeof(void*)) {
 #if defined(_SC_PAGESIZE)
 	page_size_ = sysconf(_SC_PAGESIZE);
 #elif defined(_SC_PAGE_SIZE)
@@ -333,6 +333,10 @@ bool DebuggerCore::has_extension(quint64 ext) const {
 //------------------------------------------------------------------------------
 edb::address_t DebuggerCore::page_size() const {
 	return page_size_;
+}
+
+std::size_t DebuggerCore::pointer_size() const {
+	return pointer_size_;
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -46,6 +46,7 @@ public:
 	virtual ~DebuggerCore();
 
 public:
+	virtual std::size_t pointer_size() const override;
 	virtual edb::address_t page_size() const;
 	virtual bool has_extension(quint64 ext) const;
 	virtual IDebugEvent::const_pointer wait_debug_event(int msecs);
@@ -133,6 +134,7 @@ private:
 	edb::tid_t       event_thread_;
 	IBinary          *binary_info_;
 	IProcess         *process_;
+	std::size_t      pointer_size_;
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -117,6 +117,7 @@ private:
 	void fillFSGSBases(PlatformState* state);
 	long get_debug_register(std::size_t n);
 	long set_debug_register(std::size_t n, long value);
+	void detectDebuggeeBitness();
 private:
 	struct thread_info {
 		int status;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -299,9 +299,8 @@ public:
 	virtual Register xmm_register(size_t n) const;
 	virtual Register ymm_register(size_t n) const;
 	virtual Register gp_register(size_t n) const;
-	size_t pointer_size() const { return edb::v1::pointer_size(); }
-	bool is64Bit() const { return pointer_size()==8; }
-	bool is32Bit() const { return pointer_size()==4; }
+	bool is64Bit() const { return edb::v1::debuggeeIs64Bit(); }
+	bool is32Bit() const { return edb::v1::debuggeeIs32Bit(); }
 	size_t dbg_reg_count() const { return MAX_DBG_REG_COUNT; }
 	size_t seg_reg_count() const { return MAX_SEG_REG_COUNT; }
 	size_t fpu_reg_count() const { return MAX_FPU_REG_COUNT; }

--- a/plugins/DumpState/DumpState.cpp
+++ b/plugins/DumpState/DumpState.cpp
@@ -111,7 +111,7 @@ void DumpState::dump_code(const State &state) {
 void DumpState::dump_registers(const State &state) {
 
 	using std::cout;
-	if(edb::v1::pointer_size()==4) { // TODO: check if state itself is 32 bit, not current debuggee. Generally it's not the same.
+	if(edb::v1::debuggeeIs32Bit()) { // TODO: check if state itself is 32 bit, not current debuggee. Generally it's not the same.
 		cout << "     eax:" <<    hex_string(state["eax"]);
 		cout << " ecx:" <<        hex_string(state["ecx"]);
 		cout << "  edx:" <<       hex_string(state["edx"]);

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -62,7 +62,7 @@ void Configuration::read_settings() {
 #ifdef DEFAULT_PLUGIN_PATH
 	const QString default_plugin_path = TOSTRING(DEFAULT_PLUGIN_PATH);
 #else
-	const QString edb_lib_dir=QCoreApplication::applicationDirPath()+(sizeof(void*)==8 ? "/../lib64/edb" : "/../lib/edb");
+	const QString edb_lib_dir=QCoreApplication::applicationDirPath()+(EDB_IS_64_BIT ? "/../lib64/edb" : "/../lib/edb");
 	const QString edb_binary_dir=QCoreApplication::applicationDirPath();
 	// If the binary is in its installation directory, then look for plugins in their installation directory
 	// Otherwise assume that we are in build directory, so the plugins are in the same directory as the binary
@@ -121,7 +121,7 @@ void Configuration::read_settings() {
 		data_row_width = 16;
 	}
 	
-	CapstoneEDB::init(sizeof(void*)==8); // TODO: properly choose bitness according to target bitness
+	CapstoneEDB::init(EDB_IS_64_BIT); // TODO: properly choose bitness according to target bitness
 	CapstoneEDB::Formatter::FormatOptions options = edb::v1::formatter().options();
 	options.capitalization = uppercase_disassembly ? CapstoneEDB::Formatter::UpperCase : CapstoneEDB::Formatter::LowerCase;
 	options.smallNumFormat = small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -675,7 +675,7 @@ edb::reg_t Debugger::get_follow_register(bool *ok) const {
 		if(const Register reg = edb::v1::arch_processor().value_from_item(*i)) {
 			if(reg.type() & (Register::TYPE_GPR | Register::TYPE_IP)) {
 				*ok = true;
-				return reg.value<edb::reg_t>();
+				return reg.valueAsAddress();
 			}
 		}
 	}

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2581,12 +2581,12 @@ void Debugger::test_native_binary() {
 			);
 		// Although non-native debugging is not fully supported, let's give the user a nicer experience with unsupported feature.
 		// Reinitialize CapstoneEDB to inverse of native bitness
-		CapstoneEDB::init(sizeof(void*)!=8);
+		CapstoneEDB::init(EDB_IS_32_BIT);
 	}
 	else {
 		// Reinitialize CapstoneEDB with native bitness. This is needed when e.g. previous
 		// debugging session was non-native, and the new one is native.
-		CapstoneEDB::init(sizeof(void*)==8);
+		CapstoneEDB::init(EDB_IS_64_BIT);
 	}
 }
 

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -66,13 +66,15 @@ enum RegisterIndex {
 	R15  = 15
 };
 
-static constexpr size_t GPR_COUNT_IA32=8;
-static constexpr size_t GPR_COUNT_AMD64=16;
+static constexpr size_t MAX_DEBUG_REGS_COUNT=8;
+static constexpr size_t MAX_SEGMENT_REGS_COUNT=6;
+static constexpr size_t MAX_GPR_COUNT=16;
+static constexpr size_t MAX_FPU_REGS_COUNT=8;
+static constexpr size_t MAX_MMX_REGS_COUNT=MAX_FPU_REGS_COUNT;
+static constexpr size_t MAX_XMM_REGS_COUNT=MAX_GPR_COUNT;
+static constexpr size_t MAX_YMM_REGS_COUNT=MAX_GPR_COUNT;
 bool debuggeeIs32Bit() { return edb::v1::pointer_size()==4; }
 bool debuggeeIs64Bit() { return edb::v1::pointer_size()==8; }
-size_t gpr_count() { return debuggeeIs32Bit() ? GPR_COUNT_IA32 : GPR_COUNT_AMD64; }
-size_t xmm_reg_count() { return debuggeeIs32Bit() ? GPR_COUNT_IA32 : GPR_COUNT_AMD64; }
-size_t ymm_reg_count() { return debuggeeIs32Bit() ? GPR_COUNT_IA32 : GPR_COUNT_AMD64; }
 int func_param_regs_count() { return debuggeeIs32Bit() ? 0 : 6; }
 
 template<typename T>
@@ -752,7 +754,7 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 
 		// setup the register view
 		if(QTreeWidgetItem *const gpr = category_list->addCategory(tr("General Purpose"))) {
-			for(std::size_t i=0;i<gpr_count();++i)
+			for(std::size_t i=0;i<MAX_GPR_COUNT;++i)
 				register_view_items_.push_back(create_register_item(gpr, QString("GPR%1").arg(i)));
 			register_view_items_.push_back(create_register_item(gpr, "rIP"));
 			register_view_items_.push_back(create_register_item(gpr, "rFLAGS"));
@@ -763,23 +765,13 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 		}
 
 		if(QTreeWidgetItem *const segs = category_list->addCategory(tr("Segments"))) {
-			register_view_items_.push_back(create_register_item(segs, "cs"));
-			register_view_items_.push_back(create_register_item(segs, "ds"));
-			register_view_items_.push_back(create_register_item(segs, "es"));
-			register_view_items_.push_back(create_register_item(segs, "fs"));
-			register_view_items_.push_back(create_register_item(segs, "gs"));
-			register_view_items_.push_back(create_register_item(segs, "ss"));
+			for(std::size_t i=0;i<MAX_SEGMENT_REGS_COUNT;++i)
+                register_view_items_.push_back(create_register_item(segs, QString("Seg%1").arg(i)));
 		}
 
 		if(QTreeWidgetItem *const fpu = category_list->addCategory(tr("FPU"))) {
-			register_view_items_.push_back(create_register_item(fpu, "R0"));
-			register_view_items_.push_back(create_register_item(fpu, "R1"));
-			register_view_items_.push_back(create_register_item(fpu, "R2"));
-			register_view_items_.push_back(create_register_item(fpu, "R3"));
-			register_view_items_.push_back(create_register_item(fpu, "R4"));
-			register_view_items_.push_back(create_register_item(fpu, "R5"));
-			register_view_items_.push_back(create_register_item(fpu, "R6"));
-			register_view_items_.push_back(create_register_item(fpu, "R7"));
+			for(std::size_t i=0;i<MAX_FPU_REGS_COUNT;++i)
+                register_view_items_.push_back(create_register_item(fpu, QString("R%1").arg(i)));
 			register_view_items_.push_back(create_register_item(fpu, "Control Word"));
 			register_view_items_.push_back(create_register_item(fpu, "PC"));
 			register_view_items_.push_back(create_register_item(fpu, "RC"));
@@ -789,38 +781,26 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 		}
 
 		if(QTreeWidgetItem *const dbg = category_list->addCategory(tr("Debug"))) {
-			register_view_items_.push_back(create_register_item(dbg, "dr0"));
-			register_view_items_.push_back(create_register_item(dbg, "dr1"));
-			register_view_items_.push_back(create_register_item(dbg, "dr2"));
-			register_view_items_.push_back(create_register_item(dbg, "dr3"));
-			register_view_items_.push_back(create_register_item(dbg, "dr4"));
-			register_view_items_.push_back(create_register_item(dbg, "dr5"));
-			register_view_items_.push_back(create_register_item(dbg, "dr6"));
-			register_view_items_.push_back(create_register_item(dbg, "dr7"));
+			for(std::size_t i=0;i<MAX_DEBUG_REGS_COUNT;++i)
+                register_view_items_.push_back(create_register_item(dbg, QString("dr%1").arg(i)));
 		}
 
 		if(has_mmx_) {
 			if(QTreeWidgetItem *const mmx = category_list->addCategory(tr("MMX"))) {
-				register_view_items_.push_back(create_register_item(mmx, "mm0"));
-				register_view_items_.push_back(create_register_item(mmx, "mm1"));
-				register_view_items_.push_back(create_register_item(mmx, "mm2"));
-				register_view_items_.push_back(create_register_item(mmx, "mm3"));
-				register_view_items_.push_back(create_register_item(mmx, "mm4"));
-				register_view_items_.push_back(create_register_item(mmx, "mm5"));
-				register_view_items_.push_back(create_register_item(mmx, "mm6"));
-				register_view_items_.push_back(create_register_item(mmx, "mm7"));
+                for(std::size_t i=0;i<MAX_MMX_REGS_COUNT;++i)
+                    register_view_items_.push_back(create_register_item(mmx, QString("mm%1").arg(i)));
 			}
 		}
 
 		if(has_ymm_) {
 			if(QTreeWidgetItem *const ymm = category_list->addCategory(tr("AVX"))) {
-				for(std::size_t i=0;i<ymm_reg_count();++i)
+				for(std::size_t i=0;i<MAX_YMM_REGS_COUNT;++i)
 					register_view_items_.push_back(create_register_item(ymm, QString("YMM%1").arg(i)));
 				register_view_items_.push_back(create_register_item(ymm, "mxcsr"));
 			}
 		} else if(has_xmm_) {
 			if(QTreeWidgetItem *const xmm = category_list->addCategory(tr("SSE"))) {
-				for(std::size_t i=0;i<xmm_reg_count();++i)
+				for(std::size_t i=0;i<MAX_XMM_REGS_COUNT;++i)
 					register_view_items_.push_back(create_register_item(xmm, QString("XMM%1").arg(i)));
 				register_view_items_.push_back(create_register_item(xmm, "mxcsr"));
 			}
@@ -848,6 +828,9 @@ Register ArchProcessor::value_from_item(const QTreeWidgetItem &item) {
 void ArchProcessor::update_register(QTreeWidgetItem *item, const Register &reg) const {
 
 	Q_ASSERT(item);
+
+	item->setHidden(!reg);
+	if(!reg) return;
 
 	QString reg_string;
 	int string_length;
@@ -1000,7 +983,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	}
 
 	int itemNumber=0;
-	for(std::size_t i=0;i<gpr_count();++i)
+	for(std::size_t i=0;i<MAX_GPR_COUNT;++i)
 		update_register(register_view_items_[itemNumber++], state.gp_register(i));
 
 	const QString symname = edb::v1::find_function_symbol(state.instruction_pointer(), default_region_name);
@@ -1048,16 +1031,18 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 
 	int padding=debuggeeIs64Bit() ? -2 : -1;
 	if(has_ymm_) {
-		for(std::size_t i = 0; i < ymm_reg_count(); ++i) {
+		for(std::size_t i = 0; i < MAX_YMM_REGS_COUNT; ++i) {
 			const Register current = state.ymm_register(i);
 			const Register prev    = last_state_.ymm_register(i);
+			register_view_items_[itemNumber]->setHidden(!current);
 			register_view_items_[itemNumber]->setText(0, QString("YMM%1: %2").arg(i, padding).arg(current.toHexString()));
 			register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 		}
 	} else if(has_xmm_) {
-		for(std::size_t i = 0; i < xmm_reg_count(); ++i) {
+		for(std::size_t i = 0; i < MAX_XMM_REGS_COUNT; ++i) {
 			const Register current = state.xmm_register(i);
 			const Register prev    = last_state_.xmm_register(i);
+			register_view_items_[itemNumber]->setHidden(!current);
 			register_view_items_[itemNumber]->setText(0, QString("XMM%1: %2").arg(i, padding).arg(current.toHexString()));
 			register_view_items_[itemNumber++]->setForeground(0, QBrush((current != prev) ? Qt::red : palette.text()));
 		}
@@ -1078,7 +1063,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 
 	// highlight any changed registers
 	itemNumber=0;
-	for(std::size_t i=0;i<gpr_count();++i)
+	for(std::size_t i=0;i<MAX_GPR_COUNT;++i)
 		register_view_items_[itemNumber++]->setForeground(0, (state.gp_register(i) != last_state_.gp_register(i)) ? Qt::red : palette.text());
 	register_view_items_[itemNumber++]->setForeground(0, (state.instruction_pointer() != last_state_.instruction_pointer()) ? Qt::red : palette.text());
 	register_view_items_[itemNumber++]->setForeground(0, flags_changed ? Qt::red : palette.text());

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1018,7 +1018,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 		QString sreg(specialSegs[i]);
 		QString sregStr=sreg.toUpper()+QString(": %1").arg(state[sreg].value<edb::seg_reg_t>().toHexString());
 		if(bases[i])
-			sregStr+=QString(" (%1)").arg(bases[i].value<edb::reg_t>().toHexString());
+			sregStr+=QString(" (%1)").arg(bases[i].valueAsAddress().toHexString());
 		register_view_items_[itemNumber]->setText(0, sregStr);
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state[sreg] != last_state_[sreg]) ? Qt::red : palette.text()));
 	}

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -73,8 +73,8 @@ static constexpr size_t MAX_FPU_REGS_COUNT=8;
 static constexpr size_t MAX_MMX_REGS_COUNT=MAX_FPU_REGS_COUNT;
 static constexpr size_t MAX_XMM_REGS_COUNT=MAX_GPR_COUNT;
 static constexpr size_t MAX_YMM_REGS_COUNT=MAX_GPR_COUNT;
-bool debuggeeIs32Bit() { return edb::v1::pointer_size()==4; }
-bool debuggeeIs64Bit() { return edb::v1::pointer_size()==8; }
+using edb::v1::debuggeeIs32Bit;
+using edb::v1::debuggeeIs64Bit;
 int func_param_regs_count() { return debuggeeIs32Bit() ? 0 : 6; }
 
 template<typename T>

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -139,6 +139,9 @@ void load_function_db() {
 
 namespace v1 {
 
+bool debuggeeIs32Bit() { return pointer_size()==sizeof(std::uint32_t); }
+bool debuggeeIs64Bit() { return pointer_size()==sizeof(std::uint64_t); }
+
 //------------------------------------------------------------------------------
 // Name: set_cpu_selected_address
 // Desc:

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -437,7 +437,7 @@ void QDisassemblyView::setShowAddressSeparator(bool value) {
 // Desc:
 //------------------------------------------------------------------------------
 QString QDisassemblyView::formatAddress(edb::address_t address) const {
-	if(edb::v1::pointer_size()==sizeof(quint32))
+	if(edb::v1::debuggeeIs32Bit())
 		return format_address<quint32>(address.toUint(), show_address_separator_);
 	else
 		return format_address(address, show_address_separator_);


### PR DESCRIPTION
This is most likely the last set of conservative changes regarding support for foreign bitness. I expect that the next set will switch `address_t` and `reg_t` to unconditional 64 bit types, thus changing behavior in many places. After that the only thing remaining would be bug fixes.