### PR TITLE
Lower required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 
 # if the user has not specified which version, we try to make Qt5 happen
 # if they have, we prefer their preference

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ project (edb)
 include("GNUInstallDirs")
 
 find_package(Boost 1.35 REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CAPSTONE REQUIRED capstone>=3.0.4)
+include_directories(${CAPSTONE_INCLUDE_DIRS})
+link_directories(${CAPSTONE_LIBRARY_DIRS})
 
 if(${ENABLE_GRAPHVIZ})
 	find_package(GraphViz)

--- a/cmake/EnableCXX11.cmake
+++ b/cmake/EnableCXX11.cmake
@@ -1,0 +1,12 @@
+include(CheckCXXCompilerFlag)
+if( CMAKE_MAJOR_VERSION>3 OR ( CMAKE_MAJOR_VERSION==3 AND CMAKE_MINOR_VERSION>=1))
+	set(CMAKE_CXX_STANDARD 11)
+else()
+	check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+	if(COMPILER_SUPPORTS_CXX11)
+		add_definitions("-std=c++11")
+	else()
+		message( FATAL_ERROR "The compiler doesn't support -std=c++11 option. EDB requires a compiler which supports C++11. If you use gcc, please upgrade. For gcc-incompatible compiler please use cmake 3.1 or higher to get it to work." )
+	endif()
+endif()
+

--- a/plugins/Analyzer/CMakeLists.txt
+++ b/plugins/Analyzer/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "Analyzer")
 
 set(UI_FILES

--- a/plugins/Analyzer/CMakeLists.txt
+++ b/plugins/Analyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "Analyzer")
 
+set(UI_FILES
+		OptionsPage.ui
+		SpecifiedFunctions.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Concurrent)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -25,6 +31,7 @@ add_library(${PluginName} SHARED
 	AnalyzerWidget.cpp
 	OptionsPage.cpp
 	SpecifiedFunctions.cpp
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/Assembler/CMakeLists.txt
+++ b/plugins/Assembler/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "Assembler")
 
 set(UI_FILES

--- a/plugins/Assembler/CMakeLists.txt
+++ b/plugins/Assembler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "Assembler")
 
+set(UI_FILES
+		DialogAssembler.ui
+		OptionsPage.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Xml XmlPatterns)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui QtXml QtXmlPatterns)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -24,6 +30,7 @@ add_library(${PluginName} SHARED
 	DialogAssembler.h
 	OptionsPage.cpp
 	OptionsPage.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/Backtrace/CMakeLists.txt
+++ b/plugins/Backtrace/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "Backtrace")
 
 set(UI_FILES

--- a/plugins/Backtrace/CMakeLists.txt
+++ b/plugins/Backtrace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "Backtrace")
 
+set(UI_FILES
+		DialogBacktrace.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	Backtrace.h
 	DialogBacktrace.cpp
 	DialogBacktrace.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/BinaryInfo/CMakeLists.txt
+++ b/plugins/BinaryInfo/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "BinaryInfo")
 
 set(UI_FILES

--- a/plugins/BinaryInfo/CMakeLists.txt
+++ b/plugins/BinaryInfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "BinaryInfo")
 
+set(UI_FILES
+		OptionsPage.ui
+		DialogHeader.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -34,6 +40,7 @@ add_library(${PluginName} SHARED
 	pe_binary.h
 	symbols.cpp
 	symbols.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/BinarySearcher/CMakeLists.txt
+++ b/plugins/BinarySearcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "BinarySearcher")
 
+set(UI_FILES
+		DialogASCIIString.ui
+		DialogBinaryString.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -23,6 +29,7 @@ add_library(${PluginName} SHARED
 	DialogASCIIString.h
 	DialogBinaryString.cpp
 	DialogBinaryString.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/BinarySearcher/CMakeLists.txt
+++ b/plugins/BinarySearcher/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "BinarySearcher")
 
 set(UI_FILES

--- a/plugins/Bookmarks/CMakeLists.txt
+++ b/plugins/Bookmarks/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "Bookmarks")
 
 set(UI_FILES

--- a/plugins/Bookmarks/CMakeLists.txt
+++ b/plugins/Bookmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "Bookmarks")
 
+set(UI_FILES
+		Bookmarks.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	Bookmarks.h
 	BookmarkWidget.cpp
 	BookmarkWidget.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/BreakpointManager/CMakeLists.txt
+++ b/plugins/BreakpointManager/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "BreakpointManager")
 
 set(UI_FILES

--- a/plugins/BreakpointManager/CMakeLists.txt
+++ b/plugins/BreakpointManager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "BreakpointManager")
 
+set(UI_FILES
+		DialogBreakpoints.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	BreakpointManager.h
 	DialogBreakpoints.cpp
 	DialogBreakpoints.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 
 add_subdirectory(DebuggerCore)
 add_subdirectory(Analyzer)

--- a/plugins/CheckVersion/CMakeLists.txt
+++ b/plugins/CheckVersion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "CheckVersion")
 
+set(UI_FILES
+		OptionsPage.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Network)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui QtNetwork)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	CheckVersion.h
 	OptionsPage.cpp
 	OptionsPage.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/CheckVersion/CMakeLists.txt
+++ b/plugins/CheckVersion/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "CheckVersion")
 
 set(UI_FILES

--- a/plugins/DebuggerCore/CMakeLists.txt
+++ b/plugins/DebuggerCore/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/plugins/DebuggerCore/CMakeLists.txt
+++ b/plugins/DebuggerCore/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "DebuggerCore")
 
 if(Qt5Core_FOUND)

--- a/plugins/DumpState/CMakeLists.txt
+++ b/plugins/DumpState/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "DumpState")
 
 set(UI_FILES

--- a/plugins/DumpState/CMakeLists.txt
+++ b/plugins/DumpState/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "DumpState")
 
+set(UI_FILES
+		OptionsPage.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DumpState.h
 	OptionsPage.cpp
 	OptionsPage.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/FunctionFinder/CMakeLists.txt
+++ b/plugins/FunctionFinder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "FunctionFinder")
 
+set(UI_FILES
+		DialogFunctions.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DialogFunctions.h
 	FunctionFinder.cpp
 	FunctionFinder.h
+	${UI_H}
 )
 
 if(${GRAPHVIZ_FOUND})

--- a/plugins/FunctionFinder/CMakeLists.txt
+++ b/plugins/FunctionFinder/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "FunctionFinder")
 
 set(UI_FILES

--- a/plugins/HardwareBreakpoints/CMakeLists.txt
+++ b/plugins/HardwareBreakpoints/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "HardwareBreakpoints")
 
 set(UI_FILES

--- a/plugins/HardwareBreakpoints/CMakeLists.txt
+++ b/plugins/HardwareBreakpoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "HardwareBreakpoints")
 
+set(UI_FILES
+		DialogHWBreakpoints.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -23,6 +28,7 @@ add_library(${PluginName} SHARED
 	HardwareBreakpoints.h
 	libHardwareBreakpoints.cpp
 	libHardwareBreakpoints.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/HeapAnalyzer/CMakeLists.txt
+++ b/plugins/HeapAnalyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "HeapAnalyzer")
 
+set(UI_FILES
+		DialogHeap.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Concurrent)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -23,6 +28,7 @@ add_library(${PluginName} SHARED
 	HeapAnalyzer.h
 	ResultViewModel.cpp
 	ResultViewModel.h
+	${UI_H}
 )
 
 if(${GRAPHVIZ_FOUND})

--- a/plugins/HeapAnalyzer/CMakeLists.txt
+++ b/plugins/HeapAnalyzer/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "HeapAnalyzer")
 
 set(UI_FILES

--- a/plugins/OpcodeSearcher/CMakeLists.txt
+++ b/plugins/OpcodeSearcher/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "OpcodeSearcher")
 
 set(UI_FILES

--- a/plugins/OpcodeSearcher/CMakeLists.txt
+++ b/plugins/OpcodeSearcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "OpcodeSearcher")
 
+set(UI_FILES
+		DialogOpcodes.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DialogOpcodes.h
 	OpcodeSearcher.cpp
 	OpcodeSearcher.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/ProcessProperties/CMakeLists.txt
+++ b/plugins/ProcessProperties/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "ProcessProperties")
 
 set(UI_FILES

--- a/plugins/ProcessProperties/CMakeLists.txt
+++ b/plugins/ProcessProperties/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,16 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "ProcessProperties")
 
+set(UI_FILES
+		DialogStrings.ui
+		DialogProcessProperties.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Network)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui QtNetwork)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -23,6 +29,7 @@ add_library(${PluginName} SHARED
 	DialogStrings.h
 	ProcessProperties.cpp
 	ProcessProperties.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/ROPTool/CMakeLists.txt
+++ b/plugins/ROPTool/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "ROPTool")
 
+set(UI_FILES
+		DialogROPTool.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DialogROPTool.h
 	ROPTool.cpp
 	ROPTool.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/ROPTool/CMakeLists.txt
+++ b/plugins/ROPTool/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "ROPTool")
 
 set(UI_FILES

--- a/plugins/References/CMakeLists.txt
+++ b/plugins/References/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "References")
 
+set(UI_FILES
+		DialogReferences.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DialogReferences.h
 	References.cpp
 	References.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/References/CMakeLists.txt
+++ b/plugins/References/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "References")
 
 set(UI_FILES

--- a/plugins/SymbolViewer/CMakeLists.txt
+++ b/plugins/SymbolViewer/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 set(PluginName "SymbolViewer")
 
 set(UI_FILES

--- a/plugins/SymbolViewer/CMakeLists.txt
+++ b/plugins/SymbolViewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -8,10 +8,15 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(PluginName "SymbolViewer")
 
+set(UI_FILES
+		DialogSymbolViewer.ui)
+
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtGui)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -21,6 +26,7 @@ add_library(${PluginName} SHARED
 	DialogSymbolViewer.h
 	SymbolViewer.cpp
 	SymbolViewer.h
+	${UI_H}
 )
 
 if(Qt5Core_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -7,10 +7,26 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 
+set(UI_FILES
+		BinaryString.ui
+		Debugger.ui
+		DialogAbout.ui
+		DialogArguments.ui
+		DialogAttach.ui
+		DialogInputBinaryString.ui
+		DialogInputValue.ui
+		DialogMemoryRegions.ui
+		DialogOptions.ui
+		FixedFontSelector.ui
+		DialogPlugins.ui
+		DialogThreads.ui)
+
 if(Qt5Core_DIR)
     find_package(Qt5 5.0.0 REQUIRED Widgets Xml XmlPatterns)
+	qt5_wrap_ui(UI_H ${UI_FILES})
 elseif(NOT Qt5Core_DIR)
 	find_package(Qt4 4.6.0 REQUIRED QtGui QtXml QtXmlPatterns)
+	qt4_wrap_ui(UI_H ${UI_FILES})
 endif()
 
 add_definitions(-DDEFAULT_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb)
@@ -67,6 +83,7 @@ set(edb_SRCS
 	widgets/RegisterViewDelegate.cpp
 	widgets/SyntaxHighlighter.cpp
 	widgets/TabWidget.cpp
+	${UI_H}
 )
 
 set(edb_INCLUDES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,9 +170,9 @@ endif()
 add_executable(edb ${edb_INCLUDES} ${edb_SRCS})
 
 if(Qt5Core_DIR)
-	target_link_libraries(edb capstone Qt5::Widgets Qt5::Xml Qt5::XmlPatterns ${GRAPHVIZ_LIBRARY} ${GVC_LIBRARY})
+	target_link_libraries(edb ${CAPSTONE_LIBRARIES} Qt5::Widgets Qt5::Xml Qt5::XmlPatterns ${GRAPHVIZ_LIBRARY} ${GVC_LIBRARY})
 elseif(NOT Qt5Core_DIR)
-	target_link_libraries(edb capstone Qt4::QtGui Qt4::QtXml Qt4::QtXmlPatterns ${GRAPHVIZ_LIBRARY} ${GVC_LIBRARY})
+	target_link_libraries(edb ${CAPSTONE_LIBRARIES} Qt4::QtGui Qt4::QtXml Qt4::QtXmlPatterns ${GRAPHVIZ_LIBRARY} ${GVC_LIBRARY})
 endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required (VERSION 2.8)
 include("GNUInstallDirs")
+include("${PROJECT_SOURCE_DIR}/cmake/EnableCXX11.cmake")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_STANDARD 11)
 
 set(UI_FILES
 		BinaryString.ui


### PR DESCRIPTION
These commits let one use CMake 2.8 to compile EDB. At least this works on my system with CMake 2.8.12.2. May need some additional tweaking for 2.8.7 (which is current on Ubuntu 12.04 LTS). Additional commit also makes use of pkg-config to find Capstone, so that the users who have it installed in non-default location will still have EDB compile, provided they have set `PKG_CONFIG_PATH` correctly.

Please check that this doesn't break with CMake 3, since I don't have it installed anywhere to test.

BTW, is it only me, or does cmake install plugins not in `${CMAKE_INSTALL_PREFIX}/lib64/edb` on 64-bit systems? For me it installed them to `${CMAKE_INSTALL_PREFIX}/lib/x86_64-linux-gnu/edb` instead on Kubuntu 14.04 amd64. In any case, default plugin search dirs may need some revision.