### PR TITLE
Show signals in status bar, let the user disable signal message boxes

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -81,6 +81,9 @@ public:
 
 	int               min_string_length;
 
+	// Exceptions tab
+	bool			  enable_signals_message_box;
+
 protected:
 	void read_settings();
 	void write_settings();

--- a/include/IDebugEvent.h
+++ b/include/IDebugEvent.h
@@ -43,7 +43,7 @@ public:
 	};
 
 	struct Message {
-		Message(const QString &c, const QString &m) : caption(c), message(m) {
+		Message(const QString &c, const QString &m, const QString &s) : caption(c), message(m), statusMessage(s) {
 		}
 
 		Message() {
@@ -51,6 +51,7 @@ public:
 
 		QString caption;
 		QString message;
+		QString statusMessage;
 	};
 	
 public:

--- a/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
@@ -41,7 +41,8 @@ IDebugEvent *PlatformEvent::clone() const {
 IDebugEvent::Message PlatformEvent::createUnexpectedSignalMessage(const QString &name, int number) {
 	return Message(
 		tr("Unexpected Signal Encountered"),
-		tr("<p>The debugged application encountered a %1 (%2).</p>").arg(name).arg(number)
+		tr("<p>The debugged application encountered a %1 (%2).</p>").arg(name).arg(number),
+		tr("% received").arg(name)
 		);
 }
 
@@ -64,19 +65,22 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 		case SEGV_MAPERR:
 			message=Message(
 				tr("Illegal Access Fault"),
-				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> does not appear to be mapped.</p>").arg(addressString)
+				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> does not appear to be mapped.</p>").arg(addressString),
+				tr("SIGSEGV: SEGV_MAPERR: Accessed address %1 not mapped").arg(addressString)
 				);
 			break;
 		case SEGV_ACCERR:
 			message=Message(
 				tr("Illegal Access Fault"),
-				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> could not be accessed.</p>").arg(addressString)
+				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> could not be accessed.</p>").arg(addressString),
+				tr("SIGSEGV: SEGV_ACCERR: Access to address %1 not permitted").arg(addressString)
 				);
 			break;
 		default:
 			message=Message(
 				tr("Illegal Access Fault"),
-				tr("<p>The debugged application encountered a segmentation fault.<br />The instruction could not be executed.</p>")
+				tr("<p>The debugged application encountered a segmentation fault.<br />The instruction could not be executed.</p>"),
+				tr("SIGSEGV: Segmentation fault")
 				);
 			break;
 		}
@@ -85,7 +89,8 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 	case SIGILL:
 		message=Message(
 			tr("Illegal Instruction Fault"),
-			tr("<p>The debugged application attempted to execute an illegal instruction.</p>")
+			tr("<p>The debugged application attempted to execute an illegal instruction.</p>"),
+			tr("SIGILL: Illegal instruction")
 			);
 		break;
 	case SIGFPE:
@@ -93,43 +98,50 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 		case FPE_INTDIV:
 			message=Message(
 				tr("Divide By Zero"),
-				tr("<p>The debugged application tried to divide an integer value by an integer divisor of zero or encountered integer division overflow.</p>")
+				tr("<p>The debugged application tried to divide an integer value by an integer divisor of zero or encountered integer division overflow.</p>"),
+				tr("SIGFPE: FPE_INTDIV: Integer division by zero or division overflow")
 				);
 			break;
 		case FPE_FLTDIV:
 			message=Message(
 				tr("Divide By Zero"),
-				tr("<p>The debugged application tried to divide an floating-point value by a floating-point divisor of zero.</p>")
+				tr("<p>The debugged application tried to divide an floating-point value by a floating-point divisor of zero.</p>"),
+				tr("SIGFPE: FPE_FLTDIV: Floating-point division by zero")
 				);
 			break;
 		case FPE_FLTOVF:
 			message=Message(
 				tr("Numeric Overflow"),
-				tr("<p>The debugged application encountered a numeric overflow while performing a floating-point computation.</p>")
+				tr("<p>The debugged application encountered a numeric overflow while performing a floating-point computation.</p>"),
+				tr("SIGFPE: FPE_FLTOVF: Numeric overflow exception")
 				);
 			break;
 		case FPE_FLTUND:
 			message=Message(
 				tr("Numeric Underflow"),
-				tr("<p>The debugged application encountered a numeric underflow while performing a floating-point computation.</p>")
+				tr("<p>The debugged application encountered a numeric underflow while performing a floating-point computation.</p>"),
+				tr("SIGFPE: FPE_FLTUND: Numeric underflow exception")
 				);
 			break;
 		case FPE_FLTRES:
 			message=Message(
 				tr("Inexact Result"),
-				tr("<p>The debugged application encountered an inexact result of a floating-point computation it was performing.</p>")
+				tr("<p>The debugged application encountered an inexact result of a floating-point computation it was performing.</p>"),
+				tr("SIGFPE: FPE_FLTRES: Inexact result exception")
 				);
 			break;
 		case FPE_FLTINV:
 			message=Message(
 				tr("Invalid Operation"),
-				tr("<p>The debugged application attempted to perform an invalid floating-point operation.</p>")
+				tr("<p>The debugged application attempted to perform an invalid floating-point operation.</p>"),
+				tr("SIGFPE: FPE_FLTINV: Invalid floating-point operation")
 				);
 			break;
 		default:
 			message=Message(
 				tr("Floating Point Exception"),
-				tr("<p>The debugged application encountered a floating-point exception.</p>")
+				tr("<p>The debugged application encountered a floating-point exception.</p>"),
+				tr("SIGFPE: Floating-point exception")
 				);
 			break;
 		}
@@ -138,27 +150,31 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 	case SIGABRT:
 		message=Message(
 			tr("Application Aborted"),
-			tr("<p>The debugged application has aborted.</p>")
+			tr("<p>The debugged application has aborted.</p>"),
+			tr("SIGABRT: Application aborted")
 			);
 		break;
 	case SIGBUS:
 		message=Message(
 			tr("Bus Error"),
-			tr("<p>The debugged application received a bus error. Typically, this means that it tried to read or write data that is misaligned.</p>")
+			tr("<p>The debugged application received a bus error. Typically, this means that it tried to read or write data that is misaligned.</p>"),
+			tr("SIGBUS: Bus error")
 			);
 		break;
 #ifdef SIGSTKFLT
 	case SIGSTKFLT:
 		message=Message(
 			tr("Stack Fault"),
-			tr("<p>The debugged application encountered a stack fault.</p>")
+			tr("<p>The debugged application encountered a stack fault.</p>"),
+			tr("SIGSTKFLT: Stack fault")
 			);
 		break;
 #endif
 	case SIGPIPE:
 		message=Message(
 			tr("Broken Pipe Fault"),
-			tr("<p>The debugged application encountered a broken pipe fault.</p>")
+			tr("<p>The debugged application encountered a broken pipe fault.</p>"),
+			tr("SIGPIPE: Pipe broken")
 			);
 		break;
 #ifdef SIGHUP
@@ -276,6 +292,7 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 	}
 
 	message.message+="<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>";
+	message.statusMessage+=". Shift+Run/Step to pass signal to the program";
 	return message;
 }
 

--- a/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformEvent.cpp
@@ -41,9 +41,7 @@ IDebugEvent *PlatformEvent::clone() const {
 IDebugEvent::Message PlatformEvent::createUnexpectedSignalMessage(const QString &name, int number) {
 	return Message(
 		tr("Unexpected Signal Encountered"),
-		tr(
-			"<p>The debugged application encountered a %1 (%2).</p>"
-			"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(name).arg(number)
+		tr("<p>The debugged application encountered a %1 (%2).</p>").arg(name).arg(number)
 		);
 }
 
@@ -57,214 +55,228 @@ IDebugEvent::Message PlatformEvent::error_description() const {
 
 	std::size_t debuggeePtrSize=edb::v1::pointer_size();
 	bool fullAddressKnown=debuggeePtrSize<=sizeof(void*);
+	const auto addressString=fault_address.toPointerString(fullAddressKnown);
 
+	Message message;
 	switch(code()) {
 	case SIGSEGV:
 		switch(siginfo_.si_code) {
 		case SEGV_MAPERR:
-			return Message(
+			message=Message(
 				tr("Illegal Access Fault"),
-				tr(
-					"<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> does not appear to be mapped.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(fault_address.toPointerString(fullAddressKnown))
+				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> does not appear to be mapped.</p>").arg(addressString)
 				);
+			break;
 		case SEGV_ACCERR:
-			return Message(
+			message=Message(
 				tr("Illegal Access Fault"),
-				tr(
-					"<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> could not be accessed.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>").arg(fault_address.toPointerString(fullAddressKnown))
+				tr("<p>The debugged application encountered a segmentation fault.<br />The address <strong>%1</strong> could not be accessed.</p>").arg(addressString)
 				);
+			break;
 		default:
-			return Message(
+			message=Message(
 				tr("Illegal Access Fault"),
-				tr(
-					"<p>The debugged application encountered a segmentation fault.<br />The instruction could not be executed.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+				tr("<p>The debugged application encountered a segmentation fault.<br />The instruction could not be executed.</p>")
 				);
+			break;
 		}
+		break;
 
 	case SIGILL:
-		return Message(
+		message=Message(
 			tr("Illegal Instruction Fault"),
-			tr(
-				"<p>The debugged application attempted to execute an illegal instruction.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			tr("<p>The debugged application attempted to execute an illegal instruction.</p>")
 			);
+		break;
 	case SIGFPE:
 		switch(siginfo_.si_code) {
 		case FPE_INTDIV:
-		return Message(
-			tr("Divide By Zero"),
-			tr(
-				"<p>The debugged application tried to divide an integer value by an integer divisor of zero or encountered integer division overflow.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		case FPE_FLTDIV:
-		return Message(
-			tr("Divide By Zero"),
-			tr(
-				"<p>The debugged application tried to divide an floating-point value by a floating-point divisor of zero.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		case FPE_FLTOVF:
-		return Message(
-			tr("Numeric Overflow"),
-			tr(
-				"<p>The debugged application encountered a numeric overflow while performing a floating-point computation.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		case FPE_FLTUND:
-		return Message(
-			tr("Numeric Underflow"),
-			tr(
-				"<p>The debugged application encountered a numeric underflow while performing a floating-point computation.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		case FPE_FLTRES:
-		return Message(
-			tr("Inexact Result"),
-			tr(
-				"<p>The debugged application encountered an inexact result of a floating-point computation it was performing.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		case FPE_FLTINV:
-		return Message(
-			tr("Invalid Operation"),
-			tr(
-				"<p>The debugged application attempted to perform an invalid floating-point operation.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
-			);
-		default:
-			return Message(
-				tr("Floating Point Exception"),
-				tr(
-					"<p>The debugged application encountered a floating-point exception.</p>"
-					"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			message=Message(
+				tr("Divide By Zero"),
+				tr("<p>The debugged application tried to divide an integer value by an integer divisor of zero or encountered integer division overflow.</p>")
 				);
+			break;
+		case FPE_FLTDIV:
+			message=Message(
+				tr("Divide By Zero"),
+				tr("<p>The debugged application tried to divide an floating-point value by a floating-point divisor of zero.</p>")
+				);
+			break;
+		case FPE_FLTOVF:
+			message=Message(
+				tr("Numeric Overflow"),
+				tr("<p>The debugged application encountered a numeric overflow while performing a floating-point computation.</p>")
+				);
+			break;
+		case FPE_FLTUND:
+			message=Message(
+				tr("Numeric Underflow"),
+				tr("<p>The debugged application encountered a numeric underflow while performing a floating-point computation.</p>")
+				);
+			break;
+		case FPE_FLTRES:
+			message=Message(
+				tr("Inexact Result"),
+				tr("<p>The debugged application encountered an inexact result of a floating-point computation it was performing.</p>")
+				);
+			break;
+		case FPE_FLTINV:
+			message=Message(
+				tr("Invalid Operation"),
+				tr("<p>The debugged application attempted to perform an invalid floating-point operation.</p>")
+				);
+			break;
+		default:
+			message=Message(
+				tr("Floating Point Exception"),
+				tr("<p>The debugged application encountered a floating-point exception.</p>")
+				);
+			break;
 		}
+		break;
 
 	case SIGABRT:
-		return Message(
+		message=Message(
 			tr("Application Aborted"),
-			tr(
-				"<p>The debugged application has aborted.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			tr("<p>The debugged application has aborted.</p>")
 			);
+		break;
 	case SIGBUS:
-		return Message(
+		message=Message(
 			tr("Bus Error"),
-			tr(
-				"<p>The debugged application received a bus error. Typically, this means that it tried to read or write data that is misaligned.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			tr("<p>The debugged application received a bus error. Typically, this means that it tried to read or write data that is misaligned.</p>")
 			);
+		break;
 #ifdef SIGSTKFLT
 	case SIGSTKFLT:
-		return Message(
+		message=Message(
 			tr("Stack Fault"),
-			tr(
-				"<p>The debugged application encountered a stack fault.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			tr("<p>The debugged application encountered a stack fault.</p>")
 			);
+		break;
 #endif
 	case SIGPIPE:
-		return Message(
+		message=Message(
 			tr("Broken Pipe Fault"),
-			tr(
-				"<p>The debugged application encountered a broken pipe fault.</p>"
-				"<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>")
+			tr("<p>The debugged application encountered a broken pipe fault.</p>")
 			);
+		break;
 #ifdef SIGHUP
 	case SIGHUP:
-		return createUnexpectedSignalMessage("SIGHUP", SIGHUP);
+		message=createUnexpectedSignalMessage("SIGHUP", SIGHUP);
+		break;
 #endif
 #ifdef SIGINT
 	case SIGINT:
-		return createUnexpectedSignalMessage("SIGINT", SIGINT);
+		message=createUnexpectedSignalMessage("SIGINT", SIGINT);
+		break;
 #endif
 #ifdef SIGQUIT
 	case SIGQUIT:
-		return createUnexpectedSignalMessage("SIGQUIT", SIGQUIT);
+		message=createUnexpectedSignalMessage("SIGQUIT", SIGQUIT);
+		break;
 #endif
 #ifdef SIGTRAP
 	case SIGTRAP:
-		return createUnexpectedSignalMessage("SIGTRAP", SIGTRAP);
+		message=createUnexpectedSignalMessage("SIGTRAP", SIGTRAP);
+		break;
 #endif
 #ifdef SIGKILL
 	case SIGKILL:
-		return createUnexpectedSignalMessage("SIGKILL", SIGKILL);
+		message=createUnexpectedSignalMessage("SIGKILL", SIGKILL);
+		break;
 #endif
 #ifdef SIGUSR1
 	case SIGUSR1:
-		return createUnexpectedSignalMessage("SIGUSR1", SIGUSR1);
+		message=createUnexpectedSignalMessage("SIGUSR1", SIGUSR1);
+		break;
 #endif
 #ifdef SIGUSR2
 	case SIGUSR2:
-		return createUnexpectedSignalMessage("SIGUSR2", SIGUSR2);
+		message=createUnexpectedSignalMessage("SIGUSR2", SIGUSR2);
+		break;
 #endif
 #ifdef SIGALRM
 	case SIGALRM:
-		return createUnexpectedSignalMessage("SIGALRM", SIGALRM);
+		message=createUnexpectedSignalMessage("SIGALRM", SIGALRM);
+		break;
 #endif
 #ifdef SIGTERM
 	case SIGTERM:
-		return createUnexpectedSignalMessage("SIGTERM", SIGTERM);
+		message=createUnexpectedSignalMessage("SIGTERM", SIGTERM);
+		break;
 #endif
 #ifdef SIGCHLD
 	case SIGCHLD:
-		return createUnexpectedSignalMessage("SIGCHLD", SIGCHLD);
+		message=createUnexpectedSignalMessage("SIGCHLD", SIGCHLD);
+		break;
 #endif
 #ifdef SIGCONT
 	case SIGCONT:
-		return createUnexpectedSignalMessage("SIGCONT", SIGCONT);
+		message=createUnexpectedSignalMessage("SIGCONT", SIGCONT);
+		break;
 #endif
 #ifdef SIGSTOP
 	case SIGSTOP:
-		return createUnexpectedSignalMessage("SIGSTOP", SIGSTOP);
+		message=createUnexpectedSignalMessage("SIGSTOP", SIGSTOP);
+		break;
 #endif
 #ifdef SIGTSTP
 	case SIGTSTP:
-		return createUnexpectedSignalMessage("SIGTSTP", SIGTSTP);
+		message=createUnexpectedSignalMessage("SIGTSTP", SIGTSTP);
+		break;
 #endif
 #ifdef SIGTTIN
 	case SIGTTIN:
-		return createUnexpectedSignalMessage("SIGTTIN", SIGTTIN);
+		message=createUnexpectedSignalMessage("SIGTTIN", SIGTTIN);
+		break;
 #endif
 #ifdef SIGTTOU
 	case SIGTTOU:
-		return createUnexpectedSignalMessage("SIGTTOU", SIGTTOU);
+		message=createUnexpectedSignalMessage("SIGTTOU", SIGTTOU);
+		break;
 #endif
 #ifdef SIGURG
 	case SIGURG:
-		return createUnexpectedSignalMessage("SIGURG", SIGURG);
+		message=createUnexpectedSignalMessage("SIGURG", SIGURG);
+		break;
 #endif
 #ifdef SIGXCPU
 	case SIGXCPU:
-		return createUnexpectedSignalMessage("SIGXCPU", SIGXCPU);
+		message=createUnexpectedSignalMessage("SIGXCPU", SIGXCPU);
+		break;
 #endif
 #ifdef SIGXFSZ
 	case SIGXFSZ:
-		return createUnexpectedSignalMessage("SIGXFSZ", SIGXFSZ);
+		message=createUnexpectedSignalMessage("SIGXFSZ", SIGXFSZ);
+		break;
 #endif
 #ifdef SIGVTALRM
 	case SIGVTALRM:
-		return createUnexpectedSignalMessage("SIGVTALRM", SIGVTALRM);
+		message=createUnexpectedSignalMessage("SIGVTALRM", SIGVTALRM);
+		break;
 #endif
 #ifdef SIGPROF
 	case SIGPROF:
-		return createUnexpectedSignalMessage("SIGPROF", SIGPROF);
+		message=createUnexpectedSignalMessage("SIGPROF", SIGPROF);
+		break;
 #endif
 #ifdef SIGWINCH
 	case SIGWINCH:
-		return createUnexpectedSignalMessage("SIGWINCH", SIGWINCH);
+		message=createUnexpectedSignalMessage("SIGWINCH", SIGWINCH);
+		break;
 #endif
 #ifdef SIGIO
 	case SIGIO:
-		return createUnexpectedSignalMessage("SIGIO", SIGIO);
+		message=createUnexpectedSignalMessage("SIGIO", SIGIO);
+		break;
 #endif
 	default:
 		return Message();
 	}
+
+	message.message+="<p>If you would like to pass this exception to the application press Shift+[F7/F8/F9]</p>";
+	return message;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -111,6 +111,10 @@ void Configuration::read_settings() {
 	session_path = settings.value("directory.session.path", QString()).value<QString>();
 	settings.endGroup();
 
+	settings.beginGroup("Exceptions");
+	enable_signals_message_box=settings.value("signals.show_message_box.enabled", true).value<bool>();
+	settings.endGroup();
+
 	// normalize values
 	if(data_word_width != 1 && data_word_width != 2 && data_word_width != 4 && data_word_width != 8) {
 		data_word_width = 1;
@@ -176,5 +180,9 @@ void Configuration::write_settings() {
 	settings.setValue("directory.symbol.path", symbol_path);
 	settings.setValue("directory.plugin.path", plugin_path);
 	settings.setValue("directory.session.path", session_path);
+	settings.endGroup();
+
+	settings.beginGroup("Exceptions");
+	settings.setValue("signals.show_message_box.enabled", enable_signals_message_box);
 	settings.endGroup();
 }

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2095,7 +2095,8 @@ edb::EVENT_STATUS Debugger::handle_event_stopped(const IDebugEvent::const_pointe
 	if(event->is_error()) {
 		const IDebugEvent::Message message = event->error_description();
 		edb::v1::set_status(message.statusMessage,0);
-		QMessageBox::information(this, message.caption, message.message);
+		if(edb::v1::config().enable_signals_message_box)
+			QMessageBox::information(this, message.caption, message.message);
 		return edb::DEBUG_STOP;
 	}
 
@@ -2124,18 +2125,22 @@ edb::EVENT_STATUS Debugger::handle_event_stopped(const IDebugEvent::const_pointe
 				exception_name = it.value();
 
 				edb::v1::set_status(tr("%1 signal received. Shift+Step/Run to pass to program, Step/Run to ignore").arg(exception_name),0);
-				QMessageBox::information(this, tr("Debug Event"),
-					tr(
-					"<p>The debugged application has received a debug event-> <strong>%1 (%2)</strong></p>"
-					"<p>If you would like to pass this event to the application press Shift+[F7/F8/F9]</p>"
-					"<p>If you would like to ignore this event, press [F7/F8/F9]</p>").arg(event->code()).arg(exception_name));
+				if(edb::v1::config().enable_signals_message_box) {
+					QMessageBox::information(this, tr("Debug Event"),
+						tr(
+						"<p>The debugged application has received a debug event-> <strong>%1 (%2)</strong></p>"
+						"<p>If you would like to pass this event to the application press Shift+[F7/F8/F9]</p>"
+						"<p>If you would like to ignore this event, press [F7/F8/F9]</p>").arg(event->code()).arg(exception_name));
+				}
 			} else {
 				edb::v1::set_status(tr("Signal received: %1. Shift+Step/Run to pass to program, Step/Run to ignore").arg(event->code()),0);
-				QMessageBox::information(this, tr("Debug Event"),
-					tr(
-					"<p>The debugged application has received a debug event-> <strong>%1</strong></p>"
-					"<p>If you would like to pass this event to the application press Shift+[F7/F8/F9]</p>"
-					"<p>If you would like to ignore this event, press [F7/F8/F9]</p>").arg(event->code()));
+				if(edb::v1::config().enable_signals_message_box) {
+					QMessageBox::information(this, tr("Debug Event"),
+						tr(
+						"<p>The debugged application has received a debug event-> <strong>%1</strong></p>"
+						"<p>If you would like to pass this event to the application press Shift+[F7/F8/F9]</p>"
+						"<p>If you would like to ignore this event, press [F7/F8/F9]</p>").arg(event->code()));
+				}
 			}
 
 			return edb::DEBUG_STOP;

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2080,6 +2080,7 @@ edb::EVENT_STATUS Debugger::handle_event_stopped(const IDebugEvent::const_pointe
 	// because we just hit a break point or because we wanted to run, but had
 	// to step first in case were were on a breakpoint already...
 
+	edb::v1::clear_status();
 
 	if(event->is_kill()) {
 		QMessageBox::information(
@@ -2093,6 +2094,7 @@ edb::EVENT_STATUS Debugger::handle_event_stopped(const IDebugEvent::const_pointe
 
 	if(event->is_error()) {
 		const IDebugEvent::Message message = event->error_description();
+		edb::v1::set_status(message.statusMessage,0);
 		QMessageBox::information(this, message.caption, message.message);
 		return edb::DEBUG_STOP;
 	}
@@ -2121,12 +2123,14 @@ edb::EVENT_STATUS Debugger::handle_event_stopped(const IDebugEvent::const_pointe
 			if(it != known_exceptions.end()) {
 				exception_name = it.value();
 
+				edb::v1::set_status(tr("%1 signal received. Shift+Step/Run to pass to program, Step/Run to ignore").arg(exception_name),0);
 				QMessageBox::information(this, tr("Debug Event"),
 					tr(
 					"<p>The debugged application has received a debug event-> <strong>%1 (%2)</strong></p>"
 					"<p>If you would like to pass this event to the application press Shift+[F7/F8/F9]</p>"
 					"<p>If you would like to ignore this event, press [F7/F8/F9]</p>").arg(event->code()).arg(exception_name));
 			} else {
+				edb::v1::set_status(tr("Signal received: %1. Shift+Step/Run to pass to program, Step/Run to ignore").arg(event->code()),0);
 				QMessageBox::information(this, tr("Debug Event"),
 					tr(
 					"<p>The debugged application has received a debug event-> <strong>%1</strong></p>"
@@ -2419,6 +2423,7 @@ edb::EVENT_STATUS Debugger::resume_status(bool pass_exception) {
 //------------------------------------------------------------------------------
 void Debugger::resume_execution(EXCEPTION_RESUME pass_exception, DEBUG_MODE mode, bool forced) {
 
+	edb::v1::clear_status();
 	Q_ASSERT(edb::v1::debugger_core);
 	
 	if(IProcess *process = edb::v1::debugger_core->process()) {

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -199,6 +199,8 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->cmbDataRowWidth->setCurrentIndex(width_to_index(config.data_row_width));
 
 	ui->chkAddressColon->setChecked(config.show_address_separator);
+
+	ui->signalsMessageBoxEnable->setChecked(config.enable_signals_message_box);
 }
 
 //------------------------------------------------------------------------------
@@ -262,6 +264,8 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	options.smallNumFormat = config.small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;
 	options.syntax=static_cast<CapstoneEDB::Formatter::Syntax>(config.syntax);
 	edb::v1::formatter().setOptions(options);
+
+	config.enable_signals_message_box = ui->signalsMessageBoxEnable->isChecked();
 
 	event->accept();
 }

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -453,6 +453,13 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
+        <widget class="QCheckBox" name="signalsMessageBoxEnable">
+         <property name="text">
+          <string>Alert about signals with a message box</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Ignore (pass to program) the following exceptions:</string>

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1268,6 +1268,8 @@ void set_status(const QString &message, int timeoutMillisecs) {
 
 void clear_status() {
 	ui()->ui.statusbar->clearMessage();
+	// Make sure the status is cleared even if the event loop isn't entered for some time
+	QCoreApplication::processEvents();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This makes it possible to have behavior more similar to that of OllyDbg regarding signals.

I'm not sure though whether such prefixes as `SIGSEGV: SEGV_ACCERR: ` are a good idea for status bar. Maybe they are better shown only for some ambiguous signals when we can't say their exact reason (e.g. `SIGSEGV` with `code==128`).