### PR TITLE
Move register editing logic to ArchProcessor and prevent crash

### DIFF
--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -42,6 +42,7 @@ public:
 public:
 	QStringList update_instruction_info(edb::address_t address);
 	Register value_from_item(const QTreeWidgetItem &item);
+	void edit_item(const QTreeWidgetItem &item);
 	bool can_step_over(const edb::Instruction &inst) const;
 	bool is_filling(const edb::Instruction &inst) const;
 	void reset();

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1104,18 +1104,9 @@ void Debugger::on_cpuView_breakPointToggled(edb::address_t address) {
 //------------------------------------------------------------------------------
 void Debugger::on_registerList_itemDoubleClicked(QTreeWidgetItem *item) {
 	Q_ASSERT(item);
-
-	if(Register r = edb::v1::arch_processor().value_from_item(*item)) {
-		if(edb::v1::get_value_from_user(r, tr("Register Value"))) {
-
-			State state;
-			edb::v1::debugger_core->get_state(&state);
-			state.set_register(r.name(), r.valueAsInteger());
-			edb::v1::debugger_core->set_state(state);
-			update_gui();
-			refresh_gui();
-		}
-	}
+	edb::v1::arch_processor().edit_item(*item);
+	update_gui();
+	refresh_gui();
 }
 
 //------------------------------------------------------------------------------

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -825,6 +825,17 @@ Register ArchProcessor::value_from_item(const QTreeWidgetItem &item) {
 	return state[name];
 }
 
+void ArchProcessor::edit_item(const QTreeWidgetItem &item) {
+	if(Register r = value_from_item(item)) {
+		if(edb::v1::get_value_from_user(r, tr("Modify %1","register").arg(r.name().toUpper()))) {
+			State state;
+			edb::v1::debugger_core->get_state(&state);
+			state.set_register(r.name(), r.valueAsInteger());
+			edb::v1::debugger_core->set_state(state);
+		}
+	}
+}
+
 //------------------------------------------------------------------------------
 // Name: update_register
 // Desc:

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -830,8 +830,10 @@ void ArchProcessor::edit_item(const QTreeWidgetItem &item) {
 		if(edb::v1::get_value_from_user(r, tr("Modify %1","register").arg(r.name().toUpper()))) {
 			State state;
 			edb::v1::debugger_core->get_state(&state);
-			state.set_register(r.name(), r.valueAsInteger());
-			edb::v1::debugger_core->set_state(state);
+			if(r && r.bitSize() <= 64) {
+				state.set_register(r.name(), r.valueAsInteger());
+				edb::v1::debugger_core->set_state(state);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is a first step to make it possible to have arch-specific register edit dialogs. Currently this doesn't do much, just moves a piece of code to ArchProcessor. Also a commit here prevents crash when clicking OK in unsupported register edit dialog.
Requesting merge just to make sure users don't get annoyed when cloning master and getting crashes :)