### PR TITLE
Fix UB in string_hash<9> due to left shift by 64

### DIFF
--- a/include/string_hash.h
+++ b/include/string_hash.h
@@ -26,11 +26,11 @@ namespace edb {
 
 namespace detail {
 
-template<std::size_t N, std::size_t n=N>
+template<std::size_t N, std::size_t n>
 constexpr typename std::enable_if<N<=9 && n==0,
 uint64_t>::type string_hash(const char (&)[N]) { return 0; }
 
-template<std::size_t N, std::size_t n=N>
+template<std::size_t N, std::size_t n=N-1>
 constexpr typename std::enable_if<N<=9 && n!=0,
 uint64_t>::type string_hash(const char (&array)[N]) {
 	return string_hash<N,n-1>(array) | ((array[n-1]&0xffull)<<(8*(n-1)));


### PR DESCRIPTION
The default argument `n=N` makes the first shift `..<<(8*(n-1))` result in UB when `N==9` (i.e. string with maximum length of 8), since the RHS evaluates to 64, equal to number of bits in `uint64_t`. This commit fixes it to start from `n=N-1`: the last character is the NULL terminator anyway, so no point in processing it.