### PR TITLE
Add missing operand push_back

### DIFF
--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -191,6 +191,7 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 			operand.type_=Operand::TYPE_ABSOLUTE;
 			operand.abs_.seg=ops[0].imm;
 			operand.abs_.offset=ops[1].imm;
+			operands_.push_back(operand);
 		}
 		else for(std::size_t i=0;i<cs_insn_operand_count();++i)
 		{


### PR DESCRIPTION
Otherwise EDB will assertion-fail when trying to format `lcall` or `ljmp` disassembly.