### PR TITLE
Switch address_t and reg_t to unconditional 64 bit

### DIFF
--- a/include/IProcess.h
+++ b/include/IProcess.h
@@ -49,7 +49,7 @@ public:
 	// or this will return false immediately.
 	virtual bool write_bytes(edb::address_t address, const void *buf, size_t len) = 0;
 	virtual bool read_bytes(edb::address_t address, void *buf, size_t len) = 0;
-	virtual bool read_pages(edb::address_t address, void *buf, size_t count) = 0;
+	virtual std::size_t read_pages(edb::address_t address, void *buf, size_t count) = 0;
 };
 
 #endif

--- a/include/Register.h
+++ b/include/Register.h
@@ -78,6 +78,16 @@ public:
 		return valueAsAddress().toUint();
 	}
 
+	int64_t valueAsSignedInteger() const {
+		auto result=valueAsInteger();
+		// If MSB is set, sign extend the result
+		if(result&(1<<(bitSize_-1))) {
+			result=-1ll;
+			std::memcpy(&result,&value_,bitSize_/8);
+		}
+		return result;
+	}
+
 	QString toHexString() const;
 
 private:

--- a/include/Register.h
+++ b/include/Register.h
@@ -67,6 +67,8 @@ public:
 	T value() const              { return T(value_); }
 	// Return the value, zero-extended to address_t to be usable in address calculations
 	edb::address_t valueAsAddress() const {
+		// This function only makes sense for GPRs
+		assert(bitSize_<=8*sizeof(edb::address_t));
 		edb::address_t result(0LL);
 		std::memcpy(&result,&value_,bitSize_/8);
 		return result;

--- a/include/Register.h
+++ b/include/Register.h
@@ -72,6 +72,10 @@ public:
 		return result;
 	}
 
+	uint64_t valueAsInteger() const {
+		return valueAsAddress().toUint();
+	}
+
 	QString toHexString() const;
 
 private:

--- a/include/Register.h
+++ b/include/Register.h
@@ -88,6 +88,10 @@ public:
 		return result;
 	}
 
+	void setScalarValue(std::uint64_t newValue) {
+		std::memcpy(&value_,&newValue,bitSize_/8);
+	}
+
 	QString toHexString() const;
 
 private:

--- a/include/Types.h
+++ b/include/Types.h
@@ -332,6 +332,7 @@ struct address_t : public value64 {
 	template<class T>
 	address_t(const T& val) : value64(val) {}
 	address_t()=default;
+	void normalize();
 };
 
 	typedef address_t                                  reg_t;

--- a/include/Types.h
+++ b/include/Types.h
@@ -32,6 +32,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstddef>
 #include <map>
 
+class Register;
+
 namespace edb {
 
 enum EVENT_STATUS {
@@ -100,6 +102,7 @@ struct SizedValue : public ValueBase<N,1> {
 	explicit SizedValue(Float floatVal) { this->value_[0]=floatVal; }
 	template<typename Integer, typename = typename std::enable_if<std::is_integral<Integer>::value>::type>
 	SizedValue(Integer integer) { this->value_[0]=integer; }
+	SizedValue(const Register&)=delete;
 
 	template<typename SmallData>
 	static SizedValue fromZeroExtended(const SmallData& data) {

--- a/include/Types.h
+++ b/include/Types.h
@@ -128,8 +128,6 @@ struct SizedValue : public ValueBase<N,1> {
 
 	operator InnerValueType() const { return this->value_[0]; }
 	operator QVariant() const { return QVariant::fromValue(this->value_[0]); }
-	template<int M=0> typename std::enable_if<sizeof(void*)==sizeof(InnerValueType) && M==0,
-	QString>::type toPointerString() const { return "0x"+this->toHexString(); }
 
 	QString toString() const { return QString("%1").arg(this->value_[0]); }
 	QString unsignedToString() const { return toString(); }

--- a/include/Types.h
+++ b/include/Types.h
@@ -323,12 +323,28 @@ static_assert(std::is_standard_layout<value8>::value &&
 			  std::is_standard_layout<value128>::value &&
 			  std::is_standard_layout<value256>::value &&
 			  std::is_standard_layout<value512>::value,"Fixed-sized values are intended to have standard layout");
+
+struct address_t : public value64 {
+	QString toPointerString(bool createdFromNativePointer=true) const;
+	QString toHexString() const;
+	template<typename SmallData>
+	static address_t fromZeroExtended(const SmallData& data) {
+		return value64::fromZeroExtended(data);
+	}
+	template<class T>
+	address_t(const T& val) : value64(val) {}
+	address_t()=default;
+};
+
+	typedef address_t                                  reg_t;
 }
 
 template<class T> typename std::enable_if<std::is_same<T,edb::value8 >::value ||
 										  std::is_same<T,edb::value16>::value ||
 										  std::is_same<T,edb::value32>::value ||
-										  std::is_same<T,edb::value64>::value,
+										  std::is_same<T,edb::value64>::value ||
+										  std::is_same<T,edb::reg_t>::value   ||
+										  std::is_same<T,edb::address_t>::value,
 std::istream&>::type operator>>(std::istream& os, T& val)
 {
 	os >> val.asUint();
@@ -338,7 +354,9 @@ std::istream&>::type operator>>(std::istream& os, T& val)
 template<class T> typename std::enable_if<std::is_same<T,edb::value8 >::value ||
 										  std::is_same<T,edb::value16>::value ||
 										  std::is_same<T,edb::value32>::value ||
-										  std::is_same<T,edb::value64>::value,
+										  std::is_same<T,edb::value64>::value ||
+										  std::is_same<T,edb::reg_t>::value   ||
+										  std::is_same<T,edb::address_t>::value,
 std::ostream&>::type operator<<(std::ostream& os, T val)
 {
 	os << val.toUint();

--- a/include/Types.h
+++ b/include/Types.h
@@ -129,6 +129,16 @@ struct SizedValue : public ValueBase<N,1> {
 	operator InnerValueType() const { return this->value_[0]; }
 	operator QVariant() const { return QVariant::fromValue(this->value_[0]); }
 
+	SizedValue signExtended(std::size_t valueLength) const {
+		SizedValue result(*this);
+		if(valueLength==sizeof(*this)) return result;
+		if(this->value_[0]&(1ull << (valueLength*8-1))) {
+			result=-1ll;
+			std::memcpy(&result,this,valueLength);
+		}
+		return result;
+	}
+
 	QString toString() const { return QString("%1").arg(this->value_[0]); }
 	QString unsignedToString() const { return toString(); }
 	QString signedToString() const { return QString("%1").arg(typename std::make_signed<InnerValueType>::type(this->value_[0])); }

--- a/include/arch/x86-generic/ArchTypes.h
+++ b/include/arch/x86-generic/ArchTypes.h
@@ -39,8 +39,6 @@ static constexpr const bool EDB_IS_32_BIT=false;
 
 namespace edb {
 	typedef value16                                    seg_reg_t;
-	typedef detail::SizedValue<8*sizeof(void*)>        reg_t;
-	typedef detail::SizedValue<8*sizeof(void*)>        address_t;
 	typedef CapstoneEDB::Instruction                   Instruction;
 	typedef Instruction::operand_type                  Operand;
 }

--- a/include/edb.h
+++ b/include/edb.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IRegion.h"
 #include "IBreakpoint.h"
 #include "Types.h"
+#include "Register.h"
 #include "Formatter.h"
 
 #include <QHash>
@@ -101,8 +102,8 @@ EDB_EXPORT bool get_expression_from_user(const QString &title, const QString pro
 EDB_EXPORT bool eval_expression(const QString &expression, address_t *value);
 
 // ask the user for a value suitable for a register via an input box
-EDB_EXPORT bool get_value_from_user(reg_t &value, const QString &title);
-EDB_EXPORT bool get_value_from_user(reg_t &value);
+EDB_EXPORT bool get_value_from_user(Register &value, const QString &title);
+EDB_EXPORT bool get_value_from_user(Register &value);
 
 // ask the user for a binary string via an input box
 EDB_EXPORT bool get_binary_string_from_user(QByteArray &value, const QString &title, int max_length);

--- a/plugins/Analyzer/AnalyzerWidget.cpp
+++ b/plugins/Analyzer/AnalyzerWidget.cpp
@@ -135,7 +135,7 @@ void AnalyzerWidget::mousePressEvent(QMouseEvent *event) {
 		const IAnalyzer::FunctionMap functions = edb::v1::analyzer()->functions(region);
 		if(region->size() != 0 && !functions.empty()) {
 			const auto byte_width = static_cast<float>(width()) / region->size();
-			const edb::address_t address = qBound(region->start(), region->start() + edb::address_t(event->x() / byte_width), region->end() - 1);
+			const edb::address_t address = qBound<edb::address_t>(region->start(), region->start() + edb::address_t(event->x() / byte_width), region->end() - 1);
 			edb::v1::jump_to_address(address);
 		}
 	}

--- a/plugins/BinaryInfo/ELF32.cpp
+++ b/plugins/BinaryInfo/ELF32.cpp
@@ -167,7 +167,8 @@ edb::address_t ELF32::calculate_main() {
 				if(ba.size() >= 11) {
 					// beginning of a call preceeded by a push and followed by a hlt
 					if(ba[0] == 0x68 && ba[5] == 0xe8 && ba[10] == 0xf4) {
-						auto address = *reinterpret_cast<const edb::address_t *>(ba.data() + 1);
+						edb::address_t address(0);
+						std::memcpy(&address,ba.data() + 1,sizeof(uint32_t));
 						// TODO: make sure that this address resides in an executable region
 						qDebug() << "No main symbol found, calculated it to be " << edb::v1::format_pointer(address) << " using heuristic";
 						return address;

--- a/plugins/BinarySearcher/DialogASCIIString.cpp
+++ b/plugins/BinarySearcher/DialogASCIIString.cpp
@@ -70,7 +70,7 @@ void DialogASCIIString::do_find() {
 
 		if(IRegion::pointer region = edb::v1::memory_regions().find_region(stack_ptr)) {
 			if(IProcess *process = edb::v1::debugger_core->process()) {
-				std::size_t count = (region->end() - stack_ptr) / sizeof(edb::address_t);
+				edb::address_t count = (region->end() - stack_ptr) / edb::v1::pointer_size();
 				stack_ptr = region->start();
 
 				try {
@@ -79,8 +79,8 @@ void DialogASCIIString::do_find() {
 					int i = 0;
 					while(stack_ptr < region->end()) {
 						// get the value from the stack
-						edb::address_t value;
-						if(process->read_bytes(stack_ptr, &value, sizeof(edb::address_t))) {
+						edb::address_t value(0);
+						if(process->read_bytes(stack_ptr, &value, edb::v1::pointer_size())) {
 							if(process->read_bytes(value, &chars[0], sz)) {
 								if(std::memcmp(&chars[0], b.constData(), sz) == 0) {
 									auto item = new QListWidgetItem(edb::v1::format_pointer(stack_ptr));
@@ -90,7 +90,7 @@ void DialogASCIIString::do_find() {
 							}
 						}
 						ui->progressBar->setValue(util::percentage(i++, count));
-						stack_ptr += sizeof(edb::address_t);
+						stack_ptr += edb::v1::pointer_size();
 					}
 				} catch(const std::bad_alloc &) {
 					QMessageBox::information(0, tr("Memroy Allocation Error"),

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -624,6 +624,13 @@ bool DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t cou
 bool DebuggerCore::write_data(edb::address_t address, long value) {
 	if(EDB_IS_32_BIT && address>0xffffffffULL) {
 		// 32 bit ptrace can't handle such long addresses
+		QFile memory_file(QString("/proc/%1/mem").arg(pid_));
+		if(memory_file.open(QIODevice::WriteOnly)) {
+
+			memory_file.seek(address);
+			if(memory_file.write(reinterpret_cast<char*>(&value), sizeof(long))==sizeof(long))
+				return true;
+		}
 		return false;
 	}
 	// NOTE: on some Linux systems ptrace prototype has ellipsis instead of third and fourth arguments

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -589,13 +589,7 @@ long DebuggerCore::read_data(edb::address_t address, bool *ok) {
 	return v;
 }
 
-//------------------------------------------------------------------------------
-// Name: read_pages
-// Desc:
-//------------------------------------------------------------------------------
-std::size_t DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t count) {
-
-	const std::size_t len = count * page_size();
+std::size_t DebuggerCore::read_bytes(edb::address_t address, void* buf, std::size_t len) {
 	quint64 bytesRead=0;
 
 	QFile memory_file(QString("/proc/%1/mem").arg(pid_));
@@ -616,7 +610,16 @@ std::size_t DebuggerCore::read_pages(edb::address_t address, void *buf, std::siz
 		memory_file.close();
 	}
 
-	return bytesRead/page_size();
+	return bytesRead;
+}
+
+//------------------------------------------------------------------------------
+// Name: read_pages
+// Desc:
+//------------------------------------------------------------------------------
+std::size_t DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t count) {
+
+	return read_bytes(address,buf,count*page_size())/page_size();
 }
 
 

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -593,18 +593,21 @@ long DebuggerCore::read_data(edb::address_t address, bool *ok) {
 // Name: read_pages
 // Desc:
 //------------------------------------------------------------------------------
-bool DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t count) {
+std::size_t DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t count) {
 
 	const std::size_t len = count * page_size();
+	quint64 bytesRead=0;
 
 	QFile memory_file(QString("/proc/%1/mem").arg(pid_));
 	if(memory_file.open(QIODevice::ReadOnly)) {
 
 		memory_file.seek(address);
-		const qint64 n = memory_file.read(reinterpret_cast<char *>(buf), len);
+		bytesRead = memory_file.read(reinterpret_cast<char *>(buf), len);
+		if(bytesRead==0 || bytesRead==quint64(-1))
+			return 0;
 
 		for(const IBreakpoint::pointer &bp: breakpoints_) {
-			if(bp->address() >= address && bp->address() < (address + n)) {
+			if(bp->address() >= address && bp->address() < (address + bytesRead)) {
 				// show the original bytes in the buffer..
 				reinterpret_cast<quint8 *>(buf)[bp->address() - address] = bp->original_byte();
 			}
@@ -613,7 +616,7 @@ bool DebuggerCore::read_pages(edb::address_t address, void *buf, std::size_t cou
 		memory_file.close();
 	}
 
-	return true;
+	return bytesRead/page_size();
 }
 
 

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -59,7 +59,7 @@ public:
 	virtual void get_state(State *state);
 	virtual void set_state(const State &state);
 	virtual bool open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty);
-	virtual bool read_pages(edb::address_t address, void *buf, std::size_t count);
+	virtual std::size_t read_pages(edb::address_t address, void *buf, std::size_t count);
 
 public:
 	// thread support stuff (optional)

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -61,6 +61,8 @@ public:
 	virtual bool open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty);
 	virtual std::size_t read_pages(edb::address_t address, void *buf, std::size_t count);
 
+	std::size_t read_bytes(edb::address_t address, void *buf, std::size_t len);
+
 public:
 	// thread support stuff (optional)
 	virtual QList<edb::tid_t> thread_ids() const { return threads_.keys(); }

--- a/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
@@ -53,7 +53,10 @@ IDebugEvent::Message PlatformEvent::createUnexpectedSignalMessage(const QString 
 IDebugEvent::Message PlatformEvent::error_description() const {
 	Q_ASSERT(is_error());
 
-	auto fault_address = edb::address_t(siginfo_.si_addr);
+	auto fault_address = edb::address_t::fromZeroExtended(siginfo_.si_addr);
+
+	std::size_t debuggeePtrSize=edb::v1::pointer_size();
+	bool fullAddressKnown=debuggeePtrSize<=sizeof(void*);
 
 	switch(code()) {
 	case SIGSEGV:
@@ -63,14 +66,14 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 				tr("Illegal Access Fault"),
 				tr(
 					"<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> does not appear to be mapped.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(edb::v1::format_pointer(fault_address))
+					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(fault_address.toPointerString(fullAddressKnown))
 				);
 		case SEGV_ACCERR:
 			return Message(
 				tr("Illegal Access Fault"),
 				tr(
 					"<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> could not be accessed.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(edb::v1::format_pointer(fault_address))
+					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(fault_address.toPointerString(fullAddressKnown))
 				);
 		default:
 			return Message(

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -231,36 +231,7 @@ bool PlatformProcess::read_pages(edb::address_t address, void *buf, std::size_t 
 
 	Q_ASSERT(buf);
 
-	if((address & (core_->page_size() - 1)) == 0) {
-	
-		const edb::address_t orig_address = address;
-		auto ptr                          = reinterpret_cast<long *>(buf);
-		auto orig_ptr                     = reinterpret_cast<quint8 *>(buf);
-
-		const edb::address_t end_address  = orig_address + core_->page_size() * count;
-
-		for(std::size_t c = 0; c < count; ++c) {
-			for(edb::address_t i = 0; i < core_->page_size(); i += EDB_WORDSIZE) {
-				bool ok;
-				const long v = core_->read_data(address, &ok);
-				if(!ok) {
-					return false;
-				}
-
-				*ptr++ = v;
-				address += EDB_WORDSIZE;
-			}
-		}
-
-		for(const IBreakpoint::pointer &bp: core_->breakpoints_) {
-			if(bp->address() >= orig_address && bp->address() < end_address) {
-				// show the original bytes in the buffer..
-				orig_ptr[bp->address() - orig_address] = bp->original_byte();
-			}
-		}
-	}
-
-	return true;
+	return core_->read_pages(address,buf,count);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -227,7 +227,7 @@ PlatformProcess::~PlatformProcess() {
 // Note: buf's size must be >= count * core_->page_size()
 // Note: address should be page aligned.
 //------------------------------------------------------------------------------
-bool PlatformProcess::read_pages(edb::address_t address, void *buf, std::size_t count) {
+std::size_t PlatformProcess::read_pages(edb::address_t address, void *buf, std::size_t count) {
 
 	Q_ASSERT(buf);
 

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -234,15 +234,7 @@ std::size_t PlatformProcess::read_pages(edb::address_t address, void *buf, std::
 	return core_->read_pages(address,buf,count);
 }
 
-//------------------------------------------------------------------------------
-// Name: read_bytes
-// Desc: reads <len> bytes into <buf> starting at <address>
-// Note: if the read failed, the part of the buffer that could not be read will
-//       be filled with 0xff bytes
-//------------------------------------------------------------------------------
-bool PlatformProcess::read_bytes(edb::address_t address, void *buf, std::size_t len) {
-
-	Q_ASSERT(buf);
+bool PlatformProcess::read_bytes_one_by_one(edb::address_t address, void* buf, std::size_t len) {
 
 	if(len != 0) {
 		bool ok;
@@ -264,6 +256,24 @@ bool PlatformProcess::read_bytes(edb::address_t address, void *buf, std::size_t 
 		}
 
 		return ok;
+	}
+
+	return true;
+}
+
+//------------------------------------------------------------------------------
+// Name: read_bytes
+// Desc: reads <len> bytes into <buf> starting at <address>
+// Note: if the read failed, the part of the buffer that could not be read will
+//       be filled with 0xff bytes
+//------------------------------------------------------------------------------
+bool PlatformProcess::read_bytes(const edb::address_t address, void *buf, const std::size_t len) {
+
+	Q_ASSERT(buf);
+
+	if(len != 0) {
+		bool ok = len==core_->read_bytes(address,buf,len);
+		if(!ok) return read_bytes_one_by_one(address,buf,len);
 	}
 
 	return true;

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.h
@@ -27,7 +27,7 @@ public:
 public:
 	virtual bool write_bytes(edb::address_t address, const void *buf, size_t len);
 	virtual bool read_bytes(edb::address_t address, void *buf, size_t len);
-	virtual bool read_pages(edb::address_t address, void *buf, size_t count);
+	virtual std::size_t read_pages(edb::address_t address, void *buf, size_t count);
 
 private:
 	quint8 read_byte(edb::address_t address, bool *ok);

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.h
@@ -30,6 +30,7 @@ public:
 	virtual std::size_t read_pages(edb::address_t address, void *buf, size_t count);
 
 private:
+	bool read_bytes_one_by_one(edb::address_t address, void *buf, size_t len);
 	quint8 read_byte(edb::address_t address, bool *ok);
 	void write_byte(edb::address_t address, quint8 value, bool *ok);
 	quint8 read_byte_base(edb::address_t address, bool *ok);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -786,10 +786,7 @@ Register PlatformState::flags_register() const {
 // Desc:
 //------------------------------------------------------------------------------
 edb::reg_t PlatformState::flags() const {
-	Register flagsR=flags_register();
-	if(flagsR.bitSize()==64) return flagsR.value<edb::reg_t>();
-	else if(flagsR) return edb::reg_t::fromZeroExtended(flagsR.value<edb::value32>());
-	return 0;
+	return flags_register().valueAsInteger();
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -437,8 +437,6 @@ void PlatformState::fillStruct(UserRegsStructX86& regs) const
 }
 void PlatformState::fillStruct(UserRegsStructX86_64& regs) const
 {
-	// Put some markers to make invalid values immediately visible
-	util::markMemory(&regs,sizeof(regs));
 	// If 64-bit part is not filled in state, we'll set marked values
 	if(x86.gpr64Filled || x86.gpr32Filled) {
 		regs.rax=x86.GPRegs[X86::RAX];

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -24,6 +24,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace DebuggerCore {
 
+constexpr const char* PlatformState::AVX::mxcsrName;
+constexpr const char* PlatformState::X86::IP64Name;
+constexpr const char* PlatformState::X86::IP32Name;
+constexpr const char* PlatformState::X86::IP16Name;
+constexpr const char* PlatformState::X86::flags64Name;
+constexpr const char* PlatformState::X86::flags32Name;
+constexpr const char* PlatformState::X86::flags16Name;
+constexpr const char* PlatformState::X86::fsBaseName;
+constexpr const char* PlatformState::X86::gsBaseName;
 const std::array<const char*,MAX_GPR_COUNT> PlatformState::X86::GPReg64Names={
 	"rax",
 	"rcx",

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -469,6 +469,40 @@ void PlatformState::fillStruct(UserRegsStructX86_64& regs) const
 	}
 }
 
+void PlatformState::fillStruct(PrStatus_X86_64& regs) const
+{
+	// If 64-bit part is not filled in state, we'll set marked values
+	if(x86.gpr64Filled || x86.gpr32Filled) {
+		regs.rax=x86.GPRegs[X86::RAX];
+		regs.rcx=x86.GPRegs[X86::RCX];
+		regs.rdx=x86.GPRegs[X86::RDX];
+		regs.rbx=x86.GPRegs[X86::RBX];
+		regs.rsp=x86.GPRegs[X86::RSP];
+		regs.rbp=x86.GPRegs[X86::RBP];
+		regs.rsi=x86.GPRegs[X86::RSI];
+		regs.rdi=x86.GPRegs[X86::RDI];
+		regs.r8 =x86.GPRegs[X86::R8 ];
+		regs.r9 =x86.GPRegs[X86::R9 ];
+		regs.r10=x86.GPRegs[X86::R10];
+		regs.r11=x86.GPRegs[X86::R11];
+		regs.r12=x86.GPRegs[X86::R12];
+		regs.r13=x86.GPRegs[X86::R13];
+		regs.r14=x86.GPRegs[X86::R14];
+		regs.r15=x86.GPRegs[X86::R15];
+		regs.orig_rax=x86.orig_ax;
+		regs.rflags=x86.flags;
+		regs.rip=x86.IP;
+		regs.es=x86.segRegs[X86::ES];
+		regs.cs=x86.segRegs[X86::CS];
+		regs.ss=x86.segRegs[X86::SS];
+		regs.ds=x86.segRegs[X86::DS];
+		regs.fs=x86.segRegs[X86::FS];
+		regs.gs=x86.segRegs[X86::GS];
+		regs.fs_base=x86.fsBase;
+		regs.gs_base=x86.gsBase;
+	}
+}
+
 edb::value128 PlatformState::AVX::xmm(std::size_t index) const {
 	return edb::value128(zmmStorage[index]);
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -459,6 +459,7 @@ private:
 
 	void fillStruct(UserRegsStructX86& regs) const;
 	void fillStruct(UserRegsStructX86_64& regs) const;
+	void fillStruct(PrStatus_X86_64& regs) const;
 };
 
 }

--- a/plugins/HeapAnalyzer/DialogHeap.h
+++ b/plugins/HeapAnalyzer/DialogHeap.h
@@ -48,8 +48,10 @@ private:
 
 private:
 	void get_library_names(QString *libcName, QString *ldName) const;
+	template<class Addr>
 	void collect_blocks(edb::address_t start_address, edb::address_t end_address);
 	void detect_pointers();
+	template<class Addr>
 	void do_find();
 	void process_potential_pointer(const QHash<edb::address_t, edb::address_t> &targets, Result &result);
 

--- a/plugins/References/DialogReferences.cpp
+++ b/plugins/References/DialogReferences.cpp
@@ -78,7 +78,7 @@ void DialogReferences::do_find() {
 			// a short circut for speading things up
 			if(region->accessible() || !ui->chkSkipNoAccess->isChecked()) {
 
-				const size_t page_count     = region->size() / page_size;
+				const edb::address_t page_count = region->size() / page_size;
 				const QVector<quint8> pages = edb::v1::read_pages(region->start(), page_count);
 
 				if(!pages.isEmpty()) {
@@ -87,14 +87,14 @@ void DialogReferences::do_find() {
 
 					while(p != pages_end) {
 
-						if(static_cast<std::size_t>(pages_end - p) < sizeof(edb::address_t)) {
+						if(pages_end - p < edb::v1::pointer_size()) {
 							break;
 						}
 
 						const edb::address_t addr = p - &pages[0] + region->start();
 
-						edb::address_t test_address;
-						memcpy(&test_address, p, sizeof(edb::address_t));
+						edb::address_t test_address(0);
+						memcpy(&test_address, p, edb::v1::pointer_size());
 
 						if(test_address == address) {
 							auto item = new QListWidgetItem(edb::v1::format_pointer(addr));

--- a/src/CallStack.cpp
+++ b/src/CallStack.cpp
@@ -52,8 +52,8 @@ void CallStack::get_call_stack() {
 	edb::address_t rsp = state.stack_pointer();
 
 	//Check the alignment.  rbp and rsp should be aligned to the stack.
-	if (rbp % sizeof(edb::address_t) != 0 ||
-			rsp % sizeof(edb::address_t) != 0)
+	if (rbp % edb::v1::pointer_size() != 0 ||
+			rsp % edb::v1::pointer_size() != 0)
 	{
 		return;
 	}
@@ -73,7 +73,7 @@ void CallStack::get_call_stack() {
 	//Code is largely from CommentServer.cpp.  Makes assumption of size of call.
 	const quint8 CALL_MIN_SIZE = 2, CALL_MAX_SIZE = 7;
 	quint8 buffer[edb::Instruction::MAX_SIZE];
-	for (edb::address_t addr = rbp; region_rbp->contains(addr); addr += sizeof(edb::address_t)) {
+	for (edb::address_t addr = rbp; region_rbp->contains(addr); addr += edb::v1::pointer_size()) {
 
 		//Get the stack value so that we can see if it's a pointer
 		bool ok;

--- a/src/CommentServer.cpp
+++ b/src/CommentServer.cpp
@@ -134,8 +134,8 @@ QString CommentServer::comment(QHexView::address_t address, int size) const {
 		// if the view is currently looking at words which are a pointer in size
 		// then see if it points to anything...
 		if(size == edb::v1::pointer_size()) {
-			edb::address_t value;
-			if(process->read_bytes(address, &value, sizeof(value))) {
+			edb::address_t value(0);
+			if(process->read_bytes(address, &value, edb::v1::pointer_size())) {
 
 				auto it = custom_comments_.find(value);
 				if(it != custom_comments_.end()) {

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -121,7 +121,8 @@ void Configuration::read_settings() {
 		data_row_width = 16;
 	}
 	
-	CapstoneEDB::init(EDB_IS_64_BIT); // TODO: properly choose bitness according to target bitness
+	// Init capstone to some default settings
+	CapstoneEDB::init(EDB_IS_64_BIT);
 	CapstoneEDB::Formatter::FormatOptions options = edb::v1::formatter().options();
 	options.capitalization = uppercase_disassembly ? CapstoneEDB::Formatter::UpperCase : CapstoneEDB::Formatter::LowerCase;
 	options.smallNumFormat = small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2579,14 +2579,6 @@ void Debugger::test_native_binary() {
 			"For example a 32-bit binary on x86-64. "
 			"This is not supported yet, so you may need to use a version of edb that was compiled for the same architecture as your target program")
 			);
-		// Although non-native debugging is not fully supported, let's give the user a nicer experience with unsupported feature.
-		// Reinitialize CapstoneEDB to inverse of native bitness
-		CapstoneEDB::init(EDB_IS_32_BIT);
-	}
-	else {
-		// Reinitialize CapstoneEDB with native bitness. This is needed when e.g. previous
-		// debugging session was non-native, and the new one is native.
-		CapstoneEDB::init(EDB_IS_64_BIT);
 	}
 }
 
@@ -2667,6 +2659,7 @@ bool Debugger::common_open(const QString &s, const QList<QByteArray> &args) {
 		if(edb::v1::debugger_core->open(s, working_directory_, args, tty_file_)) {
 			set_initial_debugger_state();
 			test_native_binary();
+			CapstoneEDB::init(edb::v1::debuggeeIs64Bit());
 			set_initial_breakpoint(s);
 			ret = true;
 		} else {

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1033,13 +1033,12 @@ void Debugger::on_cpuView_breakPointToggled(edb::address_t address) {
 void Debugger::on_registerList_itemDoubleClicked(QTreeWidgetItem *item) {
 	Q_ASSERT(item);
 
-	if(const Register reg = edb::v1::arch_processor().value_from_item(*item)) {
-		edb::reg_t r = reg.value<edb::reg_t>();
+	if(Register r = edb::v1::arch_processor().value_from_item(*item)) {
 		if(edb::v1::get_value_from_user(r, tr("Register Value"))) {
 
 			State state;
 			edb::v1::debugger_core->get_state(&state);
-			state.set_register(reg.name(), r);
+			state.set_register(r.name(), r.valueAsInteger());
 			edb::v1::debugger_core->set_state(state);
 			update_gui();
 			refresh_gui();
@@ -1408,7 +1407,9 @@ void Debugger::on_actionApplication_Working_Directory_triggered() {
 // Desc:
 //------------------------------------------------------------------------------
 void Debugger::mnuStackPush() {
-	edb::reg_t value = 0;
+	Register value(edb::v1::debuggeeIs32Bit()?
+					   make_Register("",edb::value32(0),Register::TYPE_GPR):
+					   make_Register("",edb::value64(0),Register::TYPE_GPR));
 	State state;
 	edb::v1::debugger_core->get_state(&state);
 
@@ -1416,7 +1417,7 @@ void Debugger::mnuStackPush() {
 	if(edb::v1::get_value_from_user(value, tr("Enter value to push"))) {
 
 		// if they said ok, do the push, just like the hardware would do
-		edb::v1::push_value(&state, value);
+		edb::v1::push_value(&state, value.valueAsInteger());
 
 		// update the state
 		edb::v1::debugger_core->set_state(state);

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -247,6 +247,7 @@ private:
 	void setup_tab_buttons();
 	void setup_ui();
 	void test_native_binary();
+	void setup_data_views();
 	void update_data_views();
 	void update_disassembly(edb::address_t address, const IRegion::pointer &r);
 	void update_menu_state(GUI_STATE state);

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -305,6 +305,8 @@ private:
 	QString                                          working_directory_;
 	QString                                          program_executable_;
 	bool                                             stack_view_locked_;
+	bool                                             auto_stack_word_width_;
+	int                                              stack_word_width_;
 	IDebugEvent::const_pointer                       last_event_;
 #ifdef Q_OS_UNIX
 	edb::address_t                                   debug_pointer_;

--- a/src/DialogInputValue.cpp
+++ b/src/DialogInputValue.cpp
@@ -61,7 +61,7 @@ edb::reg_t DialogInputValue::value() const {
 // Desc:
 //------------------------------------------------------------------------------
 void DialogInputValue::set_value(edb::reg_t value) {
-	ui->hexInput->setText(edb::v1::format_pointer(value));
+	ui->hexInput->setText(value.toHexString());
 	ui->signedInput->setText(value.signedToString());
 	ui->unsignedInput->setText(value.unsignedToString());
 }
@@ -95,7 +95,7 @@ void DialogInputValue::on_signedInput_textEdited(const QString &s) {
 		value = 0;
 	}
 
-	ui->hexInput->setText(edb::v1::format_pointer(value));
+	ui->hexInput->setText(value.toHexString());
 	ui->unsignedInput->setText(value.unsignedToString());
 }
 
@@ -110,6 +110,6 @@ void DialogInputValue::on_unsignedInput_textEdited(const QString &s) {
 	if(!ok) {
 		value = 0;
 	}
-	ui->hexInput->setText(edb::v1::format_pointer(value));
+	ui->hexInput->setText(value.toHexString());
 	ui->signedInput->setText(value.signedToString());
 }

--- a/src/DialogInputValue.h
+++ b/src/DialogInputValue.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QDialog>
 #include "Types.h"
+#include "Register.h"
 
 namespace Ui { class DialogInputValue; }
 
@@ -38,10 +39,12 @@ public Q_SLOTS:
 
 public:
 	edb::reg_t value() const;
-	void set_value(edb::reg_t value);
+	void set_value(Register &reg);
 
 private:
 	Ui::DialogInputValue *const ui;
+	edb::reg_t mask;
+	std::size_t valueLength;
 };
 
 #endif

--- a/src/QLongValidator.h
+++ b/src/QLongValidator.h
@@ -20,10 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define QLONGVALIDATOR_20071128_H_
 
 #include <QValidator>
+#include <cstdint>
 
 class QLongValidator : public QValidator {
 public:
-	typedef long value_type;
+	typedef std::int64_t value_type;
 
 public:
 	explicit QLongValidator(QObject *parent = 0);

--- a/src/QULongValidator.h
+++ b/src/QULongValidator.h
@@ -20,10 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define QULONGVALIDATOR_20071128_H_
 
 #include <QValidator>
+#include <cstdint>
 
 class QULongValidator : public QValidator {
 public:
-	typedef ulong value_type;
+	typedef std::uint64_t value_type;
 
 public:
 	explicit QULongValidator(QObject *parent = 0);

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -815,7 +815,7 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 // Desc:
 //------------------------------------------------------------------------------
 Register ArchProcessor::value_from_item(const QTreeWidgetItem &item) {
-	const QString name = item.text(0).split(':').front();
+	const QString name = item.text(0).split(':').front().trimmed();
 	State state;
 	edb::v1::debugger_core->get_state(&state);
 	return state[name];

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -347,10 +347,10 @@ void resolve_function_parameters(const State &state, const QString &symname, int
 			int i = 0;
 			for(edb::Argument argument: info->arguments) {
 
-				edb::reg_t arg;
+				edb::reg_t arg(0);
 				if(i+1 > func_param_regs_count()) {
-					size_t arg_i_position=(i - func_param_regs_count()) * sizeof(edb::reg_t);
-					process->read_bytes(state.stack_pointer() + offset + arg_i_position, &arg, sizeof(arg));
+					size_t arg_i_position=(i - func_param_regs_count()) * edb::v1::pointer_size();
+					process->read_bytes(state.stack_pointer() + offset + arg_i_position, &arg, edb::v1::pointer_size());
 				} else {
 					arg = state[parameter_registers[i]].valueAsInteger();
 				}
@@ -537,9 +537,9 @@ void analyze_call(const State &state, const edb::Instruction &inst, QStringList 
 			case edb::Operand::TYPE_EXPRESSION:
 			default:
 				do {
-					edb::address_t target;
+					edb::address_t target(0);
 
-					if(process->read_bytes(effective_address, &target, sizeof(target))) {
+					if(process->read_bytes(effective_address, &target, edb::v1::pointer_size())) {
 						int offset;
 						const QString symname = edb::v1::find_function_symbol(target, QString(), &offset);
 						if(!symname.isEmpty()) {

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -461,7 +461,7 @@ void analyze_return(const State &state, const edb::Instruction &inst, QStringLis
 	Q_UNUSED(inst);
 
 	if(IProcess *process = edb::v1::debugger_core->process()) {
-		edb::address_t return_address;
+		edb::address_t return_address(0);
 		process->read_bytes(state.stack_pointer(), &return_address, edb::v1::pointer_size());
 	
 		const QString symname = edb::v1::find_function_symbol(return_address);

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -462,7 +462,7 @@ void analyze_return(const State &state, const edb::Instruction &inst, QStringLis
 
 	if(IProcess *process = edb::v1::debugger_core->process()) {
 		edb::address_t return_address;
-		process->read_bytes(state.stack_pointer(), &return_address, sizeof(return_address));
+		process->read_bytes(state.stack_pointer(), &return_address, edb::v1::pointer_size());
 	
 		const QString symname = edb::v1::find_function_symbol(return_address);
 		if(!symname.isEmpty()) {

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -352,7 +352,7 @@ void resolve_function_parameters(const State &state, const QString &symname, int
 					size_t arg_i_position=(i - func_param_regs_count()) * sizeof(edb::reg_t);
 					process->read_bytes(state.stack_pointer() + offset + arg_i_position, &arg, sizeof(arg));
 				} else {
-					arg = state[parameter_registers[i]].value<edb::reg_t>();
+					arg = state[parameter_registers[i]].valueAsInteger();
 				}
 
 				arguments << format_argument(argument.type, arg);
@@ -696,7 +696,7 @@ void analyze_syscall(const State &state, const edb::Instruction &inst, QStringLi
 		QString res;
 		query.setFocus(&file);
 		const QString arch=debuggeeIs64Bit() ? "x86-64" : "x86";
-		query.setQuery(QString("syscalls[@version='1.0']/linux[@arch='"+arch+"']/syscall[index=%1]").arg(state.gp_register(rAX).value<edb::reg_t>()));
+		query.setQuery(QString("syscalls[@version='1.0']/linux[@arch='"+arch+"']/syscall[index=%1]").arg(state.gp_register(rAX).valueAsInteger()));
 		if (query.isValid()) {
 			query.evaluateTo(&syscall_entry);
 		}

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -734,12 +734,12 @@ address_t get_variable(const QString &s, bool *ok, ExpressionError *err) {
 	// FIXME: if it's really meant to return base, then need to check whether
 	//        State::operator[]() returned valid Register
 	if(reg.name() == "fs") {
-		return state["fs_base"].value<reg_t>();
+		return state["fs_base"].valueAsAddress();
 	} else if(reg.name() == "gs") {
-		return state["gs_base"].value<reg_t>();
+		return state["gs_base"].valueAsAddress();
 	}
 
-	return reg.value<reg_t>();
+	return reg.valueAsAddress();
 }
 
 //------------------------------------------------------------------------------

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -504,7 +504,7 @@ bool get_expression_from_user(const QString &title, const QString prompt, addres
 // Name: get_value_from_user
 // Desc:
 //------------------------------------------------------------------------------
-bool get_value_from_user(reg_t &value) {
+bool get_value_from_user(Register &value) {
 	return get_value_from_user(value, QT_TRANSLATE_NOOP("edb", "Input Value"));
 }
 
@@ -512,14 +512,14 @@ bool get_value_from_user(reg_t &value) {
 // Name: get_value_from_user
 // Desc:
 //------------------------------------------------------------------------------
-bool get_value_from_user(reg_t &value, const QString &title) {
+bool get_value_from_user(Register &value, const QString &title) {
 	static auto dlg = new DialogInputValue(debugger_ui);
 	bool ret = false;
 
 	dlg->setWindowTitle(title);
 	dlg->set_value(value);
 	if(dlg->exec() == QDialog::Accepted) {
-		value = dlg->value();
+		value.setScalarValue(dlg->value());
 		ret = true;
 	}
 

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -760,7 +760,7 @@ address_t get_value(address_t address, bool *ok, ExpressionError *err) {
 	*ok = false;
 
 	if(IProcess *process = edb::v1::debugger_core->process()) {
-		*ok = process->read_bytes(address, &ret, sizeof(ret));
+		*ok = process->read_bytes(address, &ret, edb::v1::pointer_size());
 	
 		if(!*ok) {
 			*err = ExpressionError(ExpressionError::CANNOT_READ_MEMORY);

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -159,6 +159,10 @@ QString address_t::toHexString() const {
 	}
 	else return value64::toHexString();
 }
+void address_t::normalize() {
+	if(v1::debuggeeIs32Bit())
+		value_[0]&=0xffffffffull;
+}
 
 namespace v1 {
 

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -137,6 +137,29 @@ void load_function_db() {
 
 }
 
+QString address_t::toPointerString(bool createdFromNativePointer) const {
+	if(v1::debuggeeIs32Bit()) {
+		return "0x"+toHexString();
+	} else {
+		if(!createdFromNativePointer) // then we don't know value of upper dword
+			return "0x????????"+value32(value_[0]).toHexString();
+		else
+			return "0x"+toHexString();
+	}
+}
+QString address_t::toHexString() const {
+	if(v1::debuggeeIs32Bit()) {
+		if(value_[0]>0xffffffffull) {
+			// Make erroneous bits visible
+			QString string=value64::toHexString();
+			string.insert(8,"]");
+			return "["+string;
+		}
+		return value32(value_[0]).toHexString();
+	}
+	else return value64::toHexString();
+}
+
 namespace v1 {
 
 bool debuggeeIs32Bit() { return pointer_size()==sizeof(std::uint32_t); }

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -957,8 +957,8 @@ void push_value(State *state, reg_t value) {
 	Q_ASSERT(state);
 	
 	if(IProcess *process = edb::v1::debugger_core->process()) {
-		state->adjust_stack(- static_cast<int>(sizeof(reg_t)));	
-		process->write_bytes(state->stack_pointer(), &value, sizeof(reg_t));
+		state->adjust_stack(- static_cast<int>(pointer_size()));	
+		process->write_bytes(state->stack_pointer(), &value, pointer_size());
 	}
 }
 


### PR DESCRIPTION
This set of commits switches `address_t` and `reg_t` to unconditional 64 bit types along with many implied changes. Now non-native bitness can be called supported (although the non-native warning dialog hasn't been changed/removed yet).

This of course needs much testing, as it appears to be quite a significant change, and I alone can't test it well enough.

Now that this has touched so many parts of code, upstream changes have also begun to conflict with it, so it seems it's better to merge it and do any further fixes in new pull requests.