### PR TITLE
Remove mentioning of X86_OP_FP

### DIFF
--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -274,8 +274,8 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 		if(activeFormatter.options().syntax==Formatter::SyntaxIntel)
 		{
 			if(operand_count()==2 && operands_[0].size()==operands_[1].size() &&
-					(operands_[0].general_type()==Operand::TYPE_REGISTER && operands_[1].general_type()==Operand::TYPE_EXPRESSION ||
-					 operands_[1].general_type()==Operand::TYPE_REGISTER && operands_[0].general_type()==Operand::TYPE_EXPRESSION))
+					((operands_[0].general_type()==Operand::TYPE_REGISTER && operands_[1].general_type()==Operand::TYPE_EXPRESSION) ||
+					 (operands_[1].general_type()==Operand::TYPE_REGISTER && operands_[0].general_type()==Operand::TYPE_EXPRESSION)))
 			{
 				stripMemorySizes(insn_.op_str);
 			}

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -263,8 +263,6 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 					else
 						operand.expr_.segment=Operand::Segment::DS;
 				}
-			case Capstone::X86_OP_FP: // FIXME: what instructions have this?
-				break;
 			case Capstone::X86_OP_INVALID:
 				break;
 			}


### PR DESCRIPTION
This operand type may go away in a future version of capstone (see https://github.com/aquynh/capstone/issues/648), so better be prepared for this.

This might create a compiler warning about not all the cases handled in the switch, but I think we could tolerate it temporarily, rather than add a default case.

Another commit here fixes an unrelated warning, which still could hide some more useful warnings of its type.