### PR TITLE
Check that index register is a GPR, otherwise EDB'd crash. 

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -655,10 +655,10 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 						break;
 					}
 				case edb::Operand::TYPE_EXPRESSION:
-					do {
+					{
 						bool ok;
 						const edb::address_t effective_address = get_effective_address(operand, state,ok);
-						if(!ok) return;
+						if(!ok) continue;
 						edb::value256 target;
 
 						if(process->read_bytes(effective_address, &target, sizeof(target))) {
@@ -736,7 +736,7 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 						} else {
 							ret << QString("%1 = [%2] = ?").arg(temp_operand).arg(edb::v1::format_pointer(effective_address));
 						}
-					} while(0);
+					}
 					break;
 				default:
 					break;

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -131,7 +131,11 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 				if(!!baseR)
 					base=baseR.valueAsAddress();
 				if(!!indexR)
+				{
+					if(indexR.type()!=Register::TYPE_GPR)
+						return ret; // TODO: add support for VSIB addressing
 					index=indexR.valueAsAddress();
+				}
 
 				// This only makes sense for x86_64, but doesn't hurt on x86
 				if(op.expression().base == edb::Operand::Register::X86_REG_RIP) {

--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -128,9 +128,22 @@ edb::address_t get_effective_address(const edb::Operand &op, const State &state,
 				edb::address_t base  = 0;
 				edb::address_t index = 0;
 
-				if(!!baseR)
+				if(!baseR)
+				{
+					if(op.expression().base!=edb::Operand::Register::X86_REG_INVALID)
+						return ret; // register is valid, but failed to be acquired from state
+				}
+				else
+				{
 					base=baseR.valueAsAddress();
-				if(!!indexR)
+				}
+
+				if(!indexR)
+				{
+					if(op.expression().index!=edb::Operand::Register::X86_REG_INVALID)
+						return ret; // register is valid, but failed to be acquired from state
+				}
+				else
 				{
 					if(indexR.type()!=Register::TYPE_GPR)
 						return ret; // TODO: add support for VSIB addressing


### PR DESCRIPTION
Currently EDB crashes when it encounters an instruction with VSIB addressing, e.g.

    C4 E2 65 93 8C 79 99 33 55 00   vgatherqps xmm1,dword [ecx+ymm7*2+0x553399],xmm3

First commit works around this, leaving addition of VSIB support as a TODO.
Second commit prevents senseless calculations when e.g. VSIB has `ymmN` as index while the CPU/OS doesn't support AVX.