### PR TITLE
Avoid processing all events just to repaint the status bar.

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -442,6 +442,7 @@ void Debugger::update_menu_state(GUI_STATE state) {
 		ui.action_Kill->setEnabled(true);
 		add_tab_->setEnabled(true);
 		status_->setText(Paused);
+		status_->repaint();
 		break;
 	case RUNNING:
 		ui.actionRun_Until_Return->setEnabled(false);
@@ -458,6 +459,7 @@ void Debugger::update_menu_state(GUI_STATE state) {
 		ui.action_Kill->setEnabled(true);
 		add_tab_->setEnabled(true);
 		status_->setText(Running);
+		status_->repaint();
 		break;
 	case TERMINATED:
 		ui.actionRun_Until_Return->setEnabled(false);
@@ -474,6 +476,7 @@ void Debugger::update_menu_state(GUI_STATE state) {
 		ui.action_Kill->setEnabled(false);
 		add_tab_->setEnabled(false);
 		status_->setText(Terminated);
+		status_->repaint();
 		break;
 	}
 

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1254,10 +1254,18 @@ address_t current_data_view_address() {
 //------------------------------------------------------------------------------
 void set_status(const QString &message, int timeoutMillisecs) {
 	ui()->ui.statusbar->showMessage(message, timeoutMillisecs);
+	// FIXME: For some reason, despite showMessage() calls repaint, there's some
+	// hysteresis in actual look of the status bar: in a busy loop of calls to set_status()
+	// it updates to previous content. In some cases it even doesn't actually update.
+	// This happens at least on Qt 4.
+	// Manual call to repaint makes it show the correct text immediately.
+	ui()->ui.statusbar->repaint();
 }
 
 void clear_status() {
 	ui()->ui.statusbar->clearMessage();
+	// FIXME: same comment applies as in set_status()
+	ui()->ui.statusbar->repaint();
 }
 
 //------------------------------------------------------------------------------

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1254,14 +1254,10 @@ address_t current_data_view_address() {
 //------------------------------------------------------------------------------
 void set_status(const QString &message, int timeoutMillisecs) {
 	ui()->ui.statusbar->showMessage(message, timeoutMillisecs);
-	// Make sure the new status is visible even if the event loop isn't entered for some time
-	QCoreApplication::processEvents();
 }
 
 void clear_status() {
 	ui()->ui.statusbar->clearMessage();
-	// Make sure the status is cleared even if the event loop isn't entered for some time
-	QCoreApplication::processEvents();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
`processEvents()` appears to take quite a bit of performance away from EDB (especially visible on my EEE PC with Intel Atom).
This commit uses the least necessary action to make sure the status is repainted, so as to avoid too much time spent uselessly.