### PR TITLE
Fix HW BP setting in case of 8-byte reads and writes

### DIFF
--- a/plugins/HardwareBreakpoints/HardwareBreakpoints.cpp
+++ b/plugins/HardwareBreakpoints/HardwareBreakpoints.cpp
@@ -135,7 +135,7 @@ void HardwareBreakpoints::setupBreakpoints() {
 						QMessageBox::information(
 							0,
 							tr("Address Alignment Error"),
-							tr("Hardware read/write breakpoints must be aligned to there address."));					
+							tr("Hardware read/write breakpoint address must be aligned to breakpoint size."));					
 						return;
 					case SizeError:
 					QMessageBox::information(

--- a/plugins/HardwareBreakpoints/libHardwareBreakpoints.cpp
+++ b/plugins/HardwareBreakpoints/libHardwareBreakpoints.cpp
@@ -150,7 +150,7 @@ void setBreakpointState(State *state, int num, const BreakpointState &bp_state) 
 			switch(bp_state.size) {
 			case 3:
 				// 8 bytes
-				Q_ASSERT(edb::v1::debuggeeIs32Bit());
+				Q_ASSERT(edb::v1::debuggeeIs64Bit());
 				state->set_debug_register(7, (state->debug_register(7) & ~(0x03 << N2)) | (0x02 << N2));
 				break;
 			case 2:


### PR DESCRIPTION
This fixes incorrect assertion condition, and additionally clearifies error message about BP alignment.