### PR TITLE
Detach and kill

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -35,7 +35,7 @@ public:
 
 	enum CloseBehavior {
 		Detach,
-		Terminate
+		Kill
 	};
 
 	enum InitialBreakpoint {

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -35,7 +35,8 @@ public:
 
 	enum CloseBehavior {
 		Detach,
-		Kill
+		Kill,
+		KillIfLaunchedDetachIfAttached
 	};
 
 	enum InitialBreakpoint {

--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -76,6 +76,7 @@ public:
 	virtual IDebugEvent::const_pointer wait_debug_event(int msecs) = 0;
 	virtual void detach() = 0;
 	virtual void kill() = 0;
+	virtual void end_debug_session() = 0;
 	virtual void get_state(State *state) = 0;	
 	virtual void set_state(const State &state) = 0;
 

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -113,6 +113,12 @@ void DebuggerCoreBase::end_debug_session() {
 		case Configuration::Kill:
 			kill();
 			break;
+		case Configuration::KillIfLaunchedDetachIfAttached:
+			if(last_means_of_capture()==MeansOfCapture::Launch)
+				kill();
+			else
+				detach();
+			break;
 		}
 	}
 }

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -18,6 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DebuggerCoreBase.h"
 #include "Breakpoint.h"
+#include "Configuration.h"
+#include "edb.h"
 
 namespace DebuggerCore {
 
@@ -92,6 +94,25 @@ void DebuggerCoreBase::remove_breakpoint(edb::address_t address) {
 		auto it = breakpoints_.find(address);
 		if(it != breakpoints_.end()) {
 			breakpoints_.erase(it);
+		}
+	}
+}
+
+//------------------------------------------------------------------------------
+// Name: end_debug_session
+// Desc: Ends debug session, detaching from or killing debuggee according to
+//		 user preferences
+//------------------------------------------------------------------------------
+void DebuggerCoreBase::end_debug_session() {
+	if(attached()) {
+		switch(edb::v1::config().close_behavior)
+		{
+		case Configuration::Detach:
+			detach();
+			break;
+		case Configuration::Kill:
+			kill();
+			break;
 		}
 	}
 }

--- a/plugins/DebuggerCore/DebuggerCoreBase.h
+++ b/plugins/DebuggerCore/DebuggerCoreBase.h
@@ -38,6 +38,7 @@ public:
 	virtual IBreakpoint::pointer find_breakpoint(edb::address_t address);
 	virtual void clear_breakpoints();
 	virtual void remove_breakpoint(edb::address_t address);
+	virtual void end_debug_session() override;
 
 public:
 	virtual edb::pid_t pid() const;

--- a/plugins/DebuggerCore/DebuggerCoreBase.h
+++ b/plugins/DebuggerCore/DebuggerCoreBase.h
@@ -31,6 +31,13 @@ public:
 public:
 	virtual QString open(const QString &path, const QString &cwd, const QList<QByteArray> &args) override;
 	virtual QString open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty) = 0;
+	enum class MeansOfCapture
+	{
+		NeverCaptured,
+		Attach,
+		Launch
+	};
+	virtual MeansOfCapture last_means_of_capture() = 0;
 
 public:
 	virtual BreakpointList backup_breakpoints() const;

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -456,6 +456,8 @@ bool DebuggerCore::attach_thread(edb::tid_t tid) {
 //------------------------------------------------------------------------------
 bool DebuggerCore::attach(edb::pid_t pid) {
 	end_debug_session();
+
+	lastMeansOfCapture=MeansOfCapture::Attach;
 	
 	// create this, so the threads created can refer to it
 	process_ = new PlatformProcess(this, pid);
@@ -595,6 +597,8 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 
 	end_debug_session();
 
+	lastMeansOfCapture=MeansOfCapture::Launch;
+
 	static constexpr std::size_t sharedMemSize=4096;
 	const auto sharedMem=static_cast<QChar*>(::mmap(nullptr,sharedMemSize,PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1,0));
 	std::memset(sharedMem,0,sharedMemSize);
@@ -704,6 +708,15 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 		} while(0);
 		break;
 	}
+}
+
+
+//------------------------------------------------------------------------------
+// Name: last_means_of_capture
+// Desc: Returns how the last process was captured to debug
+//------------------------------------------------------------------------------
+DebuggerCore::MeansOfCapture DebuggerCore::last_means_of_capture() {
+	return lastMeansOfCapture;
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -201,7 +201,7 @@ std::size_t DebuggerCore::pointer_size() const {
 // Desc: destructor
 //------------------------------------------------------------------------------
 DebuggerCore::~DebuggerCore() {
-	detach();
+	end_debug_session();
 }
 
 //------------------------------------------------------------------------------
@@ -455,7 +455,7 @@ bool DebuggerCore::attach_thread(edb::tid_t tid) {
 // Desc:
 //------------------------------------------------------------------------------
 bool DebuggerCore::attach(edb::pid_t pid) {
-	detach();
+	end_debug_session();
 	
 	// create this, so the threads created can refer to it
 	process_ = new PlatformProcess(this, pid);
@@ -593,7 +593,7 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 
 	static const QString statusOK{};
 
-	detach();
+	end_debug_session();
 
 	static constexpr std::size_t sharedMemSize=4096;
 	const auto sharedMem=static_cast<QChar*>(::mmap(nullptr,sharedMemSize,PROT_READ|PROT_WRITE,MAP_SHARED|MAP_ANONYMOUS,-1,0));
@@ -658,7 +658,7 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 
 			// the very first event should be a STOP of type SIGTRAP
 			if(!WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP) {
-				detach();
+				end_debug_session();
 				return QObject::tr("First event after waitpid() should be a STOP of type SIGTRAP, but wasn't, instead status=0x%1")
 											.arg(status,0,16)+(childError.isEmpty()?"":QObject::tr(".\nError returned by child:\n%1.").arg(childError));
 			}
@@ -667,15 +667,15 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 
 			// enable following clones (threads)
 			if(ptrace_set_options(pid, PTRACE_O_TRACECLONE) == -1) {
-				const auto strerr=strerror(errno); // NOTE: must be called before detach, otherwise errno can change
-				detach();
+				const auto strerr=strerror(errno); // NOTE: must be called before end_debug_session, otherwise errno can change
+				end_debug_session();
 				return QObject::tr("[DebuggerCore] failed to set PTRACE_O_TRACECLONE: %1").arg(strerr);
 			}
 			
 #ifdef PTRACE_O_EXITKILL
 			if(ptrace_set_options(pid, PTRACE_O_EXITKILL) == -1) {
-				const auto strerr=strerror(errno); // NOTE: must be called before detach, otherwise errno can change
-				detach();
+				const auto strerr=strerror(errno); // NOTE: must be called before end_debug_session, otherwise errno can change
+				end_debug_session();
 				return QObject::tr("[DebuggerCore] failed to set PTRACE_O_EXITKILL: %1").arg(strerr);
 			}
 #endif

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -58,6 +58,7 @@ public:
 	virtual void get_state(State *state);
 	virtual void set_state(const State &state);
 	virtual QString open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty) override;
+	virtual MeansOfCapture last_means_of_capture() override;
 	
 public:
 	virtual edb::pid_t parent_pid(edb::pid_t pid) const;
@@ -113,6 +114,7 @@ private:
 	const edb::seg_reg_t USER_CS_32;
 	const edb::seg_reg_t USER_CS_64;
 	const edb::seg_reg_t USER_SS;
+	MeansOfCapture	 lastMeansOfCapture=MeansOfCapture::NeverCaptured;
 };
 
 }

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -397,7 +397,7 @@ Debugger::Debugger(QWidget *parent) : QMainWindow(parent),
 //------------------------------------------------------------------------------
 Debugger::~Debugger() {
 
-	detach_from_process((edb::v1::config().close_behavior == Configuration::Terminate) ? KILL_ON_DETACH : NO_KILL_ON_DETACH);
+	detach_from_process((edb::v1::config().close_behavior == Configuration::Kill) ? KILL_ON_DETACH : NO_KILL_ON_DETACH);
 
 	// kill our xterm and wait for it to die
 	tty_proc_->kill();

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -397,7 +397,8 @@ Debugger::Debugger(QWidget *parent) : QMainWindow(parent),
 //------------------------------------------------------------------------------
 Debugger::~Debugger() {
 
-	detach_from_process((edb::v1::config().close_behavior == Configuration::Kill) ? KILL_ON_DETACH : NO_KILL_ON_DETACH);
+	if(const auto& dc=edb::v1::debugger_core)
+		dc->end_debug_session();
 
 	// kill our xterm and wait for it to die
 	tty_proc_->kill();
@@ -990,7 +991,6 @@ void Debugger::dropEvent(QDropEvent* event) {
 		if(!s.isEmpty()) {
 			Q_ASSERT(edb::v1::debugger_core);
 
-			detach_from_process(KILL_ON_DETACH);
 			common_open(s, QList<QByteArray>());
 		}
 	}
@@ -2886,8 +2886,6 @@ void Debugger::open_file(const QString &s) {
 	if(!s.isEmpty()) {
 		last_open_directory_ = QFileInfo(s).canonicalFilePath();
 
-		detach_from_process(NO_KILL_ON_DETACH);
-
 		execute(s, arguments_dialog_->arguments());
 	}
 }
@@ -2926,8 +2924,6 @@ void Debugger::attach(edb::pid_t pid) {
 	}
 
 
-	detach_from_process(NO_KILL_ON_DETACH);
-	
 	if(edb::v1::debugger_core->attach(pid)) {
 
 		working_directory_ = edb::v1::debugger_core->process()->current_working_directory();

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -229,7 +229,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	if(ui->rdoDetach->isChecked()) {
 		config.close_behavior = Configuration::Detach;
 	} else if(ui->rdoKill->isChecked()) {
-		config.close_behavior = Configuration::Terminate;
+		config.close_behavior = Configuration::Kill;
 	}
 
 	config.stack_font            = ui->stackFont->currentFont().toString();

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -163,7 +163,8 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->rdoSytntaxIntel->setChecked(config.syntax != Configuration::ATT);
 
 	ui->rdoDetach->setChecked(config.close_behavior == Configuration::Detach);
-	ui->rdoKill->setChecked(config.close_behavior != Configuration::Detach);
+	ui->rdoKill->setChecked(config.close_behavior == Configuration::Kill);
+	ui->rdoReverseCapture->setChecked(config.close_behavior == Configuration::KillIfLaunchedDetachIfAttached);
 
 	ui->rdoBPEntry->setChecked(config.initial_breakpoint == Configuration::EntryPoint);
 	ui->rdoBPMain->setChecked(config.initial_breakpoint != Configuration::EntryPoint);
@@ -230,6 +231,8 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 		config.close_behavior = Configuration::Detach;
 	} else if(ui->rdoKill->isChecked()) {
 		config.close_behavior = Configuration::Kill;
+	} else if(ui->rdoReverseCapture->isChecked()) {
+		config.close_behavior = Configuration::KillIfLaunchedDetachIfAttached;
 	}
 
 	config.stack_font            = ui->stackFont->currentFont().toString();

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -53,7 +53,7 @@
           <item>
            <widget class="QRadioButton" name="rdoKill">
             <property name="text">
-             <string>Terminate Debugged Application</string>
+             <string>Kill Debugged Application</string>
             </property>
            </widget>
           </item>

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -57,6 +57,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QRadioButton" name="rdoReverseCapture">
+            <property name="text">
+             <string>Detach If Debugged Application Was Attached To, Kill If Launched</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/lang/edb_en.ts
+++ b/src/lang/edb_en.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <location filename="../DialogOptions.ui" line="56"/>
-        <source>Terminate Debugged Application</source>
+        <source>Kill Debugged Application</source>
         <translation></translation>
     </message>
     <message>


### PR DESCRIPTION
This fixes #377 and adds a third option of close behavior: kill if launched, detach if attached.