### PR TITLE
Minor clang fixes

### DIFF
--- a/plugins/DebuggerCore/DebuggerCore.pro
+++ b/plugins/DebuggerCore/DebuggerCore.pro
@@ -16,7 +16,7 @@ unix {
 		# Add detector of broken writes to /proc/pid/mem
 		checkProcPidMemWrites.target = $$currentVPath/detect/procPidMemWrites.h
 		checkProcPidMemWritesOutFile = $$currentVPath/detect/proc-pid-mem-write
-		checkProcPidMemWrites.commands += $$QMAKE_CXX $$QMAKE_CXXFLAGS -std=c++11 $$currentVPath/detect/proc-pid-mem-write.cpp -o $$checkProcPidMemWritesOutFile && \
+		checkProcPidMemWrites.commands += $$QMAKE_CXX $$QMAKE_CXXFLAGS $$QMAKE_LFLAGS -std=c++11 $$currentVPath/detect/proc-pid-mem-write.cpp -o $$checkProcPidMemWritesOutFile && \
 										  $$currentVPath/detect/proc-pid-mem-write $$checkProcPidMemWrites.target
 		checkProcPidMemWrites.depends += $$currentVPath/detect/proc-pid-mem-write.cpp
 		# and its clean target

--- a/plugins/DebuggerCore/unix/linux/detect/proc-pid-mem-write.cpp
+++ b/plugins/DebuggerCore/unix/linux/detect/proc-pid-mem-write.cpp
@@ -108,7 +108,7 @@ bool detectAndWriteHeader(std::string progName)
         int buf=0x12345678;
         const size_t len=sizeof buf;
         {
-            const auto read=file.read(reinterpret_cast<char*>(&buf),len);
+            file.read(reinterpret_cast<char*>(&buf),len);
             if(!file)
             {
                 perror((progName+": failed to read data from child's memory, won't even try to write").c_str());
@@ -124,7 +124,7 @@ bool detectAndWriteHeader(std::string progName)
         }
 
         {
-            const auto written=file.write(reinterpret_cast<char*>(&buf),len);
+            file.write(reinterpret_cast<char*>(&buf),len);
             if(!file) writeHeader(true);
             else writeHeader(false);
 			return true;


### PR DESCRIPTION
The first commit `$$QMAKE_LFLAGS` to compilation commands of the broken kernel detector. I've come across a problem when clang (on my system) requires additional LDFLAGS to be able to locate some of the libs for every app it builds.
And the second one removes unused variables, thus silencing clang.