### PR TITLE
Show better symbolic addresses

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -77,6 +77,7 @@ public:
 	bool              small_int_as_decimal;
 	bool			  tab_between_mnemonic_and_operands;
 	bool			  show_local_module_name_in_jump_targets;
+	bool			  show_symbolic_addresses;
 	bool			  simplify_rip_relative_targets;
 
 	// directories tab

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -107,6 +107,7 @@ void Configuration::read_settings() {
 	small_int_as_decimal  = settings.value("disassembly.small_int_as_decimal.enabled", false).value<bool>();
 	tab_between_mnemonic_and_operands=settings.value("disassembly.tab_between_mnemonic_and_operands.enabled", false).value<bool>();
 	show_local_module_name_in_jump_targets = settings.value("disassembly.show_local_module_name_in_jump_targets.enabled", true).value<bool>();
+	show_symbolic_addresses = settings.value("disassembly.show_symbolic_addresses.enabled", true).value<bool>();
 	simplify_rip_relative_targets = settings.value("disassembly.simplify_rip_relative_targets.enabled", true).value<bool>();
 	settings.endGroup();
 
@@ -193,6 +194,7 @@ void Configuration::write_settings() {
 	settings.setValue("disassembly.small_int_as_decimal.enabled", small_int_as_decimal);
 	settings.setValue("disassembly.tab_between_mnemonic_and_operands.enabled", tab_between_mnemonic_and_operands);
 	settings.setValue("disassembly.show_local_module_name_in_jump_targets.enabled", show_local_module_name_in_jump_targets);
+	settings.setValue("disassembly.show_symbolic_addresses.enabled", show_symbolic_addresses);
 	settings.setValue("disassembly.simplify_rip_relative_targets.enabled", simplify_rip_relative_targets);
 	settings.endGroup();
 

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -206,6 +206,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 
 	ui->chkTabBetweenMnemonicAndOperands->setChecked(config.tab_between_mnemonic_and_operands);
 	ui->chkShowLocalModuleName->setChecked(config.show_local_module_name_in_jump_targets);
+	ui->chkShowSymbolicAddresses->setChecked(config.show_symbolic_addresses);
 	ui->chkSimplifyRIPRelativeTargets->setChecked(config.simplify_rip_relative_targets);
 }
 
@@ -225,6 +226,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 
 	config.tab_between_mnemonic_and_operands=ui->chkTabBetweenMnemonicAndOperands->isChecked();
 	config.show_local_module_name_in_jump_targets=ui->chkShowLocalModuleName->isChecked();
+	config.show_symbolic_addresses=ui->chkShowSymbolicAddresses->isChecked();
 	config.simplify_rip_relative_targets=ui->chkSimplifyRIPRelativeTargets->isChecked();
 
 	if(ui->rdoDetach->isChecked()) {

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -561,6 +561,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkShowSymbolicAddresses">
+         <property name="text">
+          <string>Show symbolic addresses</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkSimplifyRIPRelativeTargets">
          <property name="text">
           <string>Show RIP-relative targets as [rel TargetAddress] instead of [rip+Displacement]</string>

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -568,20 +568,20 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 
 						static const QRegExp addrPattern("0x[0-9a-fA-F]+");
 						const edb::address_t target = oper.relative_target();
-						if(showSymbolicAddresses && target==inst.size()+inst.rva()) {
-							opcode.replace(addrPattern,"<next instruction>");
-						} else if(showSymbolicAddresses && target==inst.rva()) {
-							opcode.replace(addrPattern,"$");
-						} else {
-							const bool showLocalModuleNames=edb::v1::config().show_local_module_name_in_jump_targets;
-							const bool prefixed=showLocalModuleNames || !targetIsLocal(target,inst.rva());
-							const QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
-							if(!sym.isEmpty()) {
-								if(showSymbolicAddresses)
-									opcode.replace(addrPattern,sym);
-								else
-									opcode.append(QString(" <%2>").arg(sym));
-							}
+
+						const bool showLocalModuleNames=edb::v1::config().show_local_module_name_in_jump_targets;
+						const bool prefixed=showLocalModuleNames || !targetIsLocal(target,inst.rva());
+						QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
+						if(sym.isEmpty() && target==inst.size()+inst.rva())
+							sym=(showSymbolicAddresses?"<":"")+QString("next instruction")+(showSymbolicAddresses?">":"");
+						else if(sym.isEmpty() && target==inst.rva())
+							sym=showSymbolicAddresses ? "$" : "current instruction";
+
+						if(!sym.isEmpty()) {
+							if(showSymbolicAddresses)
+								opcode.replace(addrPattern,sym);
+							else
+								opcode.append(QString(" <%2>").arg(sym));
 						}
 					}
 				}

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -560,16 +560,28 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 		} else {
 
 			if(is_call(inst) || is_jump(inst)) {
-				if(inst.operand_count() != 0) {
+				if(inst.operand_count() == 1) {
 					const edb::Operand &oper = inst.operands()[0];
 					if(oper.general_type() == edb::Operand::TYPE_REL) {
-						const edb::address_t target = oper.relative_target();
 
-						const bool showLocalModuleNames=edb::v1::config().show_local_module_name_in_jump_targets;
-						const bool prefixed=showLocalModuleNames || !targetIsLocal(target,inst.rva());
-						const QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
-						if(!sym.isEmpty()) {
-							opcode.append(QString(" <%2>").arg(sym));
+						const bool showSymbolicAddresses=edb::v1::config().show_symbolic_addresses;
+
+						static const QRegExp addrPattern("0x[0-9a-fA-F]+");
+						const edb::address_t target = oper.relative_target();
+						if(showSymbolicAddresses && target==inst.size()+inst.rva()) {
+							opcode.replace(addrPattern,"<next instruction>");
+						} else if(showSymbolicAddresses && target==inst.rva()) {
+							opcode.replace(addrPattern,"$");
+						} else {
+							const bool showLocalModuleNames=edb::v1::config().show_local_module_name_in_jump_targets;
+							const bool prefixed=showLocalModuleNames || !targetIsLocal(target,inst.rva());
+							const QString sym = edb::v1::symbol_manager().find_address_name(target,prefixed);
+							if(!sym.isEmpty()) {
+								if(showSymbolicAddresses)
+									opcode.replace(addrPattern,sym);
+								else
+									opcode.append(QString(" <%2>").arg(sym));
+							}
 						}
 					}
 				}

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -896,14 +896,16 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 			if(inst.operands()[0].general_type() == edb::Operand::TYPE_REL) {
 				const edb::address_t target = inst.operands()[0].relative_target();
 
-				painter.drawText(
-					l2 + font_width_ + (font_width_ / 2),
-					y,
-					font_width_,
-					line_height,
-					Qt::AlignVCenter,
-					QString((target > address) ? QChar(0x2304) : QChar(0x2303))
-					);
+				if(target!=inst.rva()) {
+					painter.drawText(
+						l2 + font_width_ + (font_width_ / 2),
+						y,
+						font_width_,
+						line_height,
+						Qt::AlignVCenter,
+						QString((target > address) ? QChar(0x2304) : QChar(0x2303))
+						);
+				}
 			}
 		}
 


### PR DESCRIPTION
This adds an option to see call/jump targets symbolically, like `call _dl_start` instead of `call 0xf76f8160 <_dl_start>`. Also, instead of `jmp $sym_0x080486d0` we'll now see something more like `jmp .plt`, since unnamed symbols are now named according to the name of the section they are in.