### PR TITLE
FPU display modes

### DIFF
--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -60,9 +60,14 @@ private:
 		Floats32,
 		Floats64
 	};
+	enum class FPUDisplayMode {
+		Hex,
+		Float
+	};
 private:
 	template<typename T>
 	QString formatSIMDRegister(const T& value, SIMDDisplayMode simdMode, IntDisplayMode intMode);
+	void setupFPURegisterMenu(QMenu& menu);
 	void setupMMXRegisterMenu(QMenu& menu);
 	void setupSSEAVXRegisterMenu(QMenu& menu, const QString& extType);
 	void update_register(QTreeWidgetItem *item, const Register &reg) const;
@@ -81,12 +86,15 @@ private:
 	SIMDDisplayMode   xymmDisplayMode_=SIMDDisplayMode::Dwords;
 	IntDisplayMode    xymmIntMode_=IntDisplayMode::Hex;
 
+	FPUDisplayMode    fpuDisplayMode_=FPUDisplayMode::Float;
+
 	std::vector<QTreeWidgetItem*> register_view_items_;
 private Q_SLOTS:
 	void setMMXDisplayMode(int);
 	void setMMXIntMode(int);
 	void setSSEAVXDisplayMode(int);
 	void setSSEAVXIntMode(int);
+	void setFPUDisplayMode(int);
 };
 
 #endif

--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -64,6 +64,10 @@ private:
 		Hex,
 		Float
 	};
+	enum class FPUOrderMode {
+		Stack, // ST(i)
+		Independent // Ri
+	};
 private:
 	template<typename T>
 	QString formatSIMDRegister(const T& value, SIMDDisplayMode simdMode, IntDisplayMode intMode);
@@ -87,6 +91,7 @@ private:
 	IntDisplayMode    xymmIntMode_=IntDisplayMode::Hex;
 
 	FPUDisplayMode    fpuDisplayMode_=FPUDisplayMode::Float;
+	FPUOrderMode      fpuOrderMode_=FPUOrderMode::Independent;
 
 	std::vector<QTreeWidgetItem*> register_view_items_;
 private Q_SLOTS:
@@ -95,6 +100,7 @@ private Q_SLOTS:
 	void setSSEAVXDisplayMode(int);
 	void setSSEAVXIntMode(int);
 	void setFPUDisplayMode(int);
+	void setFPUOrderMode(int);
 };
 
 #endif

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -174,6 +174,10 @@ edb::value80 PlatformState::X87::st(std::size_t n) const {
 	return R[STIndexToRIndex(n)];
 }
 
+edb::value80& PlatformState::X87::st(std::size_t n) {
+	return R[STIndexToRIndex(n)];
+}
+
 int PlatformState::X87::makeTag(std::size_t n, uint16_t twd) const {
 	int minitag=(twd>>n)&0x1;
 	return minitag ? recreateTag(R[n]) : TAG_EMPTY;
@@ -1127,6 +1131,19 @@ void PlatformState::set_register(const Register& reg) {
 			assert(fpuIndexValid(i));
 			const auto value=reg.value<edb::value80>();
 			std::memcpy(&x87.R[i],&value,sizeof value);
+			return;
+		}
+	}
+	{
+		QRegExp Rx("^st\\(?([0-7])\\)?$");
+		if(Rx.indexIn(regName)!=-1) {
+			QChar digit=Rx.cap(1).at(0);
+			assert(digit.isDigit());
+			char digitChar=digit.toLatin1();
+			std::size_t i=digitChar-'0';
+			assert(fpuIndexValid(i));
+			const auto value=reg.value<edb::value80>();
+			std::memcpy(&x87.st(i),&value,sizeof value);
 			return;
 		}
 	}

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -1020,7 +1020,7 @@ void PlatformState::clear() {
 }
 
 //------------------------------------------------------------------------------
-// Name: clear
+// Name: empty
 // Desc:
 //------------------------------------------------------------------------------
 bool PlatformState::empty() const {
@@ -1054,7 +1054,7 @@ void PlatformState::set_instruction_pointer(edb::address_t value) {
 }
 
 //------------------------------------------------------------------------------
-// Name: set_register
+// Name: gp_register
 // Desc:
 //------------------------------------------------------------------------------
 Register PlatformState::gp_register(size_t n) const {

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -370,6 +370,7 @@ private:
 		std::uint16_t reducedTagWord() const;
 		int tag(std::size_t n) const;
 		edb::value80 st(std::size_t n) const;
+		edb::value80& st(std::size_t n);
 		enum Tag {
 			TAG_VALID=0,
 			TAG_ZERO=1,

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -985,7 +985,22 @@ void ArchProcessor::update_fpu_view(int& itemNumber, const State &state, const Q
 		bool changed=current != prev;
 		QPalette::ColorGroup colGroup(empty ? QPalette::Disabled : QPalette::Normal);
 		QBrush textColor(changed ? Qt::red : palette.brush(colGroup,QPalette::Text));
-		register_view_items_[itemNumber]->setText(0, QString("%1R%2: %3 %4").arg(fpuTop==i?"=>":"  ").arg(i).arg(tag.leftJustified(8)).arg(formatFloat(current)));
+		QString valueStr;
+		switch(fpuDisplayMode_)
+		{
+		case FPUDisplayMode::Float:
+			valueStr=formatFloat(current);
+			break;
+		case FPUDisplayMode::Hex:
+		{
+			valueStr=current.toHexString();
+			const QChar groupSeparator(' ');
+			valueStr.insert(valueStr.size()-8,groupSeparator);
+			valueStr.insert(valueStr.size()-16-1,groupSeparator);
+			break;
+		}
+		}
+		register_view_items_[itemNumber]->setText(0, QString("%1R%2: %3 %4").arg(fpuTop==i?"=>":"  ").arg(i).arg(tag.leftJustified(8)).arg(valueStr));
 		register_view_items_[itemNumber++]->setForeground(0, textColor);
 	}
 	edb::value16 controlWord=state.fpu_control_word();
@@ -1516,6 +1531,23 @@ void ArchProcessor::setSSEAVXDisplayMode(int mode) {
 	xymmDisplayMode_=static_cast<SIMDDisplayMode>(mode);
 }
 
+void ArchProcessor::setFPUDisplayMode(int mode) {
+	fpuDisplayMode_=static_cast<FPUDisplayMode>(mode);
+}
+
+void ArchProcessor::setupFPURegisterMenu(QMenu& menu) {
+	const auto displayModeMapper = new QSignalMapper(&menu);
+	if(fpuDisplayMode_!=FPUDisplayMode::Hex) {
+		const auto action = menu.addAction(tr("View FPU as raw &hex values"),displayModeMapper,SLOT(map()));
+		displayModeMapper->setMapping(action,static_cast<int>(FPUDisplayMode::Hex));
+	}
+	if(fpuDisplayMode_!=FPUDisplayMode::Float) {
+		const auto action = menu.addAction(tr("View FPU as 80-bit &floats"),displayModeMapper,SLOT(map()));
+		displayModeMapper->setMapping(action,static_cast<int>(FPUDisplayMode::Float));
+	}
+	connect(displayModeMapper,SIGNAL(mapped(int)),this,SLOT(setFPUDisplayMode(int)));
+}
+
 std::unique_ptr<QMenu> ArchProcessor::register_item_context_menu(const Register& reg) {
 	std::unique_ptr<QMenu> menu(new QMenu());
 
@@ -1529,6 +1561,10 @@ std::unique_ptr<QMenu> ArchProcessor::register_item_context_menu(const Register&
 	}
 	if(reg.type()==Register::TYPE_SIMD && reg.name().startsWith("ymm")) {
 		setupSSEAVXRegisterMenu(*menu,"AVX");
+		return menu;
+	}
+	if(reg.type()==Register::TYPE_FPU) {
+		setupFPURegisterMenu(*menu);
 		return menu;
 	}
 


### PR DESCRIPTION
This allows the user to choose to view FPU as hex/float and as `ST(i)`/`Ri`.