### PR TITLE
Improve user experience with Assemble dialog

### DIFF
--- a/plugins/Assembler/DialogAssembler.cpp
+++ b/plugins/Assembler/DialogAssembler.cpp
@@ -32,6 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QSettings>
 #include <QDomDocument>
 #include <QXmlQuery>
+#include <QLineEdit>
 
 #ifdef Q_OS_UNIX
 #include <sys/types.h>
@@ -326,6 +327,8 @@ void DialogAssembler::on_buttonBox_accepted() {
 				set_address(new_address);
 				edb::v1::set_cpu_selected_address(new_address);
 			}
+			ui->assembly->setFocus(Qt::OtherFocusReason);
+			ui->assembly->lineEdit()->selectAll();
 		}
 
 	}
@@ -342,6 +345,8 @@ void DialogAssembler::showEvent(QShowEvent *event) {
 	const QString assembler = settings.value("Assembler/helper", "yasm").toString();
 
 	ui->label->setText(tr("Assembler: %1").arg(assembler));
+
+	ui->assembly->setFocus(Qt::OtherFocusReason);
 }
 
 }


### PR DESCRIPTION
This fixes the necessity for the user to press Ctrl+A after pressing Enter to be able to just continue entering the assembly code. Now when the Assemble dialog is shown, it focuses the assembly field, and when Enter is pressed, regardless of the result (success or failure), the entry is focused and its text is selected, since it's the most likely thing the user would expect (enter next instruction or fix erroneous one).