### PR TITLE
Improve rendering performance of SymbolViewer's list

### DIFF
--- a/plugins/SymbolViewer/DialogSymbolViewer.cpp
+++ b/plugins/SymbolViewer/DialogSymbolViewer.cpp
@@ -46,6 +46,7 @@ DialogSymbolViewer::DialogSymbolViewer(QWidget *parent) : QDialog(parent), ui(ne
 	filter_model_->setFilterKeyColumn(0);
 	filter_model_->setSourceModel(model_);
 	ui->listView->setModel(filter_model_);
+	ui->listView->setUniformItemSizes(true);
 
 	connect(ui->txtSearch, SIGNAL(textChanged(const QString &)), filter_model_, SLOT(setFilterFixedString(const QString &)));
 }


### PR DESCRIPTION
This addresses #340. In fact it appeared that most of the slowliness was due to debug build of Qt. Still, this commit makes even debug Qt more than an order of magnitude faster to render the list after the model is set.