### PR TITLE
Show bases of all relevant segment registers

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -836,13 +836,14 @@ void DebuggerCore::fillFSGSBases(PlatformState* state) {
 		struct user_desc desc;
 		std::memset(&desc, 0, sizeof(desc));
 
-		if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state->x86.segRegs[PlatformState::X86::FS] / LDT_ENTRY_SIZE), &desc) != -1) {
-			state->x86.segRegBases[PlatformState::X86::FS] = desc.base_addr;
-			state->x86.segRegBasesFilled[PlatformState::X86::FS]=true;
-		}
-		if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state->x86.segRegs[PlatformState::X86::GS] / LDT_ENTRY_SIZE), &desc) != -1) {
-			state->x86.segRegBases[PlatformState::X86::GS] = desc.base_addr;
-			state->x86.segRegBasesFilled[PlatformState::X86::GS]=true;
+		for(size_t sregIndex=0;sregIndex<state->seg_reg_count();++sregIndex) {
+			const edb::seg_reg_t reg=state->x86.segRegs[sregIndex];
+			bool fromGDT=!(reg&0x04); // otherwise the selector picks descriptor from LDT
+			if(!fromGDT) continue;
+			if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), reg / LDT_ENTRY_SIZE, &desc) != -1) {
+				state->x86.segRegBases[sregIndex] = desc.base_addr;
+				state->x86.segRegBasesFilled[sregIndex]=true;
+			}
 		}
 	}
 }

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -813,12 +813,12 @@ void DebuggerCore::fillFSGSBases(PlatformState* state) {
 		std::memset(&desc, 0, sizeof(desc));
 
 		if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state->x86.segRegs[PlatformState::X86::FS] / LDT_ENTRY_SIZE), &desc) != -1) {
-			state->x86.fsBase = desc.base_addr;
-			state->x86.fsBaseFilled=true;
+			state->x86.segRegBases[PlatformState::X86::FS] = desc.base_addr;
+			state->x86.segRegBasesFilled[PlatformState::X86::FS]=true;
 		}
 		if(ptrace(PTRACE_GET_THREAD_AREA, active_thread(), (state->x86.segRegs[PlatformState::X86::GS] / LDT_ENTRY_SIZE), &desc) != -1) {
-			state->x86.gsBase = desc.base_addr;
-			state->x86.gsBaseFilled=true;
+			state->x86.segRegBases[PlatformState::X86::GS] = desc.base_addr;
+			state->x86.segRegBasesFilled[PlatformState::X86::GS]=true;
 		}
 	}
 }

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -967,6 +967,8 @@ void DebuggerCore::detectDebuggeeBitness() {
 void DebuggerCore::get_state(State *state) {
 	// TODO: assert that we are paused
 
+	detectDebuggeeBitness();
+
 	if(auto state_impl = static_cast<PlatformState *>(state->impl_)) {
 		// State must be cleared before filling to zero all presence flags, otherwise something
 		// may remain not updated. Also, this way we'll mark all the unfilled values.

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -846,6 +846,17 @@ void DebuggerCore::fillFSGSBases(PlatformState* state) {
 			}
 		}
 	}
+	static const edb::seg_reg_t USER_CS_32 = osIs64Bit?0x23:0x73;
+	static const edb::seg_reg_t USER_CS_64 = osIs64Bit?0x33:0xfff8; // RPL 0 can't appear in user segment registers, so 0xfff8 is safe
+	static const edb::seg_reg_t USER_SS = osIs64Bit?0x2b:0x7b;
+	for(size_t sregIndex=0;sregIndex<state->seg_reg_count();++sregIndex) {
+		const edb::seg_reg_t sreg=state->x86.segRegs[sregIndex];
+		if(sreg==USER_CS_32||sreg==USER_CS_64||sreg==USER_SS ||
+				(state->is64Bit() && sregIndex<PlatformState::X86::FS)) {
+			state->x86.segRegBases[sregIndex] = 0;
+			state->x86.segRegBasesFilled[sregIndex]=true;
+		}
+	}
 }
 
 bool DebuggerCore::fillStateFromPrStatus(PlatformState* state) {

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -831,7 +831,7 @@ void DebuggerCore::step(edb::EVENT_STATUS status) {
 	}
 }
 
-void DebuggerCore::fillFSGSBases(PlatformState* state) {
+void DebuggerCore::fillSegmentBases(PlatformState* state) {
 	if(state->is32Bit()) {
 		struct user_desc desc;
 		std::memset(&desc, 0, sizeof(desc));
@@ -891,7 +891,7 @@ bool DebuggerCore::fillStateFromPrStatus(PlatformState* state) {
 		perror("PTRACE_GETREGSET(NT_PRSTATUS) failed");
 		return false;
 	}
-	fillFSGSBases(state);
+	fillSegmentBases(state);
 	return true;
 }
 
@@ -901,7 +901,7 @@ bool DebuggerCore::fillStateFromSimpleRegs(PlatformState* state) {
 	if(ptrace(PTRACE_GETREGS, active_thread(), 0, &regs) != -1) {
 
 		state->fillFrom(regs);
-		fillFSGSBases(state);
+		fillSegmentBases(state);
 		return true;
 	}
 	else {

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -116,7 +116,7 @@ private:
 
 	bool fillStateFromPrStatus(PlatformState* state);
 	bool fillStateFromSimpleRegs(PlatformState* state);
-	void fillFSGSBases(PlatformState* state);
+	void fillSegmentBases(PlatformState* state);
 	unsigned long get_debug_register(std::size_t n);
 	long set_debug_register(std::size_t n, long value);
 	void detectDebuggeeBitness();

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -138,8 +138,11 @@ private:
 	IBinary          *binary_info_;
 	IProcess         *process_;
 	std::size_t      pointer_size_;
-	bool             osIs64Bit;
-	bool             edbIsIn64BitSegment;
+	const bool       edbIsIn64BitSegment;
+	const bool       osIs64Bit;
+	const edb::seg_reg_t USER_CS_32;
+	const edb::seg_reg_t USER_CS_64;
+	const edb::seg_reg_t USER_SS;
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -138,6 +138,8 @@ private:
 	IBinary          *binary_info_;
 	IProcess         *process_;
 	std::size_t      pointer_size_;
+	bool             osIs64Bit;
+	bool             edbIsIn64BitSegment;
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -250,10 +250,12 @@ void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	x86.segRegs[X86::GS] = regs.gs;
 	x86.gpr32Filled=true;
 	x86.gpr64Filled=true;
-	x86.segRegBases[X86::FS] = regs.fs_base;
-	x86.segRegBasesFilled[X86::FS]=true;
-	x86.segRegBases[X86::GS] = regs.gs_base;
-	x86.segRegBasesFilled[X86::GS]=true;
+	if(is64Bit()) { // 32-bit processes get always zeros here, which may be wrong or meaningless
+		x86.segRegBases[X86::FS] = regs.fs_base;
+		x86.segRegBasesFilled[X86::FS]=true;
+		x86.segRegBases[X86::GS] = regs.gs_base;
+		x86.segRegBasesFilled[X86::GS]=true;
+	}
 }
 void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
 	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -251,10 +251,14 @@ void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	x86.gpr32Filled=true;
 	x86.gpr64Filled=true;
 	if(is64Bit()) { // 32-bit processes get always zeros here, which may be wrong or meaningless
-		x86.segRegBases[X86::FS] = regs.fs_base;
-		x86.segRegBasesFilled[X86::FS]=true;
-		x86.segRegBases[X86::GS] = regs.gs_base;
-		x86.segRegBasesFilled[X86::GS]=true;
+		if(x86.segRegs[X86::FS]==0) {
+			x86.segRegBases[X86::FS] = regs.fs_base;
+			x86.segRegBasesFilled[X86::FS]=true;
+		}
+		if(x86.segRegs[X86::GS]==0) {
+			x86.segRegBases[X86::GS] = regs.gs_base;
+			x86.segRegBasesFilled[X86::GS]=true;
+		}
 	}
 }
 void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -31,8 +31,6 @@ constexpr const char* PlatformState::X86::IP16Name;
 constexpr const char* PlatformState::X86::flags64Name;
 constexpr const char* PlatformState::X86::flags32Name;
 constexpr const char* PlatformState::X86::flags16Name;
-constexpr const char* PlatformState::X86::fsBaseName;
-constexpr const char* PlatformState::X86::gsBaseName;
 const std::array<const char*,MAX_GPR_COUNT> PlatformState::X86::GPReg64Names={
 	"rax",
 	"rcx",
@@ -252,10 +250,10 @@ void PlatformState::fillFrom(const UserRegsStructX86_64& regs) {
 	x86.segRegs[X86::GS] = regs.gs;
 	x86.gpr32Filled=true;
 	x86.gpr64Filled=true;
-	x86.fsBase = regs.fs_base;
-	x86.fsBaseFilled=true;
-	x86.gsBase = regs.gs_base;
-	x86.gsBaseFilled=true;
+	x86.segRegBases[X86::FS] = regs.fs_base;
+	x86.segRegBasesFilled[X86::FS]=true;
+	x86.segRegBases[X86::GS] = regs.gs_base;
+	x86.segRegBasesFilled[X86::GS]=true;
 }
 void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
 	x87.statusWord=regs.swd; // should be first for RIndexToSTIndex() to work
@@ -331,10 +329,10 @@ void PlatformState::fillFrom(const PrStatus_X86_64& regs)
 	x86.segRegs[X86::GS] = regs.gs;
 	x86.gpr32Filled=true;
 	x86.gpr64Filled=true;
-	x86.fsBase = regs.fs_base;
-	x86.fsBaseFilled=true;
-	x86.gsBase = regs.gs_base;
-	x86.gsBaseFilled=true;
+	x86.segRegBases[X86::FS] = regs.fs_base;
+	x86.segRegBasesFilled[X86::FS]=true;
+	x86.segRegBases[X86::GS] = regs.gs_base;
+	x86.segRegBasesFilled[X86::GS]=true;
 }
 
 void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) {
@@ -470,8 +468,8 @@ void PlatformState::fillStruct(UserRegsStructX86_64& regs) const
 		regs.ds=x86.segRegs[X86::DS];
 		regs.fs=x86.segRegs[X86::FS];
 		regs.gs=x86.segRegs[X86::GS];
-		regs.fs_base=x86.fsBase;
-		regs.gs_base=x86.gsBase;
+		regs.fs_base=x86.segRegBases[X86::FS];
+		regs.gs_base=x86.segRegBases[X86::GS];
 		regs.orig_rax=x86.orig_ax;
 		regs.eflags=x86.flags;
 		regs.rip=x86.IP;
@@ -507,8 +505,8 @@ void PlatformState::fillStruct(PrStatus_X86_64& regs) const
 		regs.ds=x86.segRegs[X86::DS];
 		regs.fs=x86.segRegs[X86::FS];
 		regs.gs=x86.segRegs[X86::GS];
-		regs.fs_base=x86.fsBase;
-		regs.gs_base=x86.gsBase;
+		regs.fs_base=x86.segRegBases[X86::FS];
+		regs.gs_base=x86.segRegBases[X86::GS];
 	}
 }
 
@@ -548,8 +546,8 @@ void PlatformState::X86::clear() {
 	util::markMemory(this,sizeof(*this));
 	gpr32Filled=false;
 	gpr64Filled=false;
-	fsBaseFilled=false;
-	gsBaseFilled=false;
+	for(auto& base : segRegBasesFilled)
+		base=false;
 }
 
 bool PlatformState::X86::empty() const {
@@ -657,17 +655,20 @@ Register PlatformState::value(const QString &reg) const {
 			return found;
 		if(!!(found=findRegisterValue(x86.segRegNames, x86.segRegs, regName, Register::TYPE_SEG, seg_reg_count())))
 			return found;
-		if(regName==x86.fsBaseName && x86.fsBaseFilled) {
-			if(is64Bit())
-				return make_Register(x86.fsBaseName, x86.fsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
-			else
-				return make_Register<32>(x86.fsBaseName, x86.fsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
-		}
-		if(regName==x86.gsBaseName && x86.gsBaseFilled) {
-			if(is64Bit())
-				return make_Register(x86.gsBaseName, x86.gsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
-			else
-				return make_Register<32>(x86.gsBaseName, x86.gsBase, Register::TYPE_SEG); // FIXME: it's not a segment register, it's an address
+		if(regName.mid(1)=="s_base") {
+			const QString segRegName=regName.mid(0,2);
+			const auto end=x86.segRegNames.end();
+			const auto regNameFoundIter=std::find(x86.segRegNames.begin(),end,segRegName);
+			if(regNameFoundIter!=end) {
+				const size_t index=regNameFoundIter-x86.segRegNames.begin();
+				if(!x86.segRegBasesFilled[index])
+					return Register();
+				const auto value=x86.segRegBases[index];
+				if(is64Bit())
+					return make_Register(regName, value, Register::TYPE_SEG);
+				else
+					return make_Register<32>(regName, value, Register::TYPE_SEG);
+			}
 		}
 
 		if(is64Bit() && regName==x86.flags64Name)

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -386,10 +386,8 @@ private:
 		edb::reg_t flags; // whole flags register: EFLAGS/RFLAGS
 		edb::address_t IP; // program counter: EIP/RIP
 		std::array<edb::seg_reg_t,MAX_SEG_REG_COUNT> segRegs;
-		edb::address_t fsBase;
-		edb::address_t gsBase;
-		bool fsBaseFilled=false;
-		bool gsBaseFilled=false;
+		std::array<edb::address_t,MAX_SEG_REG_COUNT> segRegBases;
+		std::array<bool,MAX_SEG_REG_COUNT> segRegBasesFilled={{false}};
 		bool gpr64Filled=false;
 		bool gpr32Filled=false;
 
@@ -428,8 +426,6 @@ private:
 		static constexpr const char* flags64Name="rflags";
 		static constexpr const char* flags32Name="eflags";
 		static constexpr const char* flags16Name="flags";
-		static constexpr const char* fsBaseName="fs_base";
-		static constexpr const char* gsBaseName="gs_base";
 		// gcc 4.8 fails to understand inline initialization of std::array, so define these the old way
 		static const std::array<const char*,MAX_GPR_COUNT> GPReg64Names;
 		static const std::array<const char*,MAX_GPR_COUNT> GPReg32Names;

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2564,13 +2564,13 @@ void Debugger::set_initial_debugger_state() {
 // Desc:
 //------------------------------------------------------------------------------
 void Debugger::test_native_binary() {
-	if(binary_info_ && !binary_info_->native()) {
+	if(EDB_IS_32_BIT && binary_info_ && !binary_info_->native()) {
 		QMessageBox::warning(
 			this,
 			tr("Not A Native Binary"),
 			tr("The program you just attached to was built for a different architecture than the one that edb was built for. "
-			"For example a 32-bit binary on x86-64. "
-			"This is not supported yet, so you may need to use a version of edb that was compiled for the same architecture as your target program")
+			"For example a AMD64 binary on EDB built for IA32. "
+			"This is not fully supported yet, so you may need to use a version of edb that was compiled for the same architecture as your target program")
 			);
 	}
 }

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1013,12 +1013,14 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 		auto sregValue=state[sreg].value<edb::seg_reg_t>();
 		QString sregStr=sreg.toUpper()+QString(": %1").arg(sregValue.toHexString());
 		const Register base=state[sregs[i]+"_base"];
-		if(base)
-			sregStr+=QString(" (%1)").arg(base.valueAsAddress().toHexString());
-		else if(edb::v1::debuggeeIs32Bit() && sregValue==0)
-			sregStr+=" NULL";
-		else
-			sregStr+=" (?)";
+		if(edb::v1::debuggeeIs32Bit() || i>=4/*FS or GS*/) {
+			if(base)
+				sregStr+=QString(" (%1)").arg(base.valueAsAddress().toHexString());
+			else if(edb::v1::debuggeeIs32Bit() && sregValue==0)
+				sregStr+=" NULL";
+			else
+				sregStr+=" (?)";
+		}
 		register_view_items_[itemNumber]->setText(0, sregStr);
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state[sreg] != last_state_[sreg]) ? Qt::red : palette.text()));
 	}

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1010,10 +1010,15 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	const QString sregs[]={"es","cs","ss","ds","fs","gs"};
 	for(std::size_t i=0;i<sizeof(sregs)/sizeof(sregs[0]);++i) {
 		QString sreg(sregs[i]);
-		QString sregStr=sreg.toUpper()+QString(": %1").arg(state[sreg].value<edb::seg_reg_t>().toHexString());
+		auto sregValue=state[sreg].value<edb::seg_reg_t>();
+		QString sregStr=sreg.toUpper()+QString(": %1").arg(sregValue.toHexString());
 		const Register base=state[sregs[i]+"_base"];
 		if(base)
 			sregStr+=QString(" (%1)").arg(base.valueAsAddress().toHexString());
+		else if(edb::v1::debuggeeIs32Bit() && sregValue==0)
+			sregStr+=" NULL";
+		else
+			sregStr+=" (?)";
 		register_view_items_[itemNumber]->setText(0, sregStr);
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state[sreg] != last_state_[sreg]) ? Qt::red : palette.text()));
 	}

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -66,6 +66,15 @@ enum RegisterIndex {
 	R15  = 15
 };
 
+enum SegmentRegisterIndex {
+	ES,
+	CS,
+	SS,
+	DS,
+	FS,
+	GS
+};
+
 static constexpr size_t MAX_DEBUG_REGS_COUNT=8;
 static constexpr size_t MAX_SEGMENT_REGS_COUNT=6;
 static constexpr size_t MAX_GPR_COUNT=16;
@@ -1013,7 +1022,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 		auto sregValue=state[sreg].value<edb::seg_reg_t>();
 		QString sregStr=sreg.toUpper()+QString(": %1").arg(sregValue.toHexString());
 		const Register base=state[sregs[i]+"_base"];
-		if(edb::v1::debuggeeIs32Bit() || i>=4/*FS or GS*/) {
+		if(edb::v1::debuggeeIs32Bit() || i>=FS) {
 			if(base)
 				sregStr+=QString(" (%1)").arg(base.valueAsAddress().toHexString());
 			else if(edb::v1::debuggeeIs32Bit() && sregValue==0)

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1007,18 +1007,13 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 	register_view_items_[itemNumber]->setText(0, QString("%0: %1").arg(flags.name().toUpper()).arg(flags.toHexString()));
 	register_view_items_[itemNumber++]->setForeground(0, flags_changed ? Qt::red : palette.text());
 
-	const QString usualSegs[]={"es","cs","ss","ds"};
-	for(const QString sreg : usualSegs) {
-		register_view_items_[itemNumber]->setText(0, sreg.toUpper()+QString(": %1").arg(state[sreg].value<edb::seg_reg_t>().toHexString()));
-		register_view_items_[itemNumber++]->setForeground(0, QBrush((state[sreg] != last_state_[sreg]) ? Qt::red : palette.text()));
-	}
-	const QString specialSegs[]={"fs","gs"};
-	const Register bases[]={state["fs_base"],state["gs_base"]};
-	for(std::size_t i=0;i<sizeof(specialSegs)/sizeof(specialSegs[0]);++i) {
-		QString sreg(specialSegs[i]);
+	const QString sregs[]={"es","cs","ss","ds","fs","gs"};
+	for(std::size_t i=0;i<sizeof(sregs)/sizeof(sregs[0]);++i) {
+		QString sreg(sregs[i]);
 		QString sregStr=sreg.toUpper()+QString(": %1").arg(state[sreg].value<edb::seg_reg_t>().toHexString());
-		if(bases[i])
-			sregStr+=QString(" (%1)").arg(bases[i].valueAsAddress().toHexString());
+		const Register base=state[sregs[i]+"_base"];
+		if(base)
+			sregStr+=QString(" (%1)").arg(base.valueAsAddress().toHexString());
 		register_view_items_[itemNumber]->setText(0, sregStr);
 		register_view_items_[itemNumber++]->setForeground(0, QBrush((state[sreg] != last_state_[sreg]) ? Qt::red : palette.text()));
 	}


### PR DESCRIPTION
This set of commits enables showing bases for all segment registers, for which it makes sense. Now the kernel isn't trusted about bases of FS&GS for 32-bit process since it's always given as zero.
Also, non-native binary message is only showed on 32-bit EDB, with correspondinly changed text. We consider 32-bit debuggee@64-bit EDB supported now, while 64-bit debuggee on 32-bit EDB is not completely supported yet (due to the limitations of 32-bit syscalls).