### PR TITLE
Show FPU operands according to their type in analysis view

### DIFF
--- a/src/FloatX.cpp
+++ b/src/FloatX.cpp
@@ -277,8 +277,7 @@ QString formatFloat(Float value)
 			return result;
 		}
 	case FloatValueClass::Infinity:
-		specialStr=QString(value.negative()?"-":"+")+"INF  ";
-		break;
+		return QString(value.negative()?"-":"+")+"INF";
 	case FloatValueClass::QNaN:
 		specialStr=QString(value.negative()?"-":"+")+"QNAN ";
 		break;
@@ -286,7 +285,7 @@ QString formatFloat(Float value)
 		specialStr=QString(value.negative()?"-":"+")+"SNAN ";
 		break;
 	case FloatValueClass::Unsupported:
-		specialStr=QString(value.negative()?"-":"+")+"BAD  ";
+		specialStr=QString(value.negative()?"-":"+")+"BAD ";
 		break;
 	}
 	// If we are here, then the value is special

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -647,8 +647,12 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value64(target).toHexString());
 								break;
 							case edb::Operand::TYPE_EXPRESSION80:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value80(target).toHexString());
+							{
+								const edb::value80 value(target);
+								const QString valueStr = inst.is_fpu() ? formatFloat(value) : "0x"+value.toHexString();
+								ret << QString("%1 = [%2] = %3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(valueStr);
 								break;
+							}
 							case edb::Operand::TYPE_EXPRESSION128:
 								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value128(target).toHexString());
 								break;

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -641,8 +641,22 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value16(target).toHexString());
 								break;
 							case edb::Operand::TYPE_EXPRESSION32:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value32(target).toHexString());
+							{
+								const edb::value32 value(target);
+								QString valueStr;
+								if(inst.is_fpu_taking_float())
+									valueStr=formatFloat(value);
+								else if(inst.is_fpu_taking_integer())
+									// FIXME: we have to explicitly say it's decimal because EDB is pretty inconsistent
+									// even across values in analysis view about its use of 0x prefix
+									// Use of hexadecimal format here is pretty much pointless since the number here is
+									// expected to be used in usual numeric computations, not as address or similar
+									valueStr=util::formatInt(value,IntDisplayMode::Signed)+" (decimal)";
+								else
+									valueStr="0x"+value.toHexString();
+								ret << QString("%1 = [%2] = %3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(valueStr);
 								break;
+							}
 							case edb::Operand::TYPE_EXPRESSION64:
 							{
 								const edb::value64 value(target);

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -644,8 +644,22 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value32(target).toHexString());
 								break;
 							case edb::Operand::TYPE_EXPRESSION64:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value64(target).toHexString());
+							{
+								const edb::value64 value(target);
+								QString valueStr;
+								if(inst.is_fpu_taking_float())
+									valueStr=formatFloat(value);
+								else if(inst.is_fpu_taking_integer())
+									// FIXME: we have to explicitly say it's decimal because EDB is pretty inconsistent
+									// even across values in analysis view about its use of 0x prefix
+									// Use of hexadecimal format here is pretty much pointless since the number here is
+									// expected to be used in usual numeric computations, not as address or similar
+									valueStr=util::formatInt(value,IntDisplayMode::Signed)+" (decimal)";
+								else
+									valueStr="0x"+value.toHexString();
+								ret << QString("%1 = [%2] = %3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(valueStr);
 								break;
+							}
 							case edb::Operand::TYPE_EXPRESSION80:
 							{
 								const edb::value80 value(target);

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -616,7 +616,12 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 						Register reg=state[QString::fromStdString(edb::v1::formatter().to_string(operand))];
 						QString valueString;
 						if(!reg) valueString = ArchProcessor::tr("(Error: obtained invalid register value from State)");
-						else valueString = reg.toHexString();
+						else {
+							if(reg.type()==Register::TYPE_FPU && reg.bitSize()==80)
+								valueString=formatFloat(reg.value<edb::value80>());
+							else
+								valueString = reg.toHexString();
+						}
 						ret << QString("%1 = %2").arg(temp_operand).arg(valueString);
 						break;
 					}

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -638,8 +638,20 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value8(target).toHexString());
 								break;
 							case edb::Operand::TYPE_EXPRESSION16:
-								ret << QString("%1 = [%2] = 0x%3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(edb::value16(target).toHexString());
+							{
+								const edb::value16 value(target);
+								QString valueStr;
+								if(inst.is_fpu_taking_integer())
+									// FIXME: we have to explicitly say it's decimal because EDB is pretty inconsistent
+									// even across values in analysis view about its use of 0x prefix
+									// Use of hexadecimal format here is pretty much pointless since the number here is
+									// expected to be used in usual numeric computations, not as address or similar
+									valueStr=util::formatInt(value,IntDisplayMode::Signed)+" (decimal)";
+								else
+									valueStr="0x"+value.toHexString();
+								ret << QString("%1 = [%2] = %3").arg(temp_operand).arg(edb::v1::format_pointer(effective_address)).arg(valueStr);
 								break;
+							}
 							case edb::Operand::TYPE_EXPRESSION32:
 							{
 								const edb::value32 value(target);

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -509,6 +509,11 @@ bool Instruction::is_nop() const
 	return operation()==Operation::X86_INS_NOP;
 }
 
+bool Instruction::is_fpu() const
+{
+	return (detail_.x86.opcode[0]&0xd8)==0xd8;
+}
+
 void Formatter::setOptions(const Formatter::FormatOptions& options)
 {
 	assert(capstoneInitialized);

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -514,6 +514,59 @@ bool Instruction::is_fpu() const
 	return (detail_.x86.opcode[0]&0xd8)==0xd8;
 }
 
+bool Instruction::is_fpu_taking_float() const
+{
+	if(!is_fpu()) return false;
+
+	const auto modrm=detail_.x86.modrm;
+	if(modrm>0xbf) return true; // always works with st(i) in this case
+
+	const auto ro=(modrm>>3)&7;
+	switch(detail_.x86.opcode[0])
+	{
+	case 0xd8:
+	case 0xdc:
+		return true;
+	case 0xdb:
+		return ro==5||ro==7;
+	case 0xd9:
+	case 0xdd:
+		return ro==0||ro==2||ro==3;
+	default:
+		return false;
+	}
+}
+
+bool Instruction::is_fpu_taking_integer() const
+{
+	if(!is_fpu()) return false;
+
+	const auto modrm=detail_.x86.modrm;
+	if(modrm>0xbf) return false; // always works with st(i) in this case
+
+	const auto ro=(modrm>>3)&7;
+	switch(detail_.x86.opcode[0])
+	{
+	case 0xda: return true;
+	case 0xdb: return 0<=ro&&ro<=3;
+	case 0xdd: return ro==1;
+	case 0xde: return true;
+	case 0xdf: return (0<=ro&&ro<=3)||ro==5||ro==7;
+	default: return false;
+	}
+}
+
+bool Instruction::is_fpu_taking_bcd() const
+{
+	if(!is_fpu()) return false;
+
+	const auto modrm=detail_.x86.modrm;
+	if(modrm>0xbf) return false; // always works with st(i) in this case
+
+	const auto ro=(modrm>>3)&7;
+	return detail_.x86.opcode[0]==0xdf && (ro==4||ro==6);
+}
+
 void Formatter::setOptions(const Formatter::FormatOptions& options)
 {
 	assert(capstoneInitialized);

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -221,6 +221,12 @@ public:
 	bool is_conditional_move() const { return is_conditional_fpu_move() || is_conditional_gpr_move(); }
 	bool is_terminator() const;
 	bool is_fpu() const;
+	// Check that instruction is an FPU instruction, taking only floating-point operands
+	bool is_fpu_taking_float() const;
+	// Check that instruction is an FPU instruction, one of operands of which is an integer
+	bool is_fpu_taking_integer() const;
+	// Check that instruction is an FPU instruction, one of operands of which is a packed BCD
+	bool is_fpu_taking_bcd() const;
 
 private:
 	Capstone::cs_insn insn_;

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -220,6 +220,7 @@ public:
 	bool is_conditional_set() const;
 	bool is_conditional_move() const { return is_conditional_fpu_move() || is_conditional_gpr_move(); }
 	bool is_terminator() const;
+	bool is_fpu() const;
 
 private:
 	Capstone::cs_insn insn_;


### PR DESCRIPTION
This makes analysis view more useful when tracing FPU computations.
Also some minor changes have been done to the way unsupported values and infinities are showed.