### PR TITLE
Let the user write binary string longer than selected bytes

### DIFF
--- a/include/BinaryString.h
+++ b/include/BinaryString.h
@@ -39,6 +39,7 @@ private Q_SLOTS:
 	void on_txtAscii_textEdited(const QString &);
 	void on_txtHex_textEdited(const QString &);
 	void on_txtUTF16_textEdited(const QString &);
+	void on_keepSize_stateChanged();
 
 public:
 	void setMaxLength(int n);
@@ -46,7 +47,16 @@ public:
 	void setValue(const QByteArray &);
 
 private:
-	 Ui::BinaryStringWidget *const ui;
+	void setEntriesMaxLength(int n);
+
+	Ui::BinaryStringWidget *const ui;
+	enum class Mode
+	{
+	    LengthLimited, // obeys setMaxLength()
+	    MemoryEditing  // obeys user's choice in keepSize checkbox
+	} mode;
+	int requestedMaxLength;
+	int valueOriginalLength;
 };
 
 #endif

--- a/include/edb.h
+++ b/include/edb.h
@@ -108,9 +108,8 @@ EDB_EXPORT bool eval_expression(const QString &expression, address_t *value);
 EDB_EXPORT bool get_value_from_user(Register &value, const QString &title);
 EDB_EXPORT bool get_value_from_user(Register &value);
 
-// ask the user for a binary string via an input box
-EDB_EXPORT bool get_binary_string_from_user(QByteArray &value, const QString &title, int max_length);
-EDB_EXPORT bool get_binary_string_from_user(QByteArray &value, const QString &title);
+// ask the user for a binary string via an input box (max_length forces maximum length, setting it to 0 removes the restriction)
+EDB_EXPORT bool get_binary_string_from_user(QByteArray &value, const QString &title, int max_length=0);
 
 // determine if the given address is the starting point of an string, if so, s will contain it
 // (formatted with C-style escape chars, so foundLength will have the original length of the string in chars).

--- a/src/BinaryString.ui
+++ b/src/BinaryString.ui
@@ -72,6 +72,16 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="keepSize">
+     <property name="text">
+      <string>&amp;Keep size</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1968,8 +1968,8 @@ void Debugger::mnuCPUModify() {
 		const bool ok = process->read_bytes(address, buf, size);
 		if(ok) {
 			QByteArray bytes = QByteArray::fromRawData(reinterpret_cast<const char *>(buf), size);
-			if(edb::v1::get_binary_string_from_user(bytes, QT_TRANSLATE_NOOP("edb", "Edit Binary String"), size)) {
-				edb::v1::modify_bytes(address, size, bytes, 0x00);
+			if(edb::v1::get_binary_string_from_user(bytes, QT_TRANSLATE_NOOP("edb", "Edit Binary String"))) {
+				edb::v1::modify_bytes(address, bytes.size(), bytes, 0x00);
 			}
 		}
 	}
@@ -1983,11 +1983,10 @@ template <class T>
 void Debugger::modify_bytes(const T &hexview) {
 	if(hexview) {
 		const edb::address_t address = hexview->selectedBytesAddress();
-		const unsigned int size      = hexview->selectedBytesSize();
 		QByteArray bytes             = hexview->selectedBytes();
 
-		if(edb::v1::get_binary_string_from_user(bytes, QT_TRANSLATE_NOOP("edb", "Edit Binary String"), size)) {
-			edb::v1::modify_bytes(address, size, bytes, 0x00);
+		if(edb::v1::get_binary_string_from_user(bytes, QT_TRANSLATE_NOOP("edb", "Edit Binary String"))) {
+			edb::v1::modify_bytes(address, bytes.size(), bytes, 0x00);
 		}
 	}
 }

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -535,14 +535,6 @@ bool get_value_from_user(Register &value, const QString &title) {
 // Name: get_binary_string_from_user
 // Desc:
 //------------------------------------------------------------------------------
-bool get_binary_string_from_user(QByteArray &value, const QString &title) {
-	return get_binary_string_from_user(value, title, 10);
-}
-
-//------------------------------------------------------------------------------
-// Name: get_binary_string_from_user
-// Desc:
-//------------------------------------------------------------------------------
 bool get_binary_string_from_user(QByteArray &value, const QString &title, int max_length) {
 	static auto dlg = new DialogInputBinaryString(debugger_ui);
 


### PR DESCRIPTION
This commit makes it possible to enter a binary string longer than selected bytes string. It follows the same idea as Assemble dialog: presents a "keep size" checkbox.
The old mode of length-limited entry is retained to leave the interface of `get_binary_string_from_user` the same, although both places where this function is used don't use this mode. In this mode the checkbox is hidden, and length limit is enforced to be equal to the supplied one — instead of being equal to initial value length.

There's also a comment regarding "set length before value", which you can later delete if you find that the comment it references is invalid.