### PR TITLE
Add missing instance of orig?AXName outside of class scope

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -29,6 +29,8 @@ constexpr const char* PlatformState::AVX::mxcsrName;
 constexpr const char* PlatformState::X86::IP64Name;
 constexpr const char* PlatformState::X86::IP32Name;
 constexpr const char* PlatformState::X86::IP16Name;
+constexpr const char* PlatformState::X86::origEAXName;
+constexpr const char* PlatformState::X86::origRAXName;
 constexpr const char* PlatformState::X86::flags64Name;
 constexpr const char* PlatformState::X86::flags32Name;
 constexpr const char* PlatformState::X86::flags16Name;


### PR DESCRIPTION
gcc makes it harder to catch these types of problems, while with clang, even though build succeeds, DebuggerCore fails to load due to missing symbols.