### PR TITLE
Fix detection of interrupted syscall

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -1345,11 +1345,12 @@ QStringList ArchProcessor::update_instruction_info(edb::address_t address) {
 				else
 					origAX=state["orig_eax"].valueAsSignedInteger();
 				const std::int64_t rax=state.gp_register(rAX).valueAsSignedInteger();
-				if(origAX!=-1 && (-rax)&EINTR) {
+				static const int ERESTARTSYS=512;
+				// both EINTR and ERESTARTSYS can be present in any nonzero combination to mean interrupted syscall
+				if(origAX!=-1 && (-rax)&(EINTR|ERESTARTSYS)) {
 					analyze_syscall(state, inst, ret, origAX);
 					if(ret.size() && ret.back().startsWith("SYSCALL"))
 						ret.back()="Interrupted "+ret.back();
-					static const int ERESTARTSYS=512;
 					if((-rax)&ERESTARTSYS)
 						ret << QString("Syscall will be restarted on next step/run");
 				}


### PR DESCRIPTION
It appears that `ERESTARTSYS` flag can be set as return value even without `EINTR` being set. So here're some cases of interrupted syscall results:

* `sleep 3600`: interrupt -> `EAX=-(ERESTARTSYS|EINTR)`
* `cat`: interrupt -> `EAX=-ERESTARTSYS`

Would also be interesting to find a reproducible (i.e. not timed) way to interrupt a non-autorestarting syscall, but for now this fix seems adequate.