### PR TITLE
SIMD registers configurable presentation in different formats

### DIFF
--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -50,15 +50,33 @@ public:
 	void update_register_view(const QString &default_region_name, const State &state);
 
 private:
+	enum class SIMDDisplayMode {
+		Bytes,
+		Words,
+		Dwords,
+		Qwords,
+		Floats32,
+		Floats64
+	};
+private:
+	template<typename T>
+	QString formatSIMDRegister(const T& value, SIMDDisplayMode simdMode, IntDisplayMode intMode);
 	void update_register(QTreeWidgetItem *item, const Register &reg) const;
 	void update_fpu_view(int& itemNumber, const State &state, const QPalette& palette) const;
 
 private:
 	QTreeWidgetItem * split_flags_;
 	State             last_state_;
+
 	bool              has_mmx_;
+	SIMDDisplayMode   mmxDisplayMode_=SIMDDisplayMode::Words;
+	IntDisplayMode    mmxIntMode_=IntDisplayMode::Hex;
+
 	bool              has_xmm_;
 	bool              has_ymm_;
+	SIMDDisplayMode   xymmDisplayMode_=SIMDDisplayMode::Dwords;
+	IntDisplayMode    xymmIntMode_=IntDisplayMode::Hex;
+
 	std::vector<QTreeWidgetItem*> register_view_items_;
 };
 

--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QObject>
 #include <vector>
 
+class QMenu;
 class QByteArray;
 class QString;
 class QTreeWidgetItem;
@@ -48,6 +49,7 @@ public:
 	void reset();
 	void setup_register_view(RegisterListWidget *category_list);
 	void update_register_view(const QString &default_region_name, const State &state);
+	std::unique_ptr<QMenu> register_item_context_menu(const Register& reg);
 
 private:
 	enum class SIMDDisplayMode {
@@ -61,6 +63,8 @@ private:
 private:
 	template<typename T>
 	QString formatSIMDRegister(const T& value, SIMDDisplayMode simdMode, IntDisplayMode intMode);
+	void setupMMXRegisterMenu(QMenu& menu);
+	void setupSSEAVXRegisterMenu(QMenu& menu, const QString& extType);
 	void update_register(QTreeWidgetItem *item, const Register &reg) const;
 	void update_fpu_view(int& itemNumber, const State &state, const QPalette& palette) const;
 
@@ -78,6 +82,11 @@ private:
 	IntDisplayMode    xymmIntMode_=IntDisplayMode::Hex;
 
 	std::vector<QTreeWidgetItem*> register_view_items_;
+private Q_SLOTS:
+	void setMMXDisplayMode(int);
+	void setMMXIntMode(int);
+	void setSSEAVXDisplayMode(int);
+	void setSSEAVXIntMode(int);
 };
 
 #endif

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1034,6 +1034,15 @@ void Debugger::on_registerList_customContextMenuRequested(const QPoint &pos) {
 
 				menu.exec(ui.registerList->mapToGlobal(pos));
 			}
+			else {
+				// Generally it's better to ask ArchProcessor to make its arch-specific item-specific menu
+				const auto menu = edb::v1::arch_processor().register_item_context_menu(reg);
+				if(menu) {
+					menu->exec(ui.registerList->mapToGlobal(pos));
+				}
+				update_gui();
+				refresh_gui();
+			}
 		}
 
 		// Special case for the flag values. Open a context menu with the flag names for toggle.

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -33,9 +33,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QFile>
 #include <QVector>
 #include <QXmlQuery>
+#include <QMenu>
+#include <QSignalMapper>
 
 #include <climits>
 #include <cmath>
+#include <memory>
 
 #include "DialogEditGPR.h"
 #include "DialogEditFPU.h"
@@ -1335,4 +1338,135 @@ bool ArchProcessor::is_filling(const edb::Instruction &inst) const {
 	}
 
 	return ret;
+}
+
+void ArchProcessor::setupMMXRegisterMenu(QMenu& menu) {
+	{
+		const auto displayModeMapper = new QSignalMapper(&menu);
+		if(mmxDisplayMode_!=SIMDDisplayMode::Bytes) {
+			const auto action = menu.addAction(tr("View MMX as &bytes"),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Bytes));
+		}
+		if(mmxDisplayMode_!=SIMDDisplayMode::Words) {
+			const auto action = menu.addAction(tr("View MMX as &words"),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Words));
+		}
+		if(mmxDisplayMode_!=SIMDDisplayMode::Dwords) {
+			const auto action = menu.addAction(tr("View MMX as &doublewords"),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Dwords));
+		}
+		if(mmxDisplayMode_!=SIMDDisplayMode::Qwords) {
+			const auto action = menu.addAction(tr("View MMX as &quadwords"),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Qwords));
+		}
+		connect(displayModeMapper,SIGNAL(mapped(int)),this,SLOT(setMMXDisplayMode(int)));
+	}
+
+	menu.addSeparator();
+
+	{
+		const auto intModeMapper = new QSignalMapper(&menu);
+		if(mmxIntMode_!=IntDisplayMode::Hex) {
+			const auto action = menu.addAction(tr("View integers as &hexadecimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Hex));
+		}
+		if(mmxIntMode_!=IntDisplayMode::Signed) {
+			const auto action = menu.addAction(tr("View integers as &signed decimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Signed));
+		}
+		if(mmxIntMode_!=IntDisplayMode::Unsigned) {
+			const auto action = menu.addAction(tr("View integers as &unsigned decimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Unsigned));
+		}
+		connect(intModeMapper,SIGNAL(mapped(int)),this,SLOT(setMMXIntMode(int)));
+	}
+}
+
+void ArchProcessor::setMMXIntMode(int mode) {
+	mmxIntMode_=static_cast<IntDisplayMode>(mode);
+}
+
+void ArchProcessor::setMMXDisplayMode(int mode) {
+	mmxDisplayMode_=static_cast<SIMDDisplayMode>(mode);
+}
+
+void ArchProcessor::setupSSEAVXRegisterMenu(QMenu& menu, const QString& extType) {
+	{
+		const auto displayModeMapper = new QSignalMapper(&menu);
+		if(xymmDisplayMode_!=SIMDDisplayMode::Bytes) {
+			const auto action = menu.addAction(tr("View %1 as &bytes").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Bytes));
+		}
+		if(xymmDisplayMode_!=SIMDDisplayMode::Words) {
+			const auto action = menu.addAction(tr("View %1 as &words").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Words));
+		}
+		if(xymmDisplayMode_!=SIMDDisplayMode::Dwords) {
+			const auto action = menu.addAction(tr("View %1 as &doublewords").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Dwords));
+		}
+		if(xymmDisplayMode_!=SIMDDisplayMode::Qwords) {
+			const auto action = menu.addAction(tr("View %1 as &quadwords").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Qwords));
+		}
+
+		menu.addSeparator();
+
+		if(xymmDisplayMode_!=SIMDDisplayMode::Floats32) {
+			const auto action = menu.addAction(tr("View %1 as &32-bit floats").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Floats32));
+		}
+		if(xymmDisplayMode_!=SIMDDisplayMode::Floats64) {
+			const auto action = menu.addAction(tr("View %1 as &64-bit floats").arg(extType),displayModeMapper,SLOT(map()));
+			displayModeMapper->setMapping(action,static_cast<int>(SIMDDisplayMode::Floats64));
+		}
+		connect(displayModeMapper,SIGNAL(mapped(int)),this,SLOT(setSSEAVXDisplayMode(int)));
+	}
+
+	if(xymmDisplayMode_!=SIMDDisplayMode::Floats32 && xymmDisplayMode_!=SIMDDisplayMode::Floats64) {
+
+		menu.addSeparator();
+
+		const auto intModeMapper = new QSignalMapper(&menu);
+		if(xymmIntMode_!=IntDisplayMode::Hex) {
+			const auto action = menu.addAction(tr("View integers as &hexadecimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Hex));
+		}
+		if(xymmIntMode_!=IntDisplayMode::Signed) {
+			const auto action = menu.addAction(tr("View integers as &signed decimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Signed));
+		}
+		if(xymmIntMode_!=IntDisplayMode::Unsigned) {
+			const auto action = menu.addAction(tr("View integers as &unsigned decimal"),intModeMapper,SLOT(map()));
+			intModeMapper->setMapping(action,static_cast<int>(IntDisplayMode::Unsigned));
+		}
+		connect(intModeMapper,SIGNAL(mapped(int)),this,SLOT(setSSEAVXIntMode(int)));
+	}
+}
+
+void ArchProcessor::setSSEAVXIntMode(int mode) {
+	xymmIntMode_=static_cast<IntDisplayMode>(mode);
+}
+
+void ArchProcessor::setSSEAVXDisplayMode(int mode) {
+	xymmDisplayMode_=static_cast<SIMDDisplayMode>(mode);
+}
+
+std::unique_ptr<QMenu> ArchProcessor::register_item_context_menu(const Register& reg) {
+	std::unique_ptr<QMenu> menu(new QMenu());
+
+	if(reg.type()==Register::TYPE_SIMD && reg.name().startsWith("mm")) {
+		setupMMXRegisterMenu(*menu);
+		return menu;
+	}
+	if(reg.type()==Register::TYPE_SIMD && reg.name().startsWith("xmm")) {
+		setupSSEAVXRegisterMenu(*menu,"SSE");
+		return menu;
+	}
+	if(reg.type()==Register::TYPE_SIMD && reg.name().startsWith("ymm")) {
+		setupSSEAVXRegisterMenu(*menu,"AVX");
+		return menu;
+	}
+
+	return nullptr;
 }

--- a/src/arch/x86-generic/DialogEditSIMDRegister.cpp
+++ b/src/arch/x86-generic/DialogEditSIMDRegister.cpp
@@ -75,7 +75,7 @@ DialogEditSIMDRegister::DialogEditSIMDRegister(QWidget* parent)
 	  qwordUnsignedValidator(new QULongValidator(0,UINT64_MAX,this)),
 	  float32Validator(new FloatXValidator<float>(this)),
 	  float64Validator(new FloatXValidator<double>(this)),
-	  mode(Mode::Hex)
+	  mode(IntDisplayMode::Hex)
 {
 	setWindowTitle(tr("Edit SIMD Register"));
 	setModal(true);
@@ -316,13 +316,13 @@ std::uint64_t DialogEditSIMDRegister::readInteger(const NumberEdit* const edit) 
 	bool ok;
 	switch(mode)
 	{
-	case Mode::Hex:
+	case IntDisplayMode::Hex:
 		return edit->text().toULongLong(&ok,16);
 		break;
-	case Mode::Signed:
+	case IntDisplayMode::Signed:
 		return edit->text().toLongLong(&ok);
 		break;
-	case Mode::Unsigned:
+	case IntDisplayMode::Unsigned:
 		return edit->text().toULongLong(&ok);
 		break;
 	}
@@ -334,15 +334,15 @@ void DialogEditSIMDRegister::formatInteger(NumberEdit* const edit, Integer integ
 {
 	switch(mode)
 	{
-	case Mode::Hex:
+	case IntDisplayMode::Hex:
 		edit->setText(QString("%1").arg(integer,2*sizeof integer,16,QChar('0')));
 		break;
-	case Mode::Signed:
+	case IntDisplayMode::Signed:
 		typedef typename std::remove_reference<Integer>::type Int;
 		typedef typename std::make_signed<Int>::type Signed;
 		edit->setText(QString("%1").arg(static_cast<Signed>(integer)));
 		break;
-	case Mode::Unsigned:
+	case IntDisplayMode::Unsigned:
 		edit->setText(QString("%1").arg(integer));
 		break;
 	}
@@ -398,9 +398,9 @@ void DialogEditSIMDRegister::onFloat64Edited()
 
 void DialogEditSIMDRegister::onHexToggled(bool checked)
 {
-	if((checked && mode!=Mode::Hex) || !bytes.front()->validator())
+	if((checked && mode!=IntDisplayMode::Hex) || !bytes.front()->validator())
 	{
-		mode=Mode::Hex;
+		mode=IntDisplayMode::Hex;
 		for(const auto& byte : bytes)
 			byte->setValidator(byteHexValidator);
 		for(const auto& word : words)
@@ -415,9 +415,9 @@ void DialogEditSIMDRegister::onHexToggled(bool checked)
 
 void DialogEditSIMDRegister::onSignedToggled(bool checked)
 {
-	if((checked && mode!=Mode::Signed) || !bytes.front()->validator())
+	if((checked && mode!=IntDisplayMode::Signed) || !bytes.front()->validator())
 	{
-		mode=Mode::Signed;
+		mode=IntDisplayMode::Signed;
 		for(const auto& byte : bytes)
 			byte->setValidator(byteSignedValidator);
 		for(const auto& word : words)
@@ -432,9 +432,9 @@ void DialogEditSIMDRegister::onSignedToggled(bool checked)
 
 void DialogEditSIMDRegister::onUnsignedToggled(bool checked)
 {
-	if((checked && mode!=Mode::Unsigned) || !bytes.front()->validator())
+	if((checked && mode!=IntDisplayMode::Unsigned) || !bytes.front()->validator())
 	{
-		mode=Mode::Unsigned;
+		mode=IntDisplayMode::Unsigned;
 		for(const auto& byte : bytes)
 			byte->setValidator(byteUnsignedValidator);
 		for(const auto& word : words)

--- a/src/arch/x86-generic/DialogEditSIMDRegister.h
+++ b/src/arch/x86-generic/DialogEditSIMDRegister.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <Register.h>
+#include "Util.h"
 
 class QRegExpValidator;
 class QULongValidator;
@@ -77,12 +78,7 @@ class DialogEditSIMDRegister : public QDialog
 	QValidator* float32Validator;
 	QValidator* float64Validator;
 
-	enum class Mode
-	{
-		Hex,
-		Signed,
-		Unsigned
-	} mode;
+	IntDisplayMode mode;
 	std::array<std::uint8_t,numBytes> value_;
 	Register reg;
 


### PR DESCRIPTION
This set of commits makes it possible to choose format of SIMD registers, i.e. integers of particular sizes or floats/doubles. User chooses the format using a context menu similar to that of OllyDbg.