### PR TITLE
Let the user enter program arguments and working dir in file open dialog

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DialogOptions.h"
 #include "DialogPlugins.h"
 #include "DialogThreads.h"
+#include "DialogOpenProgram.h"
 #include "Expression.h"
 #include "IAnalyzer.h"
 #include "IBinary.h"
@@ -2912,12 +2913,16 @@ void Debugger::on_action_Open_triggered() {
 	// TODO: we need a core concept of debugger capabilities which
 	// may restrict some actions
 
-	const QString filename = QFileDialog::getOpenFileName(
-		this,
-		tr("Choose a file"),
-		last_open_directory_);
+	static auto* dialog = new DialogOpenProgram(this,
+												tr("Choose a file"),
+												last_open_directory_);
+	if(dialog->exec()==QDialog::Accepted) {
 
-	open_file(filename);
+		arguments_dialog_->set_arguments(dialog->arguments());
+		const QString filename = dialog->selectedFiles().front();
+		working_directory_ = dialog->workingDirectory();
+		open_file(filename);
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/src/DialogOpenProgram.cpp
+++ b/src/DialogOpenProgram.cpp
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2015 Ruslan Kabatsayev <b7.10110111@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DialogOpenProgram.h"
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QGridLayout>
+#include <QDebug>
+
+DialogOpenProgram::DialogOpenProgram(QWidget* parent,const QString& caption, const QString& directory,const QString& filter)
+	: QFileDialog(parent,caption,directory,filter),
+			  argsEdit(new QLineEdit(this)),
+			  workDir(new QLineEdit(QDir::currentPath(),this))
+{
+	QGridLayout* const layout=dynamic_cast<QGridLayout*>(this->layout());
+	// We want to be sure that the layout is as we expect it
+	if(layout && layout->rowCount()==4 && layout->columnCount()==3)
+	{
+		setFileMode(QFileDialog::ExistingFile);
+		const int rowCount=layout->rowCount();
+		QPushButton* const browseDirButton(new QPushButton(tr("Browse..."),this));
+		layout->addWidget(new QLabel(tr("Program arguments:"),this),rowCount,0);
+		layout->addWidget(argsEdit,rowCount,1);
+		layout->addWidget(new QLabel(tr("Working directory:"),this),rowCount+1,0);
+		layout->addWidget(workDir,rowCount+1,1);
+		layout->addWidget(browseDirButton,rowCount+1,2);
+
+		connect(browseDirButton,SIGNAL(clicked()),this,SLOT(browsePressed()));
+	}
+	else qDebug() << tr("Failed to setup program arguments and working directory entries for file open dialog, please report and be sure to tell your Qt version");
+}
+
+void DialogOpenProgram::browsePressed()
+{
+	const QString dir=QFileDialog::getExistingDirectory(this,tr("Choose program working directory"),workDir->text());
+	if(dir.size()) workDir->setText(dir);
+}
+
+QList<QByteArray> DialogOpenProgram::arguments() const
+{
+	const QStringList args=argsEdit->text().split(' ');
+	qDebug() << "stringlist:" << args;
+	QList<QByteArray> ret;
+	for(auto arg : args)
+		ret << arg.toLocal8Bit();
+	return ret;
+}
+
+QString DialogOpenProgram::workingDirectory() const
+{
+	return workDir->text();
+}

--- a/src/DialogOpenProgram.h
+++ b/src/DialogOpenProgram.h
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2015 Ruslan Kabatsayev <b7.10110111@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DIALOG_OPEN_PROGRAM_H_20151117
+#define DIALOG_OPEN_PROGRAM_H_20151117
+
+#include <QFileDialog>
+#include <QList>
+#include <QByteArray>
+
+class QLineEdit;
+
+class DialogOpenProgram : public QFileDialog
+{
+	Q_OBJECT // This also enables QFileDialog::DontUseNativeDialog, so that we get Qt dialog on any platform
+
+	QLineEdit* argsEdit;
+	QLineEdit* workDir;
+public:
+	DialogOpenProgram(QWidget* parent=0,
+					  const QString& caption=QString(),
+					  const QString& directory=QString(),
+					  const QString& filter=QString());
+	QList<QByteArray> arguments() const;
+	QString workingDirectory() const;
+private Q_SLOTS:
+	void browsePressed();
+};
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -39,6 +39,7 @@ HEADERS += \
 	DialogInputBinaryString.h \
 	DialogInputValue.h \
 	DialogMemoryRegions.h \
+	DialogOpenProgram.h \
 	DialogOptions.h \
 	DialogPlugins.h \
 	DialogAbout.h \
@@ -124,6 +125,7 @@ SOURCES += \
 	DialogInputBinaryString.cpp \
 	DialogInputValue.cpp \
 	DialogMemoryRegions.cpp \
+	DialogOpenProgram.cpp \
 	DialogOptions.cpp \
 	DialogPlugins.cpp \
 	DialogAbout.cpp \


### PR DESCRIPTION
This clones the functionality present in OllyDbg's file open dialog. OllyDbg seems to do some ugly-looking hack on the stock Win32 dialog, so that the entries are misaligned with the stock ones. This attempt tries to use QFileDialog's layout to align the labels and entries so that the result looks much better.

A downside of this feature is that we no longer have native dialogs since Qt4+ doesn't allow us to add custom widgets using the official API.

Another downside is that no one guarantees that the layout will always be as it is. OTOH, I see no reasons why they would suddenly change it, and the code does sanity check the dialog's layout and refrains from modifying if it looks suspiciously.