### PR TITLE
Don't use fixed-size buffers to format symbol names

### DIFF
--- a/plugins/BinaryInfo/symbols.cpp
+++ b/plugins/BinaryInfo/symbols.cpp
@@ -71,13 +71,7 @@ struct elf32_model {
 		}
 
 		QString to_string() const {
-			char buf[256];
-			qsnprintf(buf, sizeof(buf), "%08x %08x %c %s",
-				address,
-				size,
-				type,
-				qPrintable(name));
-			return buf;
+			return QString("%1 %2 %3 %4").arg(edb::value32(address).toHexString()).arg(edb::value32(size).toHexString()).arg(type).arg(name);
 		}
 	};
 };
@@ -114,13 +108,7 @@ struct elf64_model {
 		}
 
 		QString to_string() const {
-			char buf[256];
-			qsnprintf(buf, sizeof(buf), "%016llx %08x %c %s",
-				address,
-				size,
-				type,
-				qPrintable(name));
-			return buf;
+			return QString("%1 %2 %3 %4").arg(edb::value64(address).toHexString()).arg(edb::value32(size).toHexString()).arg(type).arg(name);
 		}
 	};
 };


### PR DESCRIPTION
Demangled symbols can get much larger than 256 characters in length. And `qsnprintf` shouldn't be used in any case, so this just switches to `QString::arg()`.