### PR TITLE
Fix choice of highlighted text color to take focused state into account

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -876,11 +876,12 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 			Qt::AlignVCenter,
 			address_buffer);
 
+		const auto group=hasFocus() ? QPalette::Active : QPalette::Inactive;
 		// draw the data bytes
 		if(selectedAddress() != address) {
-			painter.setPen(palette().text().color());
+			painter.setPen(palette().color(group,QPalette::Text));
 		} else {
-			painter.setPen(palette().highlightedText().color());
+			painter.setPen(palette().color(group,QPalette::HighlightedText));
 		}
 
 		painter.drawText(


### PR DESCRIPTION
Otherwise we have still inverted color even when selection becomes duller, which is wrong (cf. treeviews behavior).