### PR TITLE
Use more visible arrows to denote jump directions

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -875,7 +875,7 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 					font_width_,
 					line_height,
 					Qt::AlignVCenter,
-					QString((target > address) ? QChar(0x02C7) : QChar(0x02C6))
+					QString((target > address) ? QChar(0x2304) : QChar(0x2303))
 					);
 			}
 		}


### PR DESCRIPTION
This uses larger arrows to show directions of jumps. The original ones are too tiny to see even on small-resolution monitors.
After this change the down arrow also appears at the bottom of the line instead of top, which further improves differentiation between the two.