### PR TITLE
Some minor Assembly dialog improvements

### DIFF
--- a/plugins/Assembler/DialogAssembler.cpp
+++ b/plugins/Assembler/DialogAssembler.cpp
@@ -182,6 +182,9 @@ QString normalizeAssembly(const QString &assembly) {
 //------------------------------------------------------------------------------
 DialogAssembler::DialogAssembler(QWidget *parent) : QDialog(parent), ui(new Ui::DialogAssembler), address_(0), instruction_size_(0) {
 	ui->setupUi(this);
+	// Disable click focus: we don't want to unnecessarily defocus instruction entry without need
+	ui->fillWithNOPs->setFocusPolicy(Qt::TabFocus);
+	ui->keepSize->setFocusPolicy(Qt::TabFocus);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/Assembler/DialogAssembler.ui
+++ b/plugins/Assembler/DialogAssembler.ui
@@ -45,7 +45,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>Keep Size</string>
+      <string>&amp;Keep Size</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -55,7 +55,7 @@
    <item row="3" column="0">
     <widget class="QCheckBox" name="fillWithNOPs">
      <property name="text">
-      <string>Fill rest with NOPs</string>
+      <string>Fill rest with &amp;NOPs</string>
      </property>
      <property name="checked">
       <bool>true</bool>


### PR DESCRIPTION
This makes it possible to toggle checkboxes in Assemble dialog, but not lose focus from the instruction entry. The checkboxes can still be focused by `Tab`, but now it's also possible to just use their shortcuts.