### PR TITLE
Address calculation

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -152,9 +152,12 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 		case edb::Operand::TYPE_IMMEDIATE:
 			break;
 		case edb::Operand::TYPE_REL:
-			// TODO: find out segment base for CS, otherwise this can be wrong
-			ret = op.relative_target();
-			break;
+			{
+				const Register csBase = state["cs_base"];
+				if(!csBase) return 0; // no way to reliably compute address
+				ret = op.relative_target() + csBase.valueAsAddress();
+				break;
+			}
 		default:
 			break;
 		}

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -135,16 +135,13 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 
 				ret = base + index * op.expression().scale + op.displacement();
 
-				if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
-					const Register gsBase=state["gs_base"];
-					if(!gsBase) return 0; // no way to reliably compute address
-					ret += gsBase.valueAsAddress();
-				}
-
-				if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
-					const Register fsBase=state["fs_base"];
-					if(!fsBase) return 0; // no way to reliably compute address
-					ret += fsBase.valueAsAddress();
+				std::size_t segRegIndex=op.expression().segment;
+				if(segRegIndex!=edb::Operand::Segment::REG_INVALID) {
+					static constexpr const char segInitials[]="ecsdfg";
+					Q_ASSERT(segRegIndex<sizeof(segInitials));
+					const Register segBase=state[segInitials[segRegIndex]+QString("s_base")];
+					if(!segBase) return 0; // no way to reliably compute address
+					ret += segBase.valueAsAddress();
 				}
 			} while(0);
 			break;

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -149,22 +149,13 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 			} while(0);
 			break;
 		case edb::Operand::TYPE_ABSOLUTE:
+			// TODO: find out segment base for op.absolute().seg, otherwise this isn't going to be useful
 			ret = op.absolute().offset;
-			if(op.owner()->prefix() & edb::Instruction::PREFIX_GS) {
-				const Register gsBase=state["gs_base"];
-				if(!gsBase) return 0; // no way to reliably compute address
-				ret += gsBase.valueAsAddress();
-			}
-
-			if(op.owner()->prefix() & edb::Instruction::PREFIX_FS) {
-				const Register fsBase=state["fs_base"];
-				if(!fsBase) return 0; // no way to reliably compute address
-				ret += fsBase.valueAsAddress();
-			}
 			break;
 		case edb::Operand::TYPE_IMMEDIATE:
 			break;
 		case edb::Operand::TYPE_REL:
+			// TODO: find out segment base for CS, otherwise this can be wrong
 			ret = op.relative_target();
 			break;
 		default:

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -35,7 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QVector>
 #include <QXmlQuery>
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <climits>
 #include <cmath>
 

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -163,6 +163,7 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 		}
 	}
 	ok=true;
+	ret.normalize();
 	return ret;
 }
 

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -229,6 +229,25 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 				operand.expr_.base =static_cast<Operand::Register>(ops[i].mem.base);
 				operand.expr_.index=static_cast<Operand::Register>(ops[i].mem.index);
 				operand.expr_.scale=ops[i].mem.scale;
+				switch(ops[i].mem.segment)
+				{
+				case Capstone::X86_REG_ES: operand.expr_.segment=Operand::Segment::ES; break;
+				case Capstone::X86_REG_CS: operand.expr_.segment=Operand::Segment::CS; break;
+				case Capstone::X86_REG_SS: operand.expr_.segment=Operand::Segment::SS; break;
+				case Capstone::X86_REG_DS: operand.expr_.segment=Operand::Segment::DS; break;
+				case Capstone::X86_REG_FS: operand.expr_.segment=Operand::Segment::FS; break;
+				case Capstone::X86_REG_GS: operand.expr_.segment=Operand::Segment::GS; break;
+				default: operand.expr_.segment=Operand::Segment::REG_INVALID; break;
+				}
+				if(operand.expr_.segment==Operand::Segment::REG_INVALID && !isAMD64)
+				{
+					if(operand.expr_.base==Capstone::X86_REG_BP ||
+					   operand.expr_.base==Capstone::X86_REG_EBP ||
+					   operand.expr_.base==Capstone::X86_REG_ESP)
+						operand.expr_.segment=Operand::Segment::SS;
+					else
+						operand.expr_.segment=Operand::Segment::DS;
+				}
 			case Capstone::X86_OP_FP: // FIXME: what instructions have this?
 				break;
 			case Capstone::X86_OP_INVALID:

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace CapstoneEDB {
 
@@ -38,6 +39,19 @@ class Operand
 {
 public:
 	using Register=Capstone::x86_reg;
+	struct Segment { // not enum class because we want to use this as array index etc.
+		enum Reg : std::size_t
+		{
+			ES,
+			CS,
+			SS,
+			DS,
+			FS,
+			GS,
+
+			REG_INVALID=std::size_t(-1)
+		};
+	};
 	enum Type {
 		TYPE_INVALID       = 0x00000000,
 		TYPE_REGISTER      = 0x00000100,
@@ -75,6 +89,7 @@ public:
 	};
 	struct expression_t {
 
+		Segment::Reg     segment=Segment::REG_INVALID;
 		DisplacementType displacement_type=DISP_NONE;
 		Register         base=Register::X86_REG_INVALID;
 		Register         index=Register::X86_REG_INVALID;


### PR DESCRIPTION
This set of commits switches the logic from using segment override prefixes to determining the segment to get base of to direct queries of segment from operand.