### PR TITLE
New options for instruction formatting

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -76,6 +76,7 @@ public:
 	bool              small_int_as_decimal;
 	bool			  tab_between_mnemonic_and_operands;
 	bool			  show_local_module_name_in_jump_targets;
+	bool			  simplify_rip_relative_targets;
 
 	// directories tab
 	QString           symbol_path;

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -74,6 +74,7 @@ public:
 	bool              zeros_are_filling;
 	bool              uppercase_disassembly;
 	bool              small_int_as_decimal;
+	bool			  tab_between_mnemonic_and_operands;
 
 	// directories tab
 	QString           symbol_path;

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -75,6 +75,7 @@ public:
 	bool              uppercase_disassembly;
 	bool              small_int_as_decimal;
 	bool			  tab_between_mnemonic_and_operands;
+	bool			  show_local_module_name_in_jump_targets;
 
 	// directories tab
 	QString           symbol_path;

--- a/include/ISymbolManager.h
+++ b/include/ISymbolManager.h
@@ -42,7 +42,7 @@ public:
 	virtual void load_symbol_file(const QString &filename, edb::address_t base) = 0;
 	virtual void set_symbol_generator(ISymbolGenerator *generator) = 0;
 	virtual void set_label(edb::address_t address, const QString &label) = 0;
-	virtual QString find_address_name(edb::address_t address) = 0;
+	virtual QString find_address_name(edb::address_t address, bool prefixed=true) = 0;
 	virtual QHash<edb::address_t, QString> labels() const = 0;
 	virtual QList<QString> files() const = 0;
 };

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -106,6 +106,7 @@ void Configuration::read_settings() {
 	uppercase_disassembly = settings.value("disassembly.uppercase.enabled", false).value<bool>();
 	small_int_as_decimal  = settings.value("disassembly.small_int_as_decimal.enabled", false).value<bool>();
 	tab_between_mnemonic_and_operands=settings.value("disassembly.tab_between_mnemonic_and_operands.enabled", false).value<bool>();
+	show_local_module_name_in_jump_targets = settings.value("disassembly.show_local_module_name_in_jump_targets.enabled", true).value<bool>();
 	settings.endGroup();
 
 	settings.beginGroup("Directories");
@@ -189,6 +190,7 @@ void Configuration::write_settings() {
 	settings.setValue("disassembly.uppercase.enabled", uppercase_disassembly);
 	settings.setValue("disassembly.small_int_as_decimal.enabled", small_int_as_decimal);
 	settings.setValue("disassembly.tab_between_mnemonic_and_operands.enabled", tab_between_mnemonic_and_operands);
+	settings.setValue("disassembly.show_local_module_name_in_jump_targets.enabled", show_local_module_name_in_jump_targets);
 	settings.endGroup();
 
 	settings.beginGroup("Directories");

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -105,6 +105,7 @@ void Configuration::read_settings() {
 	zeros_are_filling     = settings.value("disassembly.zeros_are_filling.enabled", true).value<bool>();
 	uppercase_disassembly = settings.value("disassembly.uppercase.enabled", false).value<bool>();
 	small_int_as_decimal  = settings.value("disassembly.small_int_as_decimal.enabled", false).value<bool>();
+	tab_between_mnemonic_and_operands=settings.value("disassembly.tab_between_mnemonic_and_operands.enabled", false).value<bool>();
 	settings.endGroup();
 
 	settings.beginGroup("Directories");
@@ -141,6 +142,7 @@ void Configuration::read_settings() {
 	options.capitalization = uppercase_disassembly ? CapstoneEDB::Formatter::UpperCase : CapstoneEDB::Formatter::LowerCase;
 	options.smallNumFormat = small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;
 	options.syntax=static_cast<CapstoneEDB::Formatter::Syntax>(syntax);
+	options.tabBetweenMnemonicAndOperands=tab_between_mnemonic_and_operands;
 	edb::v1::formatter().setOptions(options);	
 }
 
@@ -186,6 +188,7 @@ void Configuration::write_settings() {
 	settings.setValue("disassembly.zeros_are_filling.enabled", zeros_are_filling);
 	settings.setValue("disassembly.uppercase.enabled", uppercase_disassembly);
 	settings.setValue("disassembly.small_int_as_decimal.enabled", small_int_as_decimal);
+	settings.setValue("disassembly.tab_between_mnemonic_and_operands.enabled", tab_between_mnemonic_and_operands);
 	settings.endGroup();
 
 	settings.beginGroup("Directories");

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -107,6 +107,7 @@ void Configuration::read_settings() {
 	small_int_as_decimal  = settings.value("disassembly.small_int_as_decimal.enabled", false).value<bool>();
 	tab_between_mnemonic_and_operands=settings.value("disassembly.tab_between_mnemonic_and_operands.enabled", false).value<bool>();
 	show_local_module_name_in_jump_targets = settings.value("disassembly.show_local_module_name_in_jump_targets.enabled", true).value<bool>();
+	simplify_rip_relative_targets = settings.value("disassembly.simplify_rip_relative_targets.enabled", true).value<bool>();
 	settings.endGroup();
 
 	settings.beginGroup("Directories");
@@ -144,6 +145,7 @@ void Configuration::read_settings() {
 	options.smallNumFormat = small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;
 	options.syntax=static_cast<CapstoneEDB::Formatter::Syntax>(syntax);
 	options.tabBetweenMnemonicAndOperands=tab_between_mnemonic_and_operands;
+	options.simplifyRIPRelativeTargets=simplify_rip_relative_targets;
 	edb::v1::formatter().setOptions(options);	
 }
 
@@ -191,6 +193,7 @@ void Configuration::write_settings() {
 	settings.setValue("disassembly.small_int_as_decimal.enabled", small_int_as_decimal);
 	settings.setValue("disassembly.tab_between_mnemonic_and_operands.enabled", tab_between_mnemonic_and_operands);
 	settings.setValue("disassembly.show_local_module_name_in_jump_targets.enabled", show_local_module_name_in_jump_targets);
+	settings.setValue("disassembly.simplify_rip_relative_targets.enabled", simplify_rip_relative_targets);
 	settings.endGroup();
 
 	settings.beginGroup("Directories");

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -202,6 +202,8 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->chkAddressColon->setChecked(config.show_address_separator);
 
 	ui->signalsMessageBoxEnable->setChecked(config.enable_signals_message_box);
+
+	ui->chkTabBetweenMnemonicAndOperands->setChecked(config.tab_between_mnemonic_and_operands);
 }
 
 //------------------------------------------------------------------------------
@@ -217,6 +219,8 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	} else if(ui->rdoSytntaxATT->isChecked()) {
 		config.syntax = Configuration::ATT;
 	}
+
+	config.tab_between_mnemonic_and_operands=ui->chkTabBetweenMnemonicAndOperands->isChecked();
 
 	if(ui->rdoDetach->isChecked()) {
 		config.close_behavior = Configuration::Detach;
@@ -265,6 +269,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	options.capitalization = config.uppercase_disassembly ? CapstoneEDB::Formatter::UpperCase : CapstoneEDB::Formatter::LowerCase;
 	options.smallNumFormat = config.small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;
 	options.syntax=static_cast<CapstoneEDB::Formatter::Syntax>(config.syntax);
+	options.tabBetweenMnemonicAndOperands=config.tab_between_mnemonic_and_operands;
 	edb::v1::formatter().setOptions(options);
 
 	config.enable_signals_message_box = ui->signalsMessageBoxEnable->isChecked();

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -204,6 +204,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->signalsMessageBoxEnable->setChecked(config.enable_signals_message_box);
 
 	ui->chkTabBetweenMnemonicAndOperands->setChecked(config.tab_between_mnemonic_and_operands);
+	ui->chkShowLocalModuleName->setChecked(config.show_local_module_name_in_jump_targets);
 }
 
 //------------------------------------------------------------------------------
@@ -221,6 +222,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	}
 
 	config.tab_between_mnemonic_and_operands=ui->chkTabBetweenMnemonicAndOperands->isChecked();
+	config.show_local_module_name_in_jump_targets=ui->chkShowLocalModuleName->isChecked();
 
 	if(ui->rdoDetach->isChecked()) {
 		config.close_behavior = Configuration::Detach;

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -205,6 +205,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 
 	ui->chkTabBetweenMnemonicAndOperands->setChecked(config.tab_between_mnemonic_and_operands);
 	ui->chkShowLocalModuleName->setChecked(config.show_local_module_name_in_jump_targets);
+	ui->chkSimplifyRIPRelativeTargets->setChecked(config.simplify_rip_relative_targets);
 }
 
 //------------------------------------------------------------------------------
@@ -223,6 +224,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 
 	config.tab_between_mnemonic_and_operands=ui->chkTabBetweenMnemonicAndOperands->isChecked();
 	config.show_local_module_name_in_jump_targets=ui->chkShowLocalModuleName->isChecked();
+	config.simplify_rip_relative_targets=ui->chkSimplifyRIPRelativeTargets->isChecked();
 
 	if(ui->rdoDetach->isChecked()) {
 		config.close_behavior = Configuration::Detach;
@@ -272,6 +274,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	options.smallNumFormat = config.small_int_as_decimal  ? CapstoneEDB::Formatter::SmallNumAsDec : CapstoneEDB::Formatter::SmallNumAsHex;
 	options.syntax=static_cast<CapstoneEDB::Formatter::Syntax>(config.syntax);
 	options.tabBetweenMnemonicAndOperands=config.tab_between_mnemonic_and_operands;
+	options.simplifyRIPRelativeTargets=config.simplify_rip_relative_targets;
 	edb::v1::formatter().setOptions(options);
 
 	config.enable_signals_message_box = ui->signalsMessageBoxEnable->isChecked();

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -547,6 +547,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkShowLocalModuleName">
+         <property name="text">
+          <string>Show local module name in jump targets</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkSyntaxHighlighting">
          <property name="text">
           <string>Enable syntax highlighting</string>

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -518,7 +518,7 @@
        <item>
         <widget class="QCheckBox" name="chkZerosAreFilling">
          <property name="text">
-          <string>Instruction &quot;add byte ptr[eax], al&quot; (0x00 0x00) is &quot;Filling&quot; on x86</string>
+          <string>Instruction &quot;add [eax], al&quot; (0x00 0x00) is &quot;Filling&quot; on x86</string>
          </property>
         </widget>
        </item>

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -554,6 +554,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkSimplifyRIPRelativeTargets">
+         <property name="text">
+          <string>Show RIP-relative targets as [rel TargetAddress] instead of [rip+Displacement]</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkSyntaxHighlighting">
          <property name="text">
           <string>Enable syntax highlighting</string>

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -540,6 +540,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkTabBetweenMnemonicAndOperands">
+         <property name="text">
+          <string>Tab between mnemonic and operands</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkSyntaxHighlighting">
          <property name="text">
           <string>Enable syntax highlighting</string>

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -293,14 +293,14 @@ void SymbolManager::set_label(edb::address_t address, const QString &label) {
 // Name: find_address_name
 // Desc:
 //------------------------------------------------------------------------------
-QString SymbolManager::find_address_name(edb::address_t address) {
+QString SymbolManager::find_address_name(edb::address_t address,bool prefixed) {
 	auto it = labels_.find(address);
 	if(it != labels_.end()) {
 		return it.value();
 	}
 
 	if(const Symbol::pointer sym = find(address)) {
-		return sym->name;
+		return prefixed ? sym->name : sym->name_no_prefix;
 	}
 
 	return QString();

--- a/src/SymbolManager.h
+++ b/src/SymbolManager.h
@@ -39,7 +39,7 @@ public:
 	virtual void load_symbol_file(const QString &filename, edb::address_t base);
 	virtual void set_symbol_generator(ISymbolGenerator *generator);
 	virtual void set_label(edb::address_t address, const QString &label);
-	virtual QString find_address_name(edb::address_t address);
+	virtual QString find_address_name(edb::address_t address,bool prefixed=true) override;
 	virtual QHash<edb::address_t, QString> labels() const;
 	virtual QList<QString> files() const;
 

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -657,10 +657,18 @@ std::string Formatter::to_string(const Instruction& instruction) const
 	s << instruction.insn_.mnemonic;
 	if(instruction.operand_count()>0) // prevent addition of trailing whitespace
 	{
-		const auto pos = s.tellp();
-		const auto pad = pos<tab1Size ? tab1Size-pos : pos<tab2Size ? tab2Size-pos : 1;
-		s << std::string(pad,' ');
+		if(options_.tabBetweenMnemonicAndOperands)
+		{
+			const auto pos = s.tellp();
+			const auto pad = pos<tab1Size ? tab1Size-pos : pos<tab2Size ? tab2Size-pos : 1;
+			s << std::string(pad,' ');
+		}
+		else s << ' ';
 		s << instruction.insn_.op_str;
+	}
+	else
+	{
+		assert(instruction.insn_.op_str[0]==0);
 	}
 	auto str = s.str();
 	checkCapitalize(str);

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -146,7 +146,7 @@ void adjustInstructionText(Capstone::cs_insn& insn)
 	operands.replace(QRegExp("\\bxword "),"tbyte ");
 	operands.replace(QRegExp("(word|byte) ptr "),"\\1 ");
 
-	if(isAMD64 && (insn.detail->x86.modrm&0xc7)==0x05)
+	if(activeFormatter.options().simplifyRIPRelativeTargets && isAMD64 && (insn.detail->x86.modrm&0xc7)==0x05)
 	{
 		QRegExp ripRel("\\brip ?[+-] ?((0x)?[0-9a-fA-F]+)\\b");
 		operands.replace(ripRel,"rel 0x"+QString::number(insn.detail->x86.disp+insn.address+insn.size,16));

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -647,7 +647,7 @@ void Formatter::setOptions(const Formatter::FormatOptions& options)
 std::string Formatter::to_string(const Instruction& instruction) const
 {
 	if(!instruction) return "(bad)";
-
+	
 	enum
 	{
 		tab1Size=8,
@@ -655,10 +655,13 @@ std::string Formatter::to_string(const Instruction& instruction) const
 	};
 	std::ostringstream s;
 	s << instruction.insn_.mnemonic;
-	const auto pos = s.tellp();
-	const auto pad = pos<tab1Size ? tab1Size-pos : pos<tab2Size ? tab2Size-pos : 1;
-	s << std::string(pad,' ');
-	s << instruction.insn_.op_str;
+	if(instruction.operand_count()>0) // prevent addition of trailing whitespace
+	{
+		const auto pos = s.tellp();
+		const auto pad = pos<tab1Size ? tab1Size-pos : pos<tab2Size ? tab2Size-pos : 1;
+		s << std::string(pad,' ');
+		s << instruction.insn_.op_str;
+	}
 	auto str = s.str();
 	checkCapitalize(str);
 	return str;

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -146,6 +146,12 @@ void adjustInstructionText(Capstone::cs_insn& insn)
 	operands.replace(QRegExp("\\bxword "),"tbyte ");
 	operands.replace(QRegExp("(word|byte) ptr "),"\\1 ");
 
+	if(isAMD64 && (insn.detail->x86.modrm&0xc7)==0x05)
+	{
+		QRegExp ripRel("\\brip ?[+-] ?((0x)?[0-9a-fA-F]+)\\b");
+		operands.replace(ripRel,"rel 0x"+QString::number(insn.detail->x86.disp+insn.address+insn.size,16));
+	}
+
 	strcpy(insn.op_str,operands.toStdString().c_str());
 }
 

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QRegExp>
 #include <stdexcept>
 #include "Util.h"
+#include <sstream>
 
 namespace CapstoneEDB {
 
@@ -647,7 +648,18 @@ std::string Formatter::to_string(const Instruction& instruction) const
 {
 	if(!instruction) return "(bad)";
 
-	std::string str(std::string(instruction.insn_.mnemonic)+" "+instruction.insn_.op_str);
+	enum
+	{
+		tab1Size=8,
+		tab2Size=11,
+	};
+	std::ostringstream s;
+	s << instruction.insn_.mnemonic;
+	const auto pos = s.tellp();
+	const auto pad = pos<tab1Size ? tab1Size-pos : pos<tab2Size ? tab2Size-pos : 1;
+	s << std::string(pad,' ');
+	s << instruction.insn_.op_str;
+	auto str = s.str();
 	checkCapitalize(str);
 	return str;
 }

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -279,6 +279,7 @@ public:
 		Capitalization    capitalization;
 		SmallNumberFormat smallNumFormat;
 		bool 			  tabBetweenMnemonicAndOperands;
+		bool			  simplifyRIPRelativeTargets;
 	};
 public:
 	std::string to_string(const Instruction&) const;
@@ -288,7 +289,7 @@ public:
 	FormatOptions options() const { return options_; }
 	void setOptions(const FormatOptions& options);
 private:
-	FormatOptions options_={SyntaxIntel,LowerCase,SmallNumAsDec,false};
+	FormatOptions options_={SyntaxIntel,LowerCase,SmallNumAsDec,false,true};
 
 	void checkCapitalize(std::string& str,bool canContainHex=true) const;
 };

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -278,6 +278,7 @@ public:
 		Syntax            syntax;
 		Capitalization    capitalization;
 		SmallNumberFormat smallNumFormat;
+		bool 			  tabBetweenMnemonicAndOperands;
 	};
 public:
 	std::string to_string(const Instruction&) const;
@@ -287,7 +288,7 @@ public:
 	FormatOptions options() const { return options_; }
 	void setOptions(const FormatOptions& options);
 private:
-	FormatOptions options_={SyntaxIntel,LowerCase,SmallNumAsDec};
+	FormatOptions options_={SyntaxIntel,LowerCase,SmallNumAsDec,false};
 
 	void checkCapitalize(std::string& str,bool canContainHex=true) const;
 };

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -565,7 +565,8 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 					if(oper.general_type() == edb::Operand::TYPE_REL) {
 						const edb::address_t target = oper.relative_target();
 
-						const bool prefixed=!targetIsLocal(target,inst.rva());
+						const bool showLocalModuleNames=edb::v1::config().show_local_module_name_in_jump_targets;
+						const bool prefixed=showLocalModuleNames || !targetIsLocal(target,inst.rva());
 						const QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
 						if(!sym.isEmpty()) {
 							opcode.append(QString(" <%2>").arg(sym));

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IDebugger.h"
 #include "ISymbolManager.h"
 #include "Instruction.h"
+#include "MemoryRegions.h"
 #include "SyntaxHighlighter.h"
 #include "Util.h"
 
@@ -520,6 +521,13 @@ void QDisassemblyView::scrollTo(edb::address_t address) {
 	verticalScrollBar()->setValue(address - address_offset_);
 }
 
+bool targetIsLocal(edb::address_t targetAddress,edb::address_t insnAddress) {
+
+	const auto insnRegion=edb::v1::memory_regions().find_region(insnAddress);
+	const auto targetRegion=edb::v1::memory_regions().find_region(targetAddress);
+	return insnRegion->compare(targetRegion)==0;
+}
+
 //------------------------------------------------------------------------------
 // Name: draw_instruction
 // Desc:
@@ -557,7 +565,8 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 					if(oper.general_type() == edb::Operand::TYPE_REL) {
 						const edb::address_t target = oper.relative_target();
 
-						const QString sym = edb::v1::symbol_manager().find_address_name(target);
+						const bool prefixed=!targetIsLocal(target,inst.rva());
+						const QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
 						if(!sym.isEmpty()) {
 							opcode.append(QString(" <%2>").arg(sym));
 						}


### PR DESCRIPTION
This adds some options for instruction formatting

1. Alignment of operands (tab-like; two tab stops for short and long instructions)
2. Avoiding extraneous display of local module names in jump/call targets (e.g. `<_dl_start>` instead of `<ld-2.14.1.so!_dl_start>` when called from within `ld-2.14.1.so`)
3. Transformation of `[rip+0xd1521ace]` into `[rel 0xad7e55]`.