### PR TITLE
Interrupted syscall analysis

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -703,6 +703,13 @@ Register PlatformState::value(const QString &reg) const {
 	Register found;
 	if(x86.gpr32Filled) // don't return valid Register with garbage value
 	{
+		if(reg==x86.origRAXName && x86.gpr64Filled && is64Bit())
+			return make_Register<64>(x86.origRAXName, x86.orig_ax, Register::TYPE_GPR);
+
+		if(reg==x86.origEAXName)
+			return make_Register<32>(x86.origEAXName, x86.orig_ax, Register::TYPE_GPR);
+
+
 		if(x86.gpr64Filled && is64Bit() && !!(found=findRegisterValue(x86.GPReg64Names, x86.GPRegs, regName, Register::TYPE_GPR, gpr64_count())))
 			return found;
 		if(!!(found=findRegisterValue<32>(x86.GPReg32Names, x86.GPRegs, regName, Register::TYPE_GPR, gpr_count())))

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -423,6 +423,8 @@ private:
 			FS,
 			GS
 		};
+		static constexpr const char* origEAXName="orig_eax";
+		static constexpr const char* origRAXName="orig_rax";
 		static constexpr const char* IP64Name="rip";
 		static constexpr const char* IP32Name="eip";
 		static constexpr const char* IP16Name="ip";


### PR DESCRIPTION
This enables EDB to analyze interrupted system calls. An unexpected side effect of this is that newly launched process appears to have interrupted `execve` call, with all arguments `NULL`. Although it's correct, I'm not sure it's worth showing. But for now I think it should be OK.