### PR TITLE
FPU/MXCSR improvements

### DIFF
--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -76,6 +76,7 @@ private:
 	void setupSSEAVXRegisterMenu(QMenu& menu, const QString& extType);
 	void update_register(QTreeWidgetItem *item, const Register &reg) const;
 	void update_fpu_view(int& itemNumber, const State &state, const QPalette& palette) const;
+	QString getRoundingMode(unsigned modeBits) const;
 
 private:
 	QTreeWidgetItem * split_flags_;
@@ -85,6 +86,11 @@ private:
 	QTreeWidgetItem * fpu_rc_;
 	QTreeWidgetItem * fpu_top_;
 	QTreeWidgetItem * fpu_status_;
+	QTreeWidgetItem * mxcsr_exceptions_mask_;
+	QTreeWidgetItem * mxcsr_exceptions_active_;
+	QTreeWidgetItem * mxcsr_daz_;
+	QTreeWidgetItem * mxcsr_ftz_;
+	QTreeWidgetItem * mxcsr_rc_;
 	State             last_state_;
 
 	bool              has_mmx_;

--- a/include/ArchProcessor.h
+++ b/include/ArchProcessor.h
@@ -79,6 +79,12 @@ private:
 
 private:
 	QTreeWidgetItem * split_flags_;
+	QTreeWidgetItem * fpu_exceptions_mask_;
+	QTreeWidgetItem * fpu_exceptions_active_;
+	QTreeWidgetItem * fpu_pc_;
+	QTreeWidgetItem * fpu_rc_;
+	QTreeWidgetItem * fpu_top_;
+	QTreeWidgetItem * fpu_status_;
 	State             last_state_;
 
 	bool              has_mmx_;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -216,8 +216,8 @@ void PlatformState::fillFrom(const UserFPRegsStructX86& regs) {
 		x87.R[n]=edb::value80(regs.st_space,10*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=regs.twd; // This is the true tag word, unlike in FPX regs and x86-64 FP regs structs
-	x87.instPtrOffset=regs.fip;
-	x87.dataPtrOffset=regs.foo;
+	x87.instPtrOffset=edb::address_t::fromZeroExtended(regs.fip);
+	x87.dataPtrOffset=edb::address_t::fromZeroExtended(regs.foo);
 	x87.instPtrSelector=regs.fcs;
 	x87.dataPtrSelector=regs.fos;
 	x87.opCode=0; // not present in the given structure
@@ -229,8 +229,8 @@ void PlatformState::fillFrom(const UserFPXRegsStructX86& regs) {
 		x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=x87.restoreTagWord(regs.twd);
-	x87.instPtrOffset=regs.fip;
-	x87.dataPtrOffset=regs.foo;
+	x87.instPtrOffset=edb::address_t::fromZeroExtended(regs.fip);
+	x87.dataPtrOffset=edb::address_t::fromZeroExtended(regs.foo);
 	x87.instPtrSelector=regs.fcs;
 	x87.dataPtrSelector=regs.fos;
 	x87.opCode=regs.fop;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -288,10 +288,10 @@ void PlatformState::fillFrom(const UserFPRegsStructX86_64& regs) {
 		x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 	x87.controlWord=regs.cwd;
 	x87.tagWord=x87.restoreTagWord(regs.ftw);
-	x87.instPtrOffset=regs.rip; // FIXME
-	x87.dataPtrOffset=regs.rdp; // FIXME
-	x87.instPtrSelector=0; // FIXME
-	x87.dataPtrSelector=0; // FIXME
+	x87.instPtrOffset=regs.rip;
+	x87.dataPtrOffset=regs.rdp;
+	x87.instPtrSelector=0;
+	x87.dataPtrSelector=0;
 	x87.opCode=regs.fop;
 	x87.filled=true;
 	x87.opCodeFilled=true;
@@ -386,10 +386,18 @@ void PlatformState::fillFrom(const X86XState& regs, std::size_t sizeFromKernel) 
 			x87.R[n]=edb::value80(regs.st_space,16*x87.RIndexToSTIndex(n));
 		x87.controlWord=regs.cwd;
 		x87.tagWord=x87.restoreTagWord(regs.twd);
-		x87.instPtrOffset=regs.fioff; // FIXME: x86_64 has different meaning of these?
-		x87.dataPtrOffset=regs.fooff; // FIXME: x86_64 has different meaning of these?
-		x87.instPtrSelector=regs.fiseg; // FIXME: x86_64 has different meaning of these?
-		x87.dataPtrSelector=regs.foseg; // FIXME: x86_64 has different meaning of these?
+		x87.instPtrOffset=regs.fioff;
+		x87.dataPtrOffset=regs.fooff;
+		if(is64Bit()) {
+			std::memcpy(reinterpret_cast<char*>(&x87.instPtrOffset)+4,&regs.fiseg,sizeof regs.fiseg);
+			std::memcpy(reinterpret_cast<char*>(&x87.dataPtrOffset)+4,&regs.foseg,sizeof regs.foseg);
+			x87.instPtrSelector=0;
+			x87.dataPtrSelector=0;
+		}
+		else {
+			x87.instPtrSelector=regs.fiseg;
+			x87.dataPtrSelector=regs.foseg;
+		}
 		x87.opCode=regs.fop;
 		x87.filled=true;
 		x87.opCodeFilled=true;

--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -858,6 +858,22 @@ Register PlatformState::value(const QString &reg) const {
 		}
 	}
 	if(x87.filled) {
+		if(regName=="fip"||regName=="fdp") {
+			const edb::address_t addr = regName=="fip" ? x87.instPtrOffset : x87.dataPtrOffset;
+			if(is64Bit())
+				return make_Register<64>(regName,addr,Register::TYPE_FPU);
+			else
+				return make_Register<32>(regName,addr,Register::TYPE_FPU);
+		}
+		if(regName=="fis"||regName=="fds") {
+			const edb::value16 val = regName=="fis" ? x87.instPtrSelector : x87.dataPtrSelector;
+			return make_Register<16>(regName,val,Register::TYPE_FPU);
+		}
+		if(regName=="fopcode") {
+			return make_Register<16>(regName,x87.opCode,Register::TYPE_FPU);
+		}
+	}
+	if(x87.filled) {
 		QRegExp MMx("^mm([0-7])$");
 		if(MMx.indexIn(regName)!=-1) {
 			QChar digit=MMx.cap(1).at(0);

--- a/plugins/DebuggerCore/unix/linux/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.h
@@ -60,9 +60,9 @@ struct UserFPRegsStructX86_64 {
 	uint16_t cwd;
 	uint16_t swd;
 	uint16_t ftw;
-	uint16_t fop;
-	uint64_t rip;
-	uint64_t rdp;
+	uint16_t fop; // last instruction opcode
+	uint64_t rip; // last instruction EIP
+	uint64_t rdp; // last operand pointer
 	uint32_t mxcsr;
 	uint32_t mxcr_mask;
 	uint32_t st_space[32];
@@ -126,11 +126,11 @@ struct UserFPXRegsStructX86 {
 	uint16_t cwd;
 	uint16_t swd;
 	uint16_t twd;
-	uint16_t fop;
-	uint32_t fip;
-	uint32_t fcs;
-	uint32_t foo;
-	uint32_t fos;
+	uint16_t fop; // last instruction opcode
+	uint32_t fip; // last instruction EIP
+	uint32_t fcs; // last instruction CS
+	uint32_t foo; // last operand offset
+	uint32_t fos; // last operand selector
 	uint32_t mxcsr;
 	uint32_t reserved;
 	uint32_t st_space[32];   /* 8*16 bytes for each FP-reg = 128 bytes */
@@ -141,10 +141,10 @@ struct UserFPRegsStructX86 {
 	uint32_t cwd;
 	uint32_t swd;
 	uint32_t twd;
-	uint32_t fip;
-	uint32_t fcs;
-	uint32_t foo;
-	uint32_t fos;
+	uint32_t fip; // last instruction EIP
+	uint32_t fcs; // last instruction CS
+	uint32_t foo; // last operand offset
+	uint32_t fos; // last operand selector
 	uint32_t st_space [20];
 };
 #endif
@@ -212,11 +212,11 @@ struct X86XState
 	uint16_t cwd;
 	uint16_t swd;
 	uint16_t twd;
-	uint16_t fop;
-	uint32_t fioff; // FIXME
-	uint32_t fiseg; // FIXME
-	uint32_t fooff; // FIXME
-	uint32_t foseg; // FIXME
+	uint16_t fop; // last instruction opcode
+	uint32_t fioff; // last instruction EIP
+	uint32_t fiseg; // last instruction CS in 32 bit mode, high 32 bits of RIP in 64 bit mode
+	uint32_t fooff; // last operand offset
+	uint32_t foseg; // last operand selector in 32 bit mode, high 32 bits of FDP in 64 bit mode
 	uint32_t mxcsr;
 	uint32_t mxcsr_mask; // FIXME
 	uint8_t st_space[16*8]; // 8 16-byte fields


### PR DESCRIPTION
This set of commits makes some improvements to the view of FPU registers and MXCSR. Namely

* last instruction, operand and opcode are added to the list of FPU registers
* Control and status words, as well as MXCSR are now expanded much like EFLAGS has been: expansions are child items
* Some code for getting rounding mode and exceptions strings is deduplicated.