### PR TITLE
Use QStyledItemDelegate as base for RegisterViewDelegate

### DIFF
--- a/src/widgets/RegisterViewDelegate.cpp
+++ b/src/widgets/RegisterViewDelegate.cpp
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Name: RegisterViewDelegate
 // Desc:
 //------------------------------------------------------------------------------
-RegisterViewDelegate::RegisterViewDelegate(QTreeView *view, QWidget *parent) : QItemDelegate(parent), view_(view) {
+RegisterViewDelegate::RegisterViewDelegate(QTreeView *view, QWidget *parent) : QStyledItemDelegate(parent), view_(view) {
 }
 
 //------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ void RegisterViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 		view_->style()->drawItemText(painter, textrect, Qt::AlignCenter, option.palette, view_->isEnabled(), text);
 
 	} else {
-		QItemDelegate::paint(painter, option, index);
+		QStyledItemDelegate::paint(painter, option, index);
 	}
 }
 
@@ -86,5 +86,5 @@ void RegisterViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 // Desc:
 //------------------------------------------------------------------------------
 QSize RegisterViewDelegate::sizeHint(const QStyleOptionViewItem &opt, const QModelIndex &index) const {
-    return QItemDelegate::sizeHint(opt, index) + QSize(2, 2);
+    return QStyledItemDelegate::sizeHint(opt, index) + QSize(2, 2);
 }

--- a/src/widgets/RegisterViewDelegate.h
+++ b/src/widgets/RegisterViewDelegate.h
@@ -19,11 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef REGISTER_VIEW_DELEGATE_20070519_H_
 #define REGISTER_VIEW_DELEGATE_20070519_H_
 
-#include <QItemDelegate>
+#include <QStyledItemDelegate>
 
 class QTreeView;
 
-class RegisterViewDelegate: public QItemDelegate {
+class RegisterViewDelegate: public QStyledItemDelegate {
 	Q_DISABLE_COPY(RegisterViewDelegate)
 public:
     RegisterViewDelegate(QTreeView *view, QWidget *parent);


### PR DESCRIPTION
Currently `RegisterViewDelegate` is based on `QItemDeletage`, which makes register view look not fully styled. Namely, with Oxygen, we lose hover effect and all those non-flat selection rectangles.
Default `QTreeView` and similar views install `QStyledItemDelegate` as their renderers. So `RegisterViewDelegate` should actually be based on it to make untouched rows look correct.

BTW, do you think it'd be a good idea to use `QStyle::drawPrimitive()` for disassembly, stack and hex views, so that they allowed hover effects and styled selections?