### PR TITLE
Make it possible to actually edit MMx registers

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -1053,6 +1053,12 @@ void DebuggerCore::set_state(const State &state) {
 			// debug registers
 			for(std::size_t i=0;i<8;++i)
 				set_debug_register(i,state_impl->x86.dbgRegs[i]);
+
+			// FPU registers
+			user_fpregs_struct fpregs;
+			state_impl->fillStruct(fpregs);
+			if(ptrace(PTRACE_SETFPREGS, active_thread(), 0, &fpregs)==-1)
+				perror("PTRACE_SETFPREGS failed");
 		}
 	}
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -516,6 +516,22 @@ void PlatformState::fillStruct(PrStatus_X86_64& regs) const
 	}
 }
 
+void PlatformState::fillStruct(UserFPRegsStructX86& regs) const {
+	util::markMemory(&regs,sizeof(regs));
+	if(x87.filled) {
+		regs.swd=x87.statusWord;
+		regs.cwd=x87.controlWord;
+		regs.twd=x87.tagWord;
+		regs.fip=x87.instPtrOffset;
+		regs.foo=x87.dataPtrOffset;
+		regs.fcs=x87.instPtrSelector;
+		regs.fos=x87.dataPtrSelector;
+		for(std::size_t n=0;n<MAX_FPU_REG_COUNT;++n)
+			std::memcpy(reinterpret_cast<char*>(regs.st_space)+10*x87.RIndexToSTIndex(n),&x87.R[n],sizeof(x87.R[n]));
+	}
+}
+
+
 edb::value128 PlatformState::AVX::xmm(std::size_t index) const {
 	return edb::value128(zmmStorage[index]);
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -545,6 +545,28 @@ void PlatformState::fillStruct(UserFPRegsStructX86& regs) const {
 	}
 }
 
+void PlatformState::fillStruct(UserFPRegsStructX86_64& regs) const {
+	util::markMemory(&regs,sizeof(regs));
+	if(x87.filled) {
+		regs.swd=x87.statusWord;
+		regs.cwd=x87.controlWord;
+		regs.ftw=x87.reducedTagWord();
+		regs.rip=x87.instPtrOffset;
+		regs.rdp=x87.dataPtrOffset;
+		if(x87.opCodeFilled)
+			regs.fop=x87.opCode;
+		for(std::size_t n=0;n<MAX_FPU_REG_COUNT;++n)
+			std::memcpy(reinterpret_cast<char*>(regs.st_space)+16*x87.RIndexToSTIndex(n),&x87.R[n],sizeof(x87.R[n]));
+		if(avx.xmmFilledIA32||avx.xmmFilledAMD64) {
+			for(std::size_t n=0;n<MAX_XMM_REG_COUNT;++n)
+				std::memcpy(reinterpret_cast<char*>(regs.xmm_space)+16*n,&avx.zmmStorage[n],sizeof(edb::value128));
+			regs.mxcsr=avx.mxcsr;
+		}
+		if(avx.mxcsrMaskFilled)
+			regs.mxcr_mask=avx.mxcsrMask;
+
+	}
+}
 
 edb::value128 PlatformState::AVX::xmm(std::size_t index) const {
 	return edb::value128(zmmStorage[index]);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -928,9 +928,10 @@ Register PlatformState::gp_register(size_t n) const {
 // Name: set_register
 // Desc:
 //------------------------------------------------------------------------------
-void PlatformState::set_register(const QString &name, edb::reg_t value) {
+void PlatformState::set_register(const Register& reg) {
+	const QString regName = reg.name().toLower();
+	const auto value=reg.value<edb::value64>();
 
-	const QString regName = name.toLower();
 	const auto gpr_end=GPRegNames().begin()+gpr_count();
 	auto GPRegNameFoundIter=std::find(GPRegNames().begin(), gpr_end, regName);
 	if(GPRegNameFoundIter!=gpr_end)
@@ -961,7 +962,17 @@ void PlatformState::set_register(const QString &name, edb::reg_t value) {
 		avx.mxcsr=edb::value32(value);
 		return;
 	}
-	qDebug() << "fixme: set_register("<<name<<", "<<value.toHexString().toStdString().c_str()<<"): didn't set register " << name;
+	qDebug() << "fixme: set_register(0x"<< qPrintable(reg.toHexString()) <<"): didn't set register " << reg.name();
+}
+
+//------------------------------------------------------------------------------
+// Name: set_register
+// Desc:
+//------------------------------------------------------------------------------
+void PlatformState::set_register(const QString &name, edb::reg_t value) {
+
+	const QString regName = name.toLower();
+	set_register(make_Register<64>(regName,value,Register::TYPE_GPR));
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -962,6 +962,20 @@ void PlatformState::set_register(const Register& reg) {
 		avx.mxcsr=edb::value32(value);
 		return;
 	}
+	{
+		QRegExp MMx("^mm([0-7])$");
+		if(MMx.indexIn(regName)!=-1) {
+			QChar digit=MMx.cap(1).at(0);
+			assert(digit.isDigit());
+			char digitChar=digit.toLatin1();
+			std::size_t i=digitChar-'0';
+			assert(mmxIndexValid(i));
+			std::memcpy(&x87.R[i],&value,sizeof value);
+			const uint16_t RiUpper=0xffff;
+			std::memcpy(reinterpret_cast<char*>(&x87.R[i])+sizeof value,&RiUpper,sizeof RiUpper);
+			return;
+		}
+	}
 	qDebug() << "fixme: set_register(0x"<< qPrintable(reg.toHexString()) <<"): didn't set register " << reg.name();
 }
 

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -457,6 +457,7 @@ private:
 	void fillStruct(UserRegsStructX86& regs) const;
 	void fillStruct(UserRegsStructX86_64& regs) const;
 	void fillStruct(PrStatus_X86_64& regs) const;
+	void fillStruct(UserFPRegsStructX86& regs) const;
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -366,6 +366,7 @@ private:
 		std::size_t STIndexToRIndex(std::size_t index) const;
 		// Restore the full FPU Tag Word from the ptrace-filtered version
 		edb::value16 restoreTagWord(uint16_t twd) const;
+		std::uint16_t reducedTagWord() const;
 		int tag(std::size_t n) const;
 		edb::value80 st(std::size_t n) const;
 		enum Tag {

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -319,9 +319,9 @@ public:
 	const std::array<const char*,MAX_GPR_COUNT>& GPRegNames() const { return is64Bit() ? x86.GPReg64Names : x86.GPReg32Names; }
 private:
 	// The whole AVX* state. XMM and YMM registers are lower parts of ZMM ones.
-	class AVX {
+	struct AVX {
 		std::array<edb::value512,MAX_ZMM_REG_COUNT> zmmStorage;
-	public:
+
 		edb::value32 mxcsr;
 		edb::value32 mxcsrMask;
 		edb::value64 xcr0;
@@ -459,6 +459,7 @@ private:
 	void fillStruct(UserRegsStructX86_64& regs) const;
 	void fillStruct(PrStatus_X86_64& regs) const;
 	void fillStruct(UserFPRegsStructX86& regs) const;
+	void fillStruct(UserFPRegsStructX86_64& regs) const;
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -294,6 +294,7 @@ public:
 	virtual void set_debug_register(size_t n, edb::reg_t value);
 	virtual void set_flags(edb::reg_t flags);
 	virtual void set_instruction_pointer(edb::address_t value);
+	virtual void set_register(const Register& reg);
 	virtual void set_register(const QString &name, edb::reg_t value);
 	virtual Register mmx_register(size_t n) const;
 	virtual Register xmm_register(size_t n) const;

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -819,7 +819,8 @@ void ArchProcessor::setup_register_view(RegisterListWidget *category_list) {
 // Desc:
 //------------------------------------------------------------------------------
 Register ArchProcessor::value_from_item(const QTreeWidgetItem &item) {
-	const QString name = item.text(0).split(':').front().trimmed();
+	QString preName = item.text(0).split(':').front().trimmed();
+	const QString name = preName.mid(0,2)=="=>" ? preName.mid(2) : preName;
 	State state;
 	edb::v1::debugger_core->get_state(&state);
 	return state[name];


### PR DESCRIPTION
This implements some functions to edit MMx registers using current dialog.
SSE/AVX registers are still not editable, nor are there any usable ways to set them via `DebuggerCore::set_state()`.