### PR TITLE
Fix reading user stat for 64-bit processes in 32-bit EDB

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
@@ -59,7 +59,7 @@ int get_user_stat(const QString &path, struct user_stat *user_stat) {
 		const QString line = in.readLine();
 		if(!line.isNull()) {
 			char ch;
-			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_ #~/-]%c %c %d %d %d %d %d %u %lu %lu %lu %lu %lu %lu %ld %ld %ld %ld %ld %ld %llu %lu %ld %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %d %d %u %u %llu %lu %ld",
+			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_ #~/-]%c %c %d %d %d %d %d %u %llu %llu %llu %llu %llu %llu %lld %lld %lld %lld %lld %lld %llu %llu %lld %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %d %d %u %u %llu %llu %lld",
 					&user_stat->pid,
 					&ch, // consume the (
 					user_stat->comm,

--- a/plugins/DebuggerCore/unix/linux/PlatformCommon.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformCommon.h
@@ -35,34 +35,34 @@ struct user_stat {
 /* 07 */ int tty_nr;
 /* 08 */ int tpgid;
 /* 09 */ unsigned flags;
-/* 10 */ unsigned long minflt;
-/* 11 */ unsigned long cminflt;
-/* 12 */ unsigned long majflt;
-/* 13 */ unsigned long cmajflt;
-/* 14 */ unsigned long utime;
-/* 15 */ unsigned long stime;
-/* 16 */ long cutime;
-/* 17 */ long cstime;
-/* 18 */ long priority;
-/* 19 */ long nice;
-/* 20 */ long num_threads;
-/* 21 */ long itrealvalue;
+/* 10 */ unsigned long long minflt;
+/* 11 */ unsigned long long cminflt;
+/* 12 */ unsigned long long majflt;
+/* 13 */ unsigned long long cmajflt;
+/* 14 */ unsigned long long utime;
+/* 15 */ unsigned long long stime;
+/* 16 */ long long cutime;
+/* 17 */ long long cstime;
+/* 18 */ long long priority;
+/* 19 */ long long nice;
+/* 20 */ long long num_threads;
+/* 21 */ long long itrealvalue;
 /* 22 */ unsigned long long starttime;
-/* 23 */ unsigned long vsize;
-/* 24 */ long rss;
-/* 25 */ unsigned long rsslim;
-/* 26 */ unsigned long startcode;
-/* 27 */ unsigned long endcode;
-/* 28 */ unsigned long startstack;
-/* 29 */ unsigned long kstkesp;
-/* 30 */ unsigned long kstkeip;
-/* 31 */ unsigned long signal;
-/* 32 */ unsigned long blocked;
-/* 33 */ unsigned long sigignore;
-/* 34 */ unsigned long sigcatch;
-/* 35 */ unsigned long wchan;
-/* 36 */ unsigned long nswap;
-/* 37 */ unsigned long cnswap;
+/* 23 */ unsigned long long vsize;
+/* 24 */ long long rss;
+/* 25 */ unsigned long long rsslim;
+/* 26 */ unsigned long long startcode;
+/* 27 */ unsigned long long endcode;
+/* 28 */ unsigned long long startstack;
+/* 29 */ unsigned long long kstkesp;
+/* 30 */ unsigned long long kstkeip;
+/* 31 */ unsigned long long signal;
+/* 32 */ unsigned long long blocked;
+/* 33 */ unsigned long long sigignore;
+/* 34 */ unsigned long long sigcatch;
+/* 35 */ unsigned long long wchan;
+/* 36 */ unsigned long long nswap;
+/* 37 */ unsigned long long cnswap;
 /* 38 */ int exit_signal;
 /* 39 */ int processor;
 /* 40 */ unsigned rt_priority;
@@ -72,19 +72,19 @@ struct user_stat {
 /* 42 */ unsigned long long delayacct_blkio_ticks;
 
 // Linux 2.6.24
-/* 43 */ unsigned long guest_time;
-/* 44 */ long cguest_time;
+/* 43 */ unsigned long long guest_time;
+/* 44 */ long long cguest_time;
 
 // Linux 3.3
-/* 45 */ unsigned long start_data;
-/* 46 */ unsigned long end_data;
-/* 47 */ unsigned long start_brk;
+/* 45 */ unsigned long long start_data;
+/* 46 */ unsigned long long end_data;
+/* 47 */ unsigned long long start_brk;
 
 // Linux 3.5
-/* 48 */ unsigned long arg_start;
-/* 49 */ unsigned long arg_end;
-/* 50 */ unsigned long env_start;
-/* 51 */ unsigned long env_end;
+/* 48 */ unsigned long long arg_start;
+/* 49 */ unsigned long long arg_end;
+/* 50 */ unsigned long long env_start;
+/* 51 */ unsigned long long env_end;
 /* 52 */ int exit_code;
 };
 


### PR DESCRIPTION
It doesn't make sense to use `long` in code intended to support both 64-bit and 32-bit debuggees, since its size depends on debugger itself.
This fixes #389.