### PR TITLE
Fix adding of resources with CMake 2.8

### DIFF
--- a/plugins/Assembler/CMakeLists.txt
+++ b/plugins/Assembler/CMakeLists.txt
@@ -11,14 +11,17 @@ set(PluginName "Assembler")
 set(UI_FILES
 		DialogAssembler.ui
 		OptionsPage.ui)
+set(RC_FILES Assembler.qrc)
 
 if(Qt5Core_FOUND)
     find_package(Qt5 5.0.0 REQUIRED Widgets Xml XmlPatterns)
 	qt5_wrap_ui(UI_H ${UI_FILES})
+	qt5_add_resources(RC_SRCS ${RC_FILES})
 else(Qt5Core_FOUND)
 	find_package(Qt4 4.6.0 QUIET REQUIRED QtCore QtGui QtXml QtXmlPatterns)
 	include(${QT_USE_FILE})
 	qt4_wrap_ui(UI_H ${UI_FILES})
+	qt4_add_resources(RC_SRCS ${RC_FILES})
 endif()
 
 # we put the header files from the include directory here 
@@ -26,11 +29,11 @@ endif()
 add_library(${PluginName} SHARED
 	Assembler.cpp
 	Assembler.h
-	Assembler.qrc
 	DialogAssembler.cpp
 	DialogAssembler.h
 	OptionsPage.cpp
 	OptionsPage.h
+	${RC_SRCS}
 	${UI_H}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,14 +20,17 @@ set(UI_FILES
 		FixedFontSelector.ui
 		DialogPlugins.ui
 		DialogThreads.ui)
+set(RC_FILES debugger.qrc)
 
 if(Qt5Core_DIR)
     find_package(Qt5 5.0.0 REQUIRED Widgets Xml XmlPatterns)
 	qt5_wrap_ui(UI_H ${UI_FILES})
+	qt5_add_resources(RC_SRCS ${RC_FILES})
 elseif(NOT Qt5Core_DIR)
 	find_package(Qt4 4.6.0 REQUIRED QtCore QtGui QtXml QtXmlPatterns)
 	include(${QT_USE_FILE})
 	qt4_wrap_ui(UI_H ${UI_FILES})
+	qt4_add_resources(RC_SRCS ${RC_FILES})
 endif()
 
 add_definitions(-DDEFAULT_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb)
@@ -48,7 +51,6 @@ set(edb_SRCS
 	Configuration.cpp
 	DataViewInfo.cpp
 	Debugger.cpp
-	debugger.qrc
 	DialogAbout.cpp
 	DialogArguments.cpp
 	DialogAttach.cpp
@@ -84,6 +86,7 @@ set(edb_SRCS
 	widgets/RegisterViewDelegate.cpp
 	widgets/SyntaxHighlighter.cpp
 	widgets/TabWidget.cpp
+	${RC_SRCS}
 	${UI_H}
 )
 


### PR DESCRIPTION
Don't know whether it does work with CMake 3, but with 2.8 I found that the current instruction arrow in disassembly view was missing, and list of assemblers in plugin settings was empty and disabled. This commit fixes adding Qt resources with CMake 2.8.