### PR TITLE
Fix comparison of regions to determine whether target is local

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -525,7 +525,7 @@ bool targetIsLocal(edb::address_t targetAddress,edb::address_t insnAddress) {
 
 	const auto insnRegion=edb::v1::memory_regions().find_region(insnAddress);
 	const auto targetRegion=edb::v1::memory_regions().find_region(targetAddress);
-	return insnRegion->compare(targetRegion)==0;
+	return !insnRegion->name().isEmpty() && targetRegion && insnRegion->name()==targetRegion->name();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
We use this function to avoid filename prefix when it's not needed. But the same file may have multiple regions, e.g. .text and .data. This doesn't make the reference from code to data non-local, since the prefix would be the same. So it's more correct to compare region names.

This will make a difference if/when EDB is able to show data references in symbolic form too.