### PR TITLE
New dialog to edit GPRs

### DIFF
--- a/include/Util.h
+++ b/include/Util.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <iomanip>
 #include <type_traits>
 #include <cstddef>
+#include <array>
 
 namespace util {
 
@@ -67,6 +68,10 @@ inline void markMemory(void* memory, std::size_t size)
 	for(std::size_t i=0;i<size;++i)
 		p[i]=i&1 ? 0xba : 0xd1;
 }
+
+template<typename T, typename... Tail>
+auto make_array(T head, Tail...tail) -> std::array<T,1+sizeof...(Tail)>
+{ return std::array<T,1+sizeof...(Tail)>{head,tail...}; }
 
 }
 

--- a/include/Util.h
+++ b/include/Util.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <type_traits>
 #include <cstddef>
 #include <array>
+#include <algorithm>
 
 namespace util {
 
@@ -72,6 +73,10 @@ inline void markMemory(void* memory, std::size_t size)
 template<typename T, typename... Tail>
 auto make_array(T head, Tail...tail) -> std::array<T,1+sizeof...(Tail)>
 { return std::array<T,1+sizeof...(Tail)>{head,tail...}; }
+
+template<typename Container, typename Element>
+bool contains(const Container& container, const Element& element)
+{ return std::find(std::begin(container),std::end(container),element)!=std::end(container); }
 
 }
 

--- a/src/QLongValidator.cpp
+++ b/src/QLongValidator.cpp
@@ -89,10 +89,10 @@ QValidator::State QLongValidator::validate(QString &input, int &pos) const {
 	}
 
 	bool ok;
-	const value_type temp = input.toLong(&ok);
+	const value_type temp = input.toLongLong(&ok);
 	if(!ok) {
 		return QValidator::Invalid;
 	}
 
-	return (temp >= bottom() && temp <= top()) ? QValidator::Acceptable : QValidator::Intermediate;
+	return (temp >= bottom() && temp <= top()) ? QValidator::Acceptable : QValidator::Invalid;
 }

--- a/src/QLongValidator.cpp
+++ b/src/QLongValidator.cpp
@@ -84,7 +84,7 @@ QValidator::State QLongValidator::validate(QString &input, int &pos) const {
 		return QValidator::Acceptable;
 	}
 
-	if(input.length() == 1 && input == "-") {
+	if(input == "-") {
 		return QValidator::Intermediate;
 	}
 

--- a/src/QULongValidator.cpp
+++ b/src/QULongValidator.cpp
@@ -85,10 +85,10 @@ QValidator::State QULongValidator::validate(QString &input, int &pos) const {
 	}
 
 	bool ok;
-	const value_type temp = input.toULong(&ok);
+	const value_type temp = input.toULongLong(&ok);
 	if(!ok) {
 		return QValidator::Invalid;
 	}
 
-	return (temp >= bottom() && temp <= top()) ? QValidator::Acceptable : QValidator::Intermediate;
+	return (temp >= bottom() && temp <= top()) ? QValidator::Acceptable : QValidator::Invalid;
 }

--- a/src/arch/x86-generic/DialogEditGPR.cpp
+++ b/src/arch/x86-generic/DialogEditGPR.cpp
@@ -1,0 +1,275 @@
+#include "DialogEditGPR.h"
+#include <QDebug>
+#include <QRegExp>
+#include <QApplication>
+#include <QLineEdit>
+#include <cstring>
+#include <type_traits>
+#include <map>
+#include <cmath>
+#include <tuple>
+#include "GPREdit.h"
+
+DialogEditGPR::DialogEditGPR(QWidget* parent)
+	: QDialog(parent)
+{
+	setWindowTitle(tr("Modify Register"));
+	setModal(true);
+	const auto allContentsGrid = new QGridLayout();
+
+	// Register name labels
+	for(std::size_t c=0;c<ENTRY_COLS;++c)
+	{
+		auto& label=columnLabel(static_cast<Column>(FIRST_ENTRY_COL+c));
+		label=new QLabel(this);
+		label->setAlignment(Qt::AlignCenter);
+		allContentsGrid->addWidget(label, GPR_LABELS_ROW, FIRST_ENTRY_COL+c);
+	}
+
+	{
+		static const auto formatNames=util::make_array(tr("Hexadecimal"),
+												   tr("Signed"),
+												   tr("Unsigned"),
+												   tr("Character"));
+		// Format labels
+		for(std::size_t f=0;f<formatNames.size();++f)
+		{
+			auto& label=rowLabel(static_cast<Row>(FIRST_ENTRY_ROW+f));
+			label=new QLabel(formatNames[f],this);
+			allContentsGrid->addWidget(label, FIRST_ENTRY_ROW+f, FORMAT_LABELS_COL);
+		}
+	}
+	// All entries but char
+	{
+		static const auto offsetsInInteger=util::make_array<std::size_t>(0u,0u,0u,1u,0u);
+		static const auto integerSizes=util::make_array<std::size_t>(8u,4u,2u,1u,1u);
+		static_assert(std::tuple_size<decltype(integerSizes)>::value==DialogEditGPR::ENTRY_COLS,"integerSizes length doesn't equal ENTRY_COLS");
+		static_assert(std::tuple_size<decltype(offsetsInInteger)>::value==DialogEditGPR::ENTRY_COLS,"offsetsInInteger length doesn't equal ENTRY_COLS");
+		static const auto formats=util::make_array(GPREdit::Format::Hex,
+												   GPREdit::Format::Signed,
+												   GPREdit::Format::Unsigned);
+		for(std::size_t f=0;f<formats.size();++f)
+		{
+			for(std::size_t c=0;c<ENTRY_COLS;++c)
+			{
+				auto& entry=this->entry(static_cast<Row>(FIRST_ENTRY_ROW+f),static_cast<Column>(FIRST_ENTRY_COL+c));
+				entry=new GPREdit(offsetsInInteger[c], integerSizes[c], formats[f], this);
+				connect(entry,SIGNAL(textEdited(const QString&)),this,SLOT(onTextEdited(const QString&)));
+				allContentsGrid->addWidget(entry, FIRST_ENTRY_ROW+f, FIRST_ENTRY_COL+c);
+			}
+		}
+	}
+	// High byte char
+	{
+		auto& charHigh=entry(CHAR_ROW,GPR8H_COL);
+		charHigh=new GPREdit(1,1,GPREdit::Format::Character,this);
+		connect(charHigh,SIGNAL(textEdited(const QString&)),this,SLOT(onTextEdited(const QString&)));
+		allContentsGrid->addWidget(charHigh,CHAR_ROW,GPR8H_COL);
+	}
+	// Low byte char
+	{
+		auto& charLow=entry(CHAR_ROW,GPR8L_COL);
+		charLow=new GPREdit(0,1,GPREdit::Format::Character,this);
+		connect(charLow,SIGNAL(textEdited(const QString&)),this,SLOT(onTextEdited(const QString&)));
+		allContentsGrid->addWidget(charLow,CHAR_ROW,GPR8L_COL);
+	}
+	resetLayout();
+
+	const auto okCancel = new QDialogButtonBox(this);
+	okCancel->setStandardButtons(QDialogButtonBox::Cancel|QDialogButtonBox::Ok);
+	connect(okCancel, SIGNAL(accepted()), this, SLOT(accept()));
+	connect(okCancel, SIGNAL(rejected()), this, SLOT(reject()));
+
+	const auto dialogLayout = new QVBoxLayout(this);
+	dialogLayout->addLayout(allContentsGrid);
+	dialogLayout->addWidget(okCancel);
+
+	for(std::size_t entry=1;entry<entries.size();++entry)
+		setTabOrder(entries[entry-1], entries[entry]);
+}
+
+GPREdit*& DialogEditGPR::entry(DialogEditGPR::Row row, DialogEditGPR::Column col)
+{
+	if(row<ENTRY_ROWS)
+		return entries.at((row-FIRST_ENTRY_ROW)*ENTRY_COLS+(col-FIRST_ENTRY_COL));
+	if(col==GPR8H_COL)
+		return *(entries.end()-2);
+	if(col==GPR8L_COL)
+		return entries.back();
+	Q_ASSERT("Invalid row&col specified" && 0);
+	return entries.front(); // silence the compiler
+}
+
+void DialogEditGPR::updateAllEntriesExcept(GPREdit* notUpdated)
+{
+	for(auto entry : entries)
+		if(entry!=notUpdated && !entry->isHidden())
+			entry->setGPRValue(value_);
+}
+
+QLabel*& DialogEditGPR::columnLabel(DialogEditGPR::Column col)
+{
+	return labels.at(col-FIRST_ENTRY_COL);
+}
+
+QLabel*& DialogEditGPR::rowLabel(DialogEditGPR::Row row)
+{
+	return labels.at(ENTRY_COLS+row-FIRST_ENTRY_ROW);
+}
+
+void DialogEditGPR::hideColumn(DialogEditGPR::Column col)
+{
+	Row fMax = col==GPR8L_COL||col==GPR8H_COL ? ENTRY_ROWS : FULL_LENGTH_ROWS;
+	for(std::size_t f=0;f<fMax;++f)
+		entry(static_cast<Row>(FIRST_ENTRY_ROW+f),col)->hide();
+	columnLabel(col)->hide();
+}
+
+void DialogEditGPR::hideRow(Row row)
+{
+	rowLabel(row)->hide();
+	if(row==CHAR_ROW)
+	{
+		entry(row,GPR8L_COL)->hide();
+		entry(row,GPR8H_COL)->hide();
+	}
+	else
+	{
+		for(std::size_t c=0;c<FULL_LENGTH_ROWS;++c)
+			entry(row,static_cast<Column>(FIRST_ENTRY_COL+c))->hide();
+	}
+}
+
+void DialogEditGPR::resetLayout()
+{
+	for(auto entry : entries)
+		entry->show();
+	for(auto label : labels)
+		label->show();
+	static const auto colLabelStrings=util::make_array("R?X","E?X","?X","?H","?L");
+	static_assert(std::tuple_size<decltype(colLabelStrings)>::value==ENTRY_COLS,"Number of labels not equal to number of entry columns");
+	for(std::size_t c=0;c<ENTRY_COLS;++c)
+		columnLabel(static_cast<Column>(GPR64_COL+c))->setText(colLabelStrings[c]);
+}
+
+void DialogEditGPR::setupEntriesAndLabels()
+{
+	resetLayout();
+	switch(bitSize_)
+	{
+	case 8:
+		hideColumn(GPR8H_COL);
+		hideColumn(GPR16_COL);
+	case 16:
+		hideColumn(GPR32_COL);
+	case 32:
+		hideColumn(GPR64_COL);
+	case 64:
+		break;
+	default:
+		Q_ASSERT("Unsupported bitSize" && 0);
+	}
+
+	const QString regName=reg.name().toUpper();
+	if(bitSize_==64)
+		columnLabel(GPR64_COL)->setText(regName);
+	else if(bitSize_==32)
+		columnLabel(GPR32_COL)->setText(regName);
+	else if(bitSize_==16)
+		columnLabel(GPR16_COL)->setText(regName);
+	else
+		columnLabel(GPR8L_COL)->setText(regName);
+
+	static const auto x86GPRsWithHighBytesAddressable=util::make_array<QString>("EAX","ECX","EDX","EBX","RAX","RCX","RDX","RBX");
+	static const auto x86GPRsWithHighBytesNotAddressable=util::make_array<QString>("ESP","EBP","ESI","EDI","RSP","RBP","RSI","RDI");
+	static const auto upperGPRs64=util::make_array<QString>("R8","R9","R10","R11","R12","R13","R14","R15");
+	static const auto segmentRegs=util::make_array<QString>("ES","CS","SS","DS","FS","GS");
+	static const auto rSP=util::make_array<QString>("ESP","RSP");
+	static const auto rIP=util::make_array<QString>("EIP","RIP");
+	static const auto rFLAGS=util::make_array<QString>("EFLAGS","RFLAGS");
+
+	bool x86GPR=false, upperGPR64=false, stackPtr=false, segmentReg=false, instPtr=false, flags=false;
+	using util::contains;
+	if(contains(rSP,regName))
+		stackPtr=true;
+	else if(contains(x86GPRsWithHighBytesNotAddressable,regName))
+	{
+		x86GPR=true;
+		hideColumn(GPR8H_COL);
+		if(bitSize_==32)
+		{
+			hideColumn(GPR8L_COL); // In 32 bit mode low bytes also can't be addressed
+			hideRow(CHAR_ROW);
+		}
+	}
+	else if(contains(x86GPRsWithHighBytesAddressable,regName))
+		x86GPR=true;
+	else if(contains(upperGPRs64,regName))
+		upperGPR64=true;
+	else if(contains(segmentRegs,regName))
+		segmentReg=true;
+	else if(contains(rIP,regName))
+		instPtr=true;
+	else if(contains(rFLAGS,regName))
+		flags=true;
+
+	if(x86GPR)
+	{
+		if(bitSize_==64)
+			columnLabel(GPR32_COL)->setText("E"+regName.mid(1));
+		columnLabel(GPR16_COL)->setText(regName.mid(1));
+		columnLabel(GPR8H_COL)->setText(regName.mid(1,1)+"H");
+		if(bitSize_==64 && !contains(x86GPRsWithHighBytesAddressable,regName))
+			columnLabel(GPR8L_COL)->setText(regName.mid(1)+"L");
+		else
+			columnLabel(GPR8L_COL)->setText(regName.mid(1,1)+"L");
+	}
+	else if(upperGPR64)
+	{
+		columnLabel(GPR32_COL)->setText(regName+"D");
+		columnLabel(GPR16_COL)->setText(regName+"W");
+		columnLabel(GPR8L_COL)->setText(regName+"B");
+		hideColumn(GPR8H_COL);
+	}
+	else if(segmentReg || instPtr || flags || stackPtr)
+	{
+		// These have hex only format
+		hideColumn(GPR8H_COL);
+		if(bitSize_!=8)
+			hideColumn(GPR8L_COL);
+		if(bitSize_!=16)
+			hideColumn(GPR16_COL);
+		if(bitSize_!=32)
+			hideColumn(GPR32_COL);
+		hideRow(SIGNED_ROW);
+		hideRow(UNSIGNED_ROW);
+		hideRow(CHAR_ROW);
+	}
+	else
+		qWarning() << "Warning: " << regName << " not found in any list\n";
+}
+
+void DialogEditGPR::set_value(const Register& newReg)
+{
+	reg=newReg;
+	value_=reg.valueAsInteger();
+	bitSize_=reg.bitSize();
+	setupEntriesAndLabels();
+	setWindowTitle(tr("Modify %1").arg(reg.name().toUpper()));
+	updateAllEntriesExcept(nullptr);
+}
+
+Register DialogEditGPR::value() const
+{
+	Register ret(reg);
+	ret.setScalarValue(value_);
+	return ret;
+}
+
+void DialogEditGPR::onTextEdited(const QString&)
+{
+	GPREdit* edit=dynamic_cast<GPREdit*>(sender());
+	edit->updateGPRValue(value_);
+	updateAllEntriesExcept(edit);
+}
+

--- a/src/arch/x86-generic/DialogEditGPR.cpp
+++ b/src/arch/x86-generic/DialogEditGPR.cpp
@@ -249,6 +249,16 @@ void DialogEditGPR::setupEntriesAndLabels()
 		qWarning() << "Warning: " << regName << " not found in any list\n";
 }
 
+void DialogEditGPR::setupFocus()
+{
+	for(auto entry : entries)
+		if(!entry->isHidden())
+		{
+			entry->setFocus(Qt::OtherFocusReason);
+			break;
+		}
+}
+
 void DialogEditGPR::set_value(const Register& newReg)
 {
 	reg=newReg;
@@ -257,6 +267,7 @@ void DialogEditGPR::set_value(const Register& newReg)
 	setupEntriesAndLabels();
 	setWindowTitle(tr("Modify %1").arg(reg.name().toUpper()));
 	updateAllEntriesExcept(nullptr);
+	setupFocus();
 }
 
 Register DialogEditGPR::value() const

--- a/src/arch/x86-generic/DialogEditGPR.h
+++ b/src/arch/x86-generic/DialogEditGPR.h
@@ -65,6 +65,7 @@ class DialogEditGPR : public QDialog
 	QLabel*& columnLabel(Column col);
 	QLabel*& rowLabel(Row row);
 	GPREdit*& entry(Row row, Column col);
+	void setupFocus();
 public:
 	DialogEditGPR(QWidget* parent=nullptr);
 	Register value() const;

--- a/src/arch/x86-generic/DialogEditGPR.h
+++ b/src/arch/x86-generic/DialogEditGPR.h
@@ -1,0 +1,76 @@
+#ifndef DIALOG_EDIT_GPR_H_20151011
+#define DIALOG_EDIT_GPR_H_20151011
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QRadioButton>
+#include <QSpacerItem>
+#include <QVBoxLayout>
+#include <array>
+#include <string>
+#include <cstddef>
+#include <cstdint>
+#include "Register.h"
+
+class GPREdit;
+
+class DialogEditGPR : public QDialog
+{
+	Q_OBJECT
+
+	enum Column
+	{
+		FORMAT_LABELS_COL,
+		FIRST_ENTRY_COL,
+		GPR64_COL=FIRST_ENTRY_COL,
+		GPR32_COL,
+		GPR16_COL,
+		GPR8H_COL,
+		GPR8L_COL,
+
+		TOTAL_COLS,
+		ENTRY_COLS=TOTAL_COLS-1,
+		CHAR_COLS=2
+	};
+	enum Row
+	{
+		GPR_LABELS_ROW,
+		FIRST_ENTRY_ROW,
+		HEX_ROW=FIRST_ENTRY_ROW,
+		SIGNED_ROW,
+		UNSIGNED_ROW,
+		LAST_FULL_LENGTH_ROW=UNSIGNED_ROW,
+		CHAR_ROW,
+
+		ROW_AFTER_ENTRIES,
+
+		FULL_LENGTH_ROWS=LAST_FULL_LENGTH_ROW-FIRST_ENTRY_ROW+1,
+		ENTRY_ROWS=ROW_AFTER_ENTRIES-FIRST_ENTRY_ROW
+	};
+
+	std::array<QLabel*,ENTRY_COLS+ENTRY_ROWS> labels={{0}};
+    std::array<GPREdit*,FULL_LENGTH_ROWS*ENTRY_COLS+CHAR_COLS> entries={{0}};
+    std::uint64_t value_;
+	std::size_t bitSize_=0;
+	Register reg;
+
+	void updateAllEntriesExcept(GPREdit* notUpdated);
+	void hideColumn(Column col);
+	void hideRow(Row row);
+	void setupEntriesAndLabels();
+	void resetLayout();
+	QLabel*& columnLabel(Column col);
+	QLabel*& rowLabel(Row row);
+	GPREdit*& entry(Row row, Column col);
+public:
+	DialogEditGPR(QWidget* parent=nullptr);
+	Register value() const;
+	void set_value(const Register& reg);
+private Q_SLOTS:
+    void onTextEdited(const QString&);
+};
+
+#endif

--- a/src/arch/x86-generic/GPREdit.cpp
+++ b/src/arch/x86-generic/GPREdit.cpp
@@ -1,0 +1,121 @@
+#include "GPREdit.h"
+#include <cstring>
+#include <QApplication>
+#include <QRegExpValidator>
+#include "QLongValidator.h"
+#include "QULongValidator.h"
+
+namespace
+{
+const QRegExpValidator byteHexValidator(QRegExp("[0-9a-fA-F]{0,2}"));
+const QRegExpValidator wordHexValidator(QRegExp("[0-9a-fA-F]{0,4}"));
+const QRegExpValidator dwordHexValidator(QRegExp("[0-9a-fA-F]{0,8}"));
+const QRegExpValidator qwordHexValidator(QRegExp("[0-9a-fA-F]{0,16}"));
+const QLongValidator byteSignedValidator(INT8_MIN,INT8_MAX);
+const QLongValidator wordSignedValidator(INT16_MIN,INT16_MAX);
+const QLongValidator dwordSignedValidator(INT32_MIN,INT32_MAX);
+const QLongValidator qwordSignedValidator(INT64_MIN,INT64_MAX);
+const QULongValidator byteUnsignedValidator(0,UINT8_MAX);
+const QULongValidator wordUnsignedValidator(0,UINT16_MAX);
+const QULongValidator dwordUnsignedValidator(0,UINT32_MAX);
+const QULongValidator qwordUnsignedValidator(0,UINT64_MAX);
+
+const std::map<int,const QRegExpValidator*> hexValidators={{1,&byteHexValidator},{2,&wordHexValidator},{4,&dwordHexValidator},{8,&qwordHexValidator}};
+const std::map<int,const QLongValidator*> signedValidators={{1,&byteSignedValidator},{2,&wordSignedValidator},{4,&dwordSignedValidator},{8,&qwordSignedValidator}};
+const std::map<int,const QULongValidator*> unsignedValidators={{1,&byteUnsignedValidator},{2,&wordUnsignedValidator},{4,&dwordUnsignedValidator},{8,&qwordUnsignedValidator}};
+}
+
+void GPREdit::setupFormat(Format newFormat)
+{
+	format=newFormat;
+	switch(format)
+	{
+	case Format::Hex:
+		setValidator(hexValidators.at(integerSize));
+		naturalWidthInChars=2*integerSize;
+		break;
+	case Format::Signed:
+		setValidator(signedValidators.at(integerSize));
+		naturalWidthInChars=1+std::lround(integerSize*std::log10(256.));
+		break;
+	case Format::Unsigned:
+		setValidator(unsignedValidators.at(integerSize));
+		naturalWidthInChars=std::lround(integerSize*std::log10(256.));
+		break;
+	case Format::Character:
+		setMaxLength(1);
+		break;
+	default:
+		Q_ASSERT("Unexpected format value" && 0);
+	}
+}
+
+GPREdit::GPREdit(std::size_t offsetInInteger, std::size_t integerSize, Format newFormat, QWidget* parent)
+	: QLineEdit(parent),
+	  naturalWidthInChars(2*integerSize),
+	  integerSize(integerSize),
+	  offsetInInteger(offsetInInteger)
+{
+	setupFormat(newFormat);
+}
+
+void GPREdit::setGPRValue(std::uint64_t gprValue)
+{
+	std::uint64_t value(0);
+	signBit = format==Format::Signed ? 1ull<<(8*integerSize-1) : 0;
+	if((gprValue>>8*offsetInInteger)&signBit)
+		value=-1;
+	std::memcpy(&value,reinterpret_cast<char*>(&gprValue)+offsetInInteger,integerSize);
+	switch(format)
+	{
+	case Format::Hex:
+		setText(QString("%1").arg(value,naturalWidthInChars,16,QChar('0')));
+		break;
+	case Format::Signed:
+		setText(QString("%1").arg(static_cast<std::int64_t>(value)));
+		break;
+	case Format::Unsigned:
+		setText(QString("%1").arg(value));
+		break;
+	case Format::Character:
+		setText(QChar(static_cast<char>(value)));
+		break;
+	}
+}
+void GPREdit::updateGPRValue(std::uint64_t& gpr) const
+{
+	bool ok;
+	std::uint64_t value;
+	switch(format)
+	{
+	case Format::Hex:
+		value=text().toLongLong(&ok,16);
+		break;
+	case Format::Signed:
+		value=text().toLongLong(&ok);
+		break;
+	case Format::Unsigned:
+		value=text().toULongLong(&ok);
+		break;
+	case Format::Character:
+		value=text().toStdString()[0];
+		break;
+	default:
+	Q_ASSERT("Unexpected format value" && 0);
+	}
+	std::memcpy(reinterpret_cast<char*>(&gpr)+offsetInInteger,&value,integerSize);
+}
+
+QSize GPREdit::sizeHint() const
+{
+	const auto baseHint=QLineEdit::sizeHint();
+	// taking long enough reference char to make enough room even in presence of inner shadows like in Oxygen style
+	const auto charWidth = QFontMetrics(font()).width(QLatin1Char('w'));
+	const auto textMargins=this->textMargins();
+	const auto contentsMargins=this->contentsMargins();
+	int customWidth = charWidth * naturalWidthInChars +
+		textMargins.left() + contentsMargins.left() + textMargins.right() + contentsMargins.right() +
+		1*charWidth; // additional char to make edit field not too tight
+	return QSize(customWidth,baseHint.height()).expandedTo(QApplication::globalStrut());
+}
+

--- a/src/arch/x86-generic/GPREdit.h
+++ b/src/arch/x86-generic/GPREdit.h
@@ -1,0 +1,28 @@
+#include <QLineEdit>
+
+class GPREdit : public QLineEdit
+{
+public:
+	enum class Format
+	{
+		Hex,
+		Signed,
+		Unsigned,
+		Character
+	};
+public:
+	GPREdit(std::size_t offsetInInteger, std::size_t integerSize, Format format, QWidget* parent=nullptr);
+	void setGPRValue(std::uint64_t gprValue);
+	void updateGPRValue(std::uint64_t& gpr) const;
+
+	QSize minimumSizeHint() const override
+	{ return sizeHint(); }
+	QSize sizeHint() const override;
+private:
+	void setupFormat(Format newFormat);
+	int naturalWidthInChars;
+	std::size_t integerSize;
+	std::size_t offsetInInteger;
+	Format format;
+	std::uint64_t signBit;
+};

--- a/src/src.pro
+++ b/src/src.pro
@@ -33,6 +33,7 @@ HEADERS += \
 	DebuggerInternal.h \
 	DialogArguments.h \
 	DialogAttach.h \
+	DialogEditGPR.h \
 	DialogInputBinaryString.h \
 	DialogInputValue.h \
 	DialogMemoryRegions.h \
@@ -42,6 +43,7 @@ HEADERS += \
 	DialogThreads.h \
 	Expression.h \
 	FixedFontSelector.h \
+	GPREdit.h \
 	HexStringValidator.h \
 	IAnalyzer.h \
 	IBinary.h \
@@ -112,6 +114,7 @@ SOURCES += \
 	Debugger.cpp \
 	DialogArguments.cpp \
 	DialogAttach.cpp \
+	DialogEditGPR.cpp \
 	DialogInputBinaryString.cpp \
 	DialogInputValue.cpp \
 	DialogMemoryRegions.cpp \
@@ -121,6 +124,7 @@ SOURCES += \
 	DialogThreads.cpp \
 	FixedFontSelector.cpp \
 	Function.cpp \
+	GPREdit.cpp \
 	HexStringValidator.cpp \
 	Instruction.cpp \
 	LineEdit.cpp \


### PR DESCRIPTION
This set of commits implements a dialog to edit registers, mainly GPRs and segment registers, which basically clones the functionality of OllyDbg's counterpart.
Editing SIMD registers is currently unsupported (including MMX), as isn't editing of FPU registers.