### PR TITLE
Use execv instead of execvp.

### DIFF
--- a/plugins/DebuggerCore/unix/DebuggerCoreUNIX.cpp
+++ b/plugins/DebuggerCore/unix/DebuggerCoreUNIX.cpp
@@ -246,11 +246,14 @@ void DebuggerCoreUNIX::execute_process(const QString &path, const QString &cwd, 
 
 		*p = 0;
 
-		const int ret = execvp(argv_pointers[0], argv_pointers);
+		// NOTE: it's a bad idea to use execvp and similar functions searching in
+		// $PATH. At least on Linux, if the file is corrupted/unsupported, they
+		// instead appear to launch shell
+		const int ret = execv(argv_pointers[0], argv_pointers);
 
 		// should be no need to cleanup, the process which allocated all that
 		// space no longer exists!
-		// if we get here...execvp failed!
+		// if we get here...execv failed!
 		if(ret == -1) {
 			p = argv_pointers;
 			while(*p) {


### PR DESCRIPTION
Otherwise, when a file can't be executed (e.g. ELF64 on 32 bit kernel or corrupted file) we get shell as a debuggee, which is very confusing.
The functionality we lose here was not used in EDB anyway, since it appears to check existence of the file before calling `execute_process()`, so this function never got any opportunity to search in `$PATH`.
As a bonus, we can now run files in current directory like `edb --run filename`, not necessarily as it was before: `edb --run ./filename`. New behavior is much more consistent than requiring a slash in file path but not searching in `$PATH` when no slash is present.