### PR TITLE
Some changes in (dis)assembly

### DIFF
--- a/plugins/Assembler/DialogAssembler.cpp
+++ b/plugins/Assembler/DialogAssembler.cpp
@@ -254,12 +254,6 @@ void DialogAssembler::on_buttonBox_accepted() {
 		}
 
 
-		const QFile file(command_line[0]);
-		if(command_line[0].isEmpty() || !file.exists()) {
-			QMessageBox::warning(this, tr("Couldn't Find Assembler"), tr("Failed to locate your assembler."));
-			return;
-		}
-
 		QTemporaryFile source_file(QString("%1/edb_asm_temp_%2_XXXXXX.%3").arg(QDir::tempPath()).arg(getpid()).arg(asm_ext));
 		if(!source_file.open()) {
 			QMessageBox::critical(this, tr("Error Creating File"), tr("Failed to create temporary source file."));
@@ -333,6 +327,13 @@ void DialogAssembler::on_buttonBox_accepted() {
 			ui->assembly->setFocus(Qt::OtherFocusReason);
 			ui->assembly->lineEdit()->selectAll();
 		}
+		else if(process.error()==QProcess::FailedToStart)
+		{
+			QMessageBox::warning(this, tr("Couldn't Launch Assembler"), tr("Failed to start your assembler."));
+			return;
+		}
+
+
 
 	}
 }

--- a/plugins/Assembler/xml/assemblers.xml
+++ b/plugins/Assembler/xml/assemblers.xml
@@ -22,4 +22,15 @@
 		]]>
 	</template>
 	</assembler>
+	<assembler name="fasm">
+		<executable command_line="fasm %IN% %OUT%" extension="asm" />
+		<template>
+		<![CDATA[
+		use%BITS%
+		ORG %ADDRESS%
+
+		%INSTRUCTION%
+		]]>
+	</template>
+	</assembler>
 </assemblers>

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -61,6 +61,11 @@ bool init(bool amd64)
 	return true;
 }
 
+int Operand::size() const
+{
+	return owner_->cs_insn().detail->x86.operands[numberInInstruction_].size;
+}
+
 void Instruction::fillPrefix()
 {
 	// FIXME: Capstone seems to be unable to correctly report prefixes for

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -168,13 +168,13 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 		if((operation()==Operation::X86_INS_LCALL||operation()==Operation::X86_INS_LJMP) &&
 				ops[0].type==Capstone::X86_OP_IMM)
 		{
-			assert(operand_count()==2);
+			assert(cs_insn_operand_count()==2);
 			Operand operand(this,0);
 			operand.type_=Operand::TYPE_ABSOLUTE;
 			operand.abs_.seg=ops[0].imm;
 			operand.abs_.offset=ops[1].imm;
 		}
-		else for(std::size_t i=0;i<operand_count();++i)
+		else for(std::size_t i=0;i<cs_insn_operand_count();++i)
 		{
 			Operand operand(this,i);
 			switch(ops[i].type)
@@ -289,9 +289,17 @@ const uint8_t* Instruction::bytes() const
 	return insn_.bytes;
 }
 
-std::size_t Instruction::operand_count() const
+std::size_t Instruction::cs_insn_operand_count() const
 {
 	return insn_.detail->x86.op_count;
+}
+
+std::size_t Instruction::operand_count() const
+{
+	std::size_t count=operands_.size();
+	for(const auto& op : operands_)
+		if(!op.valid()) --count;
+	return count;
 }
 
 std::size_t Instruction::size() const

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -142,6 +142,7 @@ void adjustInstructionText(Capstone::cs_insn& insn)
 	operands.replace(" - ","-");
 
 	operands.replace(QRegExp("\\bxword "),"tbyte ");
+	operands.replace(QRegExp("(word|byte) ptr "),"\\1 ");
 
 	strcpy(insn.op_str,operands.toStdString().c_str());
 }

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -231,6 +231,8 @@ public:
 	bool is_fpu_taking_bcd() const;
 
 private:
+	std::size_t cs_insn_operand_count() const; // may be not equal to operand_count()
+
 	Capstone::cs_insn insn_;
 	Capstone::cs_detail detail_;
 	bool valid_=false;

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -107,6 +107,7 @@ public:
 	const expression_t expression() const { return expr_; }
 	Instruction* owner() const { return owner_; }
 	Register reg() const { return reg_; }
+	int size() const;
 	Operand(Instruction* instr, std::size_t numberInInstruction) : owner_(instr), numberInInstruction_(numberInInstruction) {}
 	Operand(){}
 private:

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -167,6 +167,7 @@ public:
 	uint64_t rva() const { return rva_; }
 	std::string mnemonic() const;
 	uint32_t prefix() const { return prefix_; }
+	Capstone::cs_insn const& cs_insn() const { return insn_; }
 	// Capstone doesn't provide any easy way to get total prefix length,
 	// so this is currently unimplemented
 	//std::size_t prefix_size() const;

--- a/src/widgets/SyntaxHighlighter.cpp
+++ b/src/widgets/SyntaxHighlighter.cpp
@@ -134,7 +134,7 @@ void SyntaxHighlighter::create_rules() {
 
 	// pointer modifiers
 	rules_.append(HighlightingRule(
-		"\\b(t?byte|([xyz]mm|[qdf]?)word) ptr\\b",
+		"\\b(t?byte|([xyz]mm|[qdf]?)word)( ptr)?\\b",
 		QColor(settings.value("theme.ptr.foreground", "darkGreen").value<QString>()),
 		QColor(settings.value("theme.ptr.background", "transparent").value<QString>()),
 		settings.value("theme.ptr.weight", QFont::Normal).value<int>(),


### PR DESCRIPTION
These commits

1. fix a bug with determining operand count in the case of long jmp/call instructions
2. Add fasm to the list of supported assemblers
3. Change size specifiers like `dword ptr` to more making sense like `dword` (so that the syntax now matches that of the three supported assemblers more closely)
4. Remove size specifiers in cases when operand size is unambiguous, e.g. `mov eax,[ecx]`.