### PR TITLE
Set focus to hex entry by default in binary string editor.

### DIFF
--- a/src/BinaryString.cpp
+++ b/src/BinaryString.cpp
@@ -67,6 +67,7 @@ BinaryString::BinaryString(QWidget *parent) : QWidget(parent),
 	ui->setupUi(this);
 	ui->txtHex->setValidator(new HexStringValidator(this));
 	ui->keepSize->setFocusPolicy(Qt::TabFocus);
+	ui->txtHex->setFocus(Qt::OtherFocusReason);
 	connect(ui->keepSize,SIGNAL(stateChanged(int)),this,SLOT(on_keepSize_stateChanged()));
 }
 


### PR DESCRIPTION
Binary string is almost always used to enter hex data, not text. This also matches the defaults of OllyDbg.