### PR TITLE
Add support for C++ symbol demangling

### DIFF
--- a/plugins/BinaryInfo/BinaryInfo.cpp
+++ b/plugins/BinaryInfo/BinaryInfo.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "PE32.h"
 #include "edb.h"
 #include "symbols.h"
+#include "OptionsPage.h"
 
 #include <QDebug>
 #include <QMenu>
@@ -77,6 +78,10 @@ void BinaryInfo::private_init() {
 	edb::v1::register_binary_info(create_binary_info_elf64);
 	edb::v1::register_binary_info(create_binary_info_pe32);
 	edb::v1::symbol_manager().set_symbol_generator(this);
+}
+
+QWidget* BinaryInfo::options_page() {
+	return new OptionsPage;
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/BinaryInfo/BinaryInfo.h
+++ b/plugins/BinaryInfo/BinaryInfo.h
@@ -41,6 +41,7 @@ public:
 
 private:
 	virtual void private_init();
+	virtual QWidget* options_page() override;
 
 public:
 	virtual QMenu *menu(QWidget *parent = 0);

--- a/plugins/BinaryInfo/BinaryInfo.pro
+++ b/plugins/BinaryInfo/BinaryInfo.pro
@@ -2,7 +2,7 @@
 include(../plugins.pri)
 
 # Input
-HEADERS += symbols.h BinaryInfo.h ELF32.h ELF64.h PE32.h elf_binary.h pe_binary.h DialogHeader.h
+HEADERS += symbols.h demangle.h BinaryInfo.h ELF32.h ELF64.h PE32.h elf_binary.h pe_binary.h DialogHeader.h
 FORMS += DialogHeader.ui
 SOURCES += symbols.cpp BinaryInfo.cpp ELF32.cpp ELF64.cpp PE32.cpp DialogHeader.cpp
 

--- a/plugins/BinaryInfo/BinaryInfo.pro
+++ b/plugins/BinaryInfo/BinaryInfo.pro
@@ -2,7 +2,7 @@
 include(../plugins.pri)
 
 # Input
-HEADERS += symbols.h demangle.h BinaryInfo.h ELF32.h ELF64.h PE32.h elf_binary.h pe_binary.h DialogHeader.h
-FORMS += DialogHeader.ui
-SOURCES += symbols.cpp BinaryInfo.cpp ELF32.cpp ELF64.cpp PE32.cpp DialogHeader.cpp
+HEADERS += symbols.h demangle.h BinaryInfo.h ELF32.h ELF64.h PE32.h elf_binary.h pe_binary.h DialogHeader.h OptionsPage.h
+FORMS += DialogHeader.ui OptionsPage.ui
+SOURCES += symbols.cpp BinaryInfo.cpp ELF32.cpp ELF64.cpp PE32.cpp DialogHeader.cpp OptionsPage.cpp
 

--- a/plugins/BinaryInfo/OptionsPage.cpp
+++ b/plugins/BinaryInfo/OptionsPage.cpp
@@ -1,0 +1,54 @@
+/*
+Copyright (C) 2015 Ruslan Kabatsayev <b7.10110111@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "OptionsPage.h"
+#include <QSettings>
+#include "demangle.h"
+
+#include "ui_OptionsPage.h"
+
+namespace BinaryInfo
+{
+
+OptionsPage::OptionsPage(QWidget* parent) : QWidget(parent), ui(new Ui::OptionsPage)
+{
+	ui->setupUi(this);
+}
+
+OptionsPage::~OptionsPage()
+{
+	delete ui;
+}
+
+void OptionsPage::showEvent(QShowEvent*)
+{
+	QSettings settings;
+	if(DEMANGLING_SUPPORTED)
+		ui->checkBox->setChecked(settings.value("BinaryInfo/demangling_enabled", true).toBool());
+	else
+	{
+		ui->checkBox->setEnabled(false);
+		ui->checkBox->setChecked(false);
+	}
+}
+
+void OptionsPage::on_checkBox_toggled(bool checked)
+{
+	QSettings().setValue("BinaryInfo/demangling_enabled", checked);
+}
+
+}

--- a/plugins/BinaryInfo/OptionsPage.h
+++ b/plugins/BinaryInfo/OptionsPage.h
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2015 Ruslan Kabatsayev <b7.10110111@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPTIONS_PAGE_20151113_H
+#define OPTIONS_PAGE_20151113_H
+
+#include <QWidget>
+#include <memory>
+
+namespace BinaryInfo
+{
+
+namespace Ui
+{ class OptionsPage; }
+
+class OptionsPage : public QWidget
+{
+	Q_OBJECT
+
+public:
+	OptionsPage(QWidget* parent = 0);
+	virtual ~OptionsPage();
+
+public:
+	virtual void showEvent(QShowEvent* event);
+
+public Q_SLOTS:
+	void on_checkBox_toggled(bool checked = false);
+
+private:
+	Ui::OptionsPage* const ui;
+};
+
+}
+
+#endif

--- a/plugins/BinaryInfo/OptionsPage.ui
+++ b/plugins/BinaryInfo/OptionsPage.ui
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BinaryInfo::OptionsPage</class>
+ <widget class="QWidget" name="OptionsPage">
+  <property name="windowTitle">
+   <string>BinaryInfo Plugin</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QCheckBox" name="checkBox">
+     <property name="text">
+      <string>Demangle auto-generated symbols</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>262</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/plugins/BinaryInfo/demangle.h
+++ b/plugins/BinaryInfo/demangle.h
@@ -1,0 +1,32 @@
+#ifndef EDB_DEMANGLE_H_20151113
+#define EDB_DEMANGLE_H_20151113
+
+#include <QString>
+#include <QStringList>
+
+#ifdef __GNUG__
+#include <memory>
+#include <cxxabi.h>
+
+#define DEMANGLING_SUPPORTED true
+
+inline QString demangle(const QString& mangled) {
+	int failed=0;
+	QStringList split=mangled.split("@"); // for cases like funcName@plt
+	std::unique_ptr<char,decltype(std::free)*> demangled(abi::__cxa_demangle(split.front().toStdString().c_str(),0,0,&failed), std::free);
+	if(failed) return mangled;
+	split.front()=QString(demangled.get());
+	return split.join("@");
+}
+
+#else
+
+#define DEMANGLING_SUPPORTED false
+
+inline QString demangle(const QString& mangled) {
+	return mangled;
+}
+
+#endif
+
+#endif

--- a/plugins/BinaryInfo/symbols.cpp
+++ b/plugins/BinaryInfo/symbols.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "symbols.h"
+#include "demangle.h"
 #include "edb.h"
 
 #include <QDateTime>
@@ -402,6 +403,7 @@ void process_symbols(const void *p, size_t size, std::ostream &os) {
 	qSort(symbols.begin(), symbols.end());
 	auto new_end = std::unique(symbols.begin(), symbols.end());
 	for(auto it = symbols.begin(); it != new_end; ++it) {
+		it->name=demangle(it->name);
 		os << qPrintable(it->to_string()) << '\n';
 	}
 }

--- a/plugins/BinaryInfo/symbols.cpp
+++ b/plugins/BinaryInfo/symbols.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QList>
 #include <QSet>
 #include <QString>
+#include <QSettings>
 #include <iostream>
 
 #include "elf/elf_types.h"
@@ -402,8 +403,10 @@ void process_symbols(const void *p, size_t size, std::ostream &os) {
 
 	qSort(symbols.begin(), symbols.end());
 	auto new_end = std::unique(symbols.begin(), symbols.end());
+	const auto demanglingEnabled = QSettings().value("BinaryInfo/demangling_enabled", true).toBool();
 	for(auto it = symbols.begin(); it != new_end; ++it) {
-		it->name=demangle(it->name);
+		if(demanglingEnabled)
+			it->name=demangle(it->name);
 		os << qPrintable(it->to_string()) << '\n';
 	}
 }

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -215,7 +215,7 @@ bool SymbolManager::process_symbol_file(const QString &f, edb::address_t base, c
 
 					sym->file           = f;
 					sym->name_no_prefix = QString::fromStdString(sym_name).trimmed();
-					sym->name           = QString("%1::%2").arg(prefix, sym->name_no_prefix);
+					sym->name           = QString("%1!%2").arg(prefix, sym->name_no_prefix);
 					sym->address        = sym_start;
 					sym->size           = sym_end;
 					sym->type           = sym_type;

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -200,11 +200,21 @@ bool SymbolManager::process_symbol_file(const QString &f, edb::address_t base, c
 				const QString prefix = info.fileName();
 				char sym_type;
 
-				while(file >> std::hex >> sym_start >> std::hex >> sym_end >> sym_type >> sym_name) {
+				while(true) {
+					file >> std::hex >> sym_start >> std::hex >> sym_end >> sym_type;
+					// For symbol name we can't use operator>>() as it may have spaces if demangled
+					// Thus, get the rest of the line as the symbol name
+					std::getline(file,sym_name);
+
+					if(!file) {
+						if(!file.eof()) qWarning() << "WARNING: File" << f << "seems corrupt";
+						break;
+					}
+
 					auto sym = std::make_shared<Symbol>();
 
 					sym->file           = f;
-					sym->name_no_prefix = QString::fromStdString(sym_name);
+					sym->name_no_prefix = QString::fromStdString(sym_name).trimmed();
 					sym->name           = QString("%1::%2").arg(prefix, sym->name_no_prefix);
 					sym->address        = sym_start;
 					sym->size           = sym_end;


### PR DESCRIPTION
This set of commits adds an option to demangle all auto-generated symbols and performs demangling if it's enabled.
Also, now separator between module and symbol names is changed to `!` to avoid confusion with C++ scope resolution operator. (Note that I've seen usage of `!` in a bunch of Windows apps, e.g. IDA and Borland Turbo Debugger AFAIR.)