### PR TITLE
Fix detection of interrupted syscall

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1275,7 +1275,8 @@ QStringList ArchProcessor::update_instruction_info(edb::address_t address) {
 					origAX=state["orig_rax"].valueAsSignedInteger();
 				else
 					origAX=state["orig_eax"].valueAsSignedInteger();
-				if(origAX!=-1) {
+				const std::int64_t rax=state.gp_register(rAX).valueAsSignedInteger();
+				if(origAX!=-1 && (-rax)&EINTR) {
 					analyze_syscall(state, inst, ret, origAX);
 					if(ret.size() && ret.back().startsWith("SYSCALL"))
 						ret.back()="Interrupted "+ret.back();

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1280,6 +1280,9 @@ QStringList ArchProcessor::update_instruction_info(edb::address_t address) {
 					analyze_syscall(state, inst, ret, origAX);
 					if(ret.size() && ret.back().startsWith("SYSCALL"))
 						ret.back()="Interrupted "+ret.back();
+					static const int ERESTARTSYS=512;
+					if((-rax)&ERESTARTSYS)
+						ret << QString("Syscall will be restarted on next step/run");
 				}
 
 				// figure out the instruction type and display some information about it


### PR DESCRIPTION
The first commit fixes a mistake I had already warned against in my own comment to #208 %)
The second one adds additional clue as to what happens if you press F7/F8/F9.