### PR TITLE
Some improvements to error messages 

### DIFF
--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -69,8 +69,8 @@ public:
 	
 public:
 	// basic process management
-	virtual bool attach(edb::pid_t pid) = 0;
-	// These two functions return empty string on success, string with error description on error
+	// These three functions return empty string on success, string with error description on error
+	virtual QString attach(edb::pid_t pid) = 0;
 	virtual QString open(const QString &path, const QString &cwd, const QList<QByteArray> &args) = 0;
 	virtual QString open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty) = 0;
 	virtual IDebugEvent::const_pointer wait_debug_event(int msecs) = 0;

--- a/plugins/Analyzer/Analyzer.cpp
+++ b/plugins/Analyzer/Analyzer.cpp
@@ -206,7 +206,7 @@ void Analyzer::goto_function_start() {
 		return;
 	}
 
-	QMessageBox::information(
+	QMessageBox::critical(
 		0,
 		tr("Goto Function Start"),
 		tr("The selected instruction is not inside of a known function. Have you run an analysis of this region?"));
@@ -226,7 +226,7 @@ void Analyzer::goto_function_end() {
 		return;
 	}
 
-	QMessageBox::information(
+	QMessageBox::critical(
 		0,
 		tr("Goto Function End"),
 		tr("The selected instruction is not inside of a known function. Have you run an analysis of this region?"));

--- a/plugins/Backtrace/DialogBacktrace.cpp
+++ b/plugins/Backtrace/DialogBacktrace.cpp
@@ -215,7 +215,7 @@ void DialogBacktrace::on_pushButtonReturnTo_clicked()
 	//If we didn't get a valid address, then fail.
 	//TODO: Make sure "ok" actually signifies success of getting an address...
 	if (!ok) {
-		QMessageBox::information(this, tr("Error"), tr("Could not return to 0x%1").arg(QString::number(address, 16)));
+		QMessageBox::critical(this, tr("Error"), tr("Could not return to 0x%1").arg(QString::number(address, 16)));
 		return;
 	}
 	

--- a/plugins/BinaryInfo/DialogHeader.cpp
+++ b/plugins/BinaryInfo/DialogHeader.cpp
@@ -524,7 +524,7 @@ void DialogHeader::on_btnExplore_clicked() {
 	const QModelIndexList sel = selModel->selectedRows();
 
 	if(sel.size() == 0) {
-		QMessageBox::information(
+		QMessageBox::critical(
 			this,
 			tr("No Region Selected"),
 			tr("You must select a region which is to be scanned for executable headers."));

--- a/plugins/BinarySearcher/DialogASCIIString.cpp
+++ b/plugins/BinarySearcher/DialogASCIIString.cpp
@@ -96,7 +96,7 @@ void DialogASCIIString::do_find() {
 							stack_ptr += edb::v1::pointer_size();
 						}
 					} catch(const std::bad_alloc &) {
-						QMessageBox::information(0, tr("Memroy Allocation Error"),
+						QMessageBox::critical(0, tr("Memroy Allocation Error"),
 							tr("Unable to satisfy memory allocation request for search string."));
 					}
 				}

--- a/plugins/BreakpointManager/DialogBreakpoints.cpp
+++ b/plugins/BreakpointManager/DialogBreakpoints.cpp
@@ -130,7 +130,7 @@ void DialogBreakpoints::on_btnAdd_clicked() {
 			updateList();
 
 		} else {
-			QMessageBox::information(this, tr("Error In Address Expression!"), err.what());
+			QMessageBox::critical(this, tr("Error In Address Expression!"), err.what());
 		}
 	}
 }
@@ -233,7 +233,7 @@ void DialogBreakpoints::on_btnImport_clicked() {
 	//Open the file; fail if error or it doesn't exist.
 	QFile file(file_name);
 	if (!file.open(QIODevice::ReadOnly)) {
-		QMessageBox::information(this, tr("Error Opening File"), tr("Unable to open breakpoint file: %1").arg(file_name));
+		QMessageBox::critical(this, tr("Error Opening File"), tr("Unable to open breakpoint file: %1").arg(file_name));
 		return;
 	}
 
@@ -288,7 +288,7 @@ void DialogBreakpoints::on_btnImport_clicked() {
 
 	//Report any errors to the user
 	if (errors.size() > 0) {
-		QMessageBox::information(this, tr("Invalid Breakpoints"), tr("The following breakpoints were not made:\n%1").arg(errors.join("")));
+		QMessageBox::warning(this, tr("Invalid Breakpoints"), tr("The following breakpoints were not made:\n%1").arg(errors.join("")));
 	}
 
 	//Report breakpoints successfully made
@@ -319,7 +319,7 @@ void DialogBreakpoints::on_btnExport_clicked() {
 
 	//If there are no breakpoints, fail
 	if (export_list.isEmpty()) {
-		QMessageBox::information(this, tr("No Breakpoints"), tr("There are no breakpoints to export."));
+		QMessageBox::critical(this, tr("No Breakpoints"), tr("There are no breakpoints to export."));
 		return;
 	}
 

--- a/plugins/CheckVersion/CheckVersion.cpp
+++ b/plugins/CheckVersion/CheckVersion.cpp
@@ -154,7 +154,7 @@ void CheckVersion::requestFinished(QNetworkReply *reply) {
 	
 	if(QNetworkReply::NoError != reply->error()) {
 		if(!initial_check_) {
-			QMessageBox::information(
+			QMessageBox::critical(
 				0,
 				tr("An Error Occured"),
 				reply->errorString());

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -52,7 +52,7 @@ public:
 	virtual edb::address_t page_size() const;
 	virtual bool has_extension(quint64 ext) const;
 	virtual IDebugEvent::const_pointer wait_debug_event(int msecs);
-	virtual bool attach(edb::pid_t pid);
+	virtual QString attach(edb::pid_t pid) override;
 	virtual void detach();
 	virtual void kill();
 	virtual void get_state(State *state);
@@ -96,7 +96,7 @@ private:
 	void reset();
 	void stop_threads();
 	IDebugEvent::const_pointer handle_event(edb::tid_t tid, int status);
-	bool attach_thread(edb::tid_t tid);
+	int attach_thread(edb::tid_t tid);
 	void detectDebuggeeBitness();
 	
 private:

--- a/plugins/DebuggerCore/unix/linux/PlatformRegion.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformRegion.cpp
@@ -244,7 +244,7 @@ void PlatformRegion::set_permissions(bool read, bool write, bool execute) {
 		if(temp_address != 0) {
 			set_permissions(read, write, execute, temp_address);
 		} else {
-			QMessageBox::information(
+			QMessageBox::critical(
 				0,
 				tr("No Suitable Address Found"),
 				tr("This feature relies on running shellcode in the debugged process, no executable memory region was found. Unfortunately, this means that no more region permission changes can be made (it also means that there is nothing the process can continue to do since it cannot execute at all)."));
@@ -367,7 +367,7 @@ void PlatformRegion::set_permissions(bool read, bool write, bool execute, edb::a
 					}
 				}
 			} catch(const std::bad_alloc &) {
-				QMessageBox::information(
+				QMessageBox::critical(
 					0,
 					tr("Memory Allocation Error"),
 					tr("Unable to satisfy memory allocation request for backup code."));

--- a/plugins/FunctionFinder/DialogFunctions.cpp
+++ b/plugins/FunctionFinder/DialogFunctions.cpp
@@ -106,7 +106,7 @@ void DialogFunctions::do_find() {
 		const QModelIndexList sel = selModel->selectedRows();
 
 		if(sel.size() == 0) {
-			QMessageBox::information(this, tr("No Region Selected"), tr("You must select a region which is to be scanned for functions."));
+			QMessageBox::critical(this, tr("No Region Selected"), tr("You must select a region which is to be scanned for functions."));
 			return;
 		}
 

--- a/plugins/HardwareBreakpoints/HardwareBreakpoints.cpp
+++ b/plugins/HardwareBreakpoints/HardwareBreakpoints.cpp
@@ -113,7 +113,7 @@ void HardwareBreakpoints::setupBreakpoints() {
 			}
 
 			if(!ok[Register1] && !ok[Register2] && !ok[Register3] && !ok[Register4]) {
-				QMessageBox::information(
+				QMessageBox::critical(
 					0,
 					tr("Address Error"),
 					tr("An address expression provided does not appear to be valid"));
@@ -132,13 +132,13 @@ void HardwareBreakpoints::setupBreakpoints() {
 					
 					switch(status) {
 					case AlignmentError:
-						QMessageBox::information(
+						QMessageBox::critical(
 							0,
 							tr("Address Alignment Error"),
 							tr("Hardware read/write breakpoint address must be aligned to breakpoint size."));					
 						return;
 					case SizeError:
-					QMessageBox::information(
+					QMessageBox::critical(
 						0,
 						tr("BP Size Error"),
 						tr("Hardware read/write breakpoints cannot be 8-bytes in a 32-bit debuggee."));					
@@ -425,7 +425,7 @@ void HardwareBreakpoints::setWriteBP(int index, bool inUse, edb::address_t addre
 				setBreakpointState(&state, index, { true, address, 1, 3 });
 				break;
 			default:
-				QMessageBox::information(nullptr, tr("Invalid Selection Size"), tr("Please select 1, 2, 4, or 8 bytes for this type of hardward breakpoint"));
+				QMessageBox::critical(nullptr, tr("Invalid Selection Size"), tr("Please select 1, 2, 4, or 8 bytes for this type of hardward breakpoint"));
 				return;
 			}
 
@@ -474,7 +474,7 @@ void HardwareBreakpoints::setReadWriteBP(int index, bool inUse, edb::address_t a
 				setBreakpointState(&state, index, { true, address, 2, 3 });
 				break;
 			default:
-				QMessageBox::information(nullptr, tr("Invalid Selection Size"), tr("Please select 1, 2, 4, or 8 bytes for this type of hardward breakpoint"));
+				QMessageBox::critical(nullptr, tr("Invalid Selection Size"), tr("Please select 1, 2, 4, or 8 bytes for this type of hardward breakpoint"));
 				return;
 			}
 

--- a/plugins/HeapAnalyzer/DialogHeap.cpp
+++ b/plugins/HeapAnalyzer/DialogHeap.cpp
@@ -483,7 +483,7 @@ void DialogHeap::do_find() {
 
 		// ok, I give up
 		if(start_address == 0 || end_address == 0) {
-			QMessageBox::information(this, tr("Could not calculate heap bounds"), tr("Failed to calculate the bounds of the heap."));
+			QMessageBox::critical(this, tr("Could not calculate heap bounds"), tr("Failed to calculate the bounds of the heap."));
 			return;
 		}	
 

--- a/plugins/OpcodeSearcher/DialogOpcodes.cpp
+++ b/plugins/OpcodeSearcher/DialogOpcodes.cpp
@@ -724,7 +724,7 @@ void DialogOpcodes::do_find() {
 	const QModelIndexList sel = selModel->selectedRows();
 
 	if(sel.size() == 0) {
-		QMessageBox::information(
+		QMessageBox::critical(
 			this,
 			tr("No Region Selected"),
 			tr("You must select a region which is to be scanned for the desired opcode."));

--- a/plugins/ProcessProperties/DialogStrings.cpp
+++ b/plugins/ProcessProperties/DialogStrings.cpp
@@ -94,7 +94,7 @@ void DialogStrings::do_find() {
 	QString str;
 
 	if(sel.size() == 0) {
-		QMessageBox::information(
+		QMessageBox::critical(
 			this,
 			tr("No Region Selected"),
 			tr("You must select a region which is to be scanned for strings."));

--- a/plugins/ROPTool/DialogROPTool.cpp
+++ b/plugins/ROPTool/DialogROPTool.cpp
@@ -335,7 +335,7 @@ void DialogROPTool::do_find() {
 	const QModelIndexList sel = selModel->selectedRows();
 
 	if(sel.size() == 0) {
-		QMessageBox::information(
+		QMessageBox::critical(
 			this,
 			tr("No Region Selected"),
 			tr("You must select a region which is to be scanned for gadgets."));

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2841,26 +2841,18 @@ void Debugger::setup_data_views() {
 bool Debugger::common_open(const QString &s, const QList<QByteArray> &args) {
 
 	bool ret = false;
-	if(!QFile(s).exists()) {
+	tty_file_ = create_tty();		
+
+	const QString errorString=edb::v1::debugger_core->open(s, working_directory_, args, tty_file_);
+	if(errorString.isEmpty()) {
+		attachComplete();			
+		set_initial_breakpoint(s);
+		ret = true;
+	} else {
 		QMessageBox::information(
 			this,
 			tr("Could Not Open"),
-			tr("The specified file (%1) does not appear to exist, please check privileges and try again.").arg(s));
-	} else {
-
-		tty_file_ = create_tty();		
-
-		const QString errorString=edb::v1::debugger_core->open(s, working_directory_, args, tty_file_);
-		if(errorString.isEmpty()) {
-			attachComplete();			
-			set_initial_breakpoint(s);
-			ret = true;
-		} else {
-			QMessageBox::information(
-				this,
-				tr("Could Not Open"),
-				tr("Failed to open and attach to process:\n%1.").arg(errorString));
-		}
+			tr("Failed to open and attach to process:\n%1.").arg(errorString));
 	}
 
 	update_gui();

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2916,7 +2916,8 @@ void Debugger::attach(edb::pid_t pid) {
 	}
 
 
-	if(edb::v1::debugger_core->attach(pid)) {
+	const auto errorStr=edb::v1::debugger_core->attach(pid);
+	if(errorStr.isEmpty()) {
 
 		working_directory_ = edb::v1::debugger_core->process()->current_working_directory();
 
@@ -2929,7 +2930,7 @@ void Debugger::attach(edb::pid_t pid) {
 		arguments_dialog_->set_arguments(args);
 		attachComplete();
 	} else {
-		QMessageBox::critical(this, tr("Attach"), tr("Failed to attach to process, please check privileges and try again."));
+		QMessageBox::critical(this, tr("Attach"), tr("Failed to attach to process: %1").arg(errorStr));
 	}
 
 	update_gui();

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1234,7 +1234,7 @@ void Debugger::step_over(F1 run_func, F2 step_func) {
 template <class F>
 void Debugger::follow_memory(edb::address_t address, F follow_func) {
 	if(!follow_func(address)) {
-		QMessageBox::information(this,
+		QMessageBox::critical(this,
 			tr("No Memory Found"),
 			tr("There appears to be no memory at that location (<strong>%1</strong>)").arg(edb::v1::format_pointer(address)));
 	}
@@ -1248,7 +1248,7 @@ void Debugger::follow_register_in_dump(bool tabbed) {
 	bool ok;
 	const edb::address_t address = get_follow_register(&ok);
 	if(ok && !edb::v1::dump_data(address, tabbed)) {
-		QMessageBox::information(this,
+		QMessageBox::critical(this,
 			tr("No Memory Found"),
 			tr("There appears to be no memory at that location (<strong>%1</strong>)").arg(edb::v1::format_pointer(address)));
 	}
@@ -1385,7 +1385,7 @@ edb::address_t Debugger::get_follow_address(const T &hexview, bool *ok) {
 		}
 	}
 
-	QMessageBox::information(this,
+	QMessageBox::critical(this,
 		tr("Invalid Selection"),
 		tr("Please select %1 bytes to use this function.").arg(pointer_size));
 
@@ -2849,7 +2849,7 @@ bool Debugger::common_open(const QString &s, const QList<QByteArray> &args) {
 		set_initial_breakpoint(s);
 		ret = true;
 	} else {
-		QMessageBox::information(
+		QMessageBox::critical(
 			this,
 			tr("Could Not Open"),
 			tr("Failed to open and attach to process:\n%1.").arg(errorString));
@@ -2895,7 +2895,7 @@ void Debugger::attach(edb::pid_t pid) {
 	edb::pid_t current_pid = getpid();
 	while(current_pid != 0) {
 		if(current_pid == pid) {
-			QMessageBox::information(
+			QMessageBox::critical(
 				this,
 				tr("Attach"),
 				tr("You may not debug a process which is a parent of the edb process."));
@@ -2907,7 +2907,7 @@ void Debugger::attach(edb::pid_t pid) {
 
 	if(IProcess *process = edb::v1::debugger_core->process()) {
 		if(pid == process->pid()) {
-			QMessageBox::information(
+			QMessageBox::critical(
 				this,
 				tr("Attach"),
 				tr("You are already debugging that process!"));
@@ -2929,7 +2929,7 @@ void Debugger::attach(edb::pid_t pid) {
 		arguments_dialog_->set_arguments(args);
 		attachComplete();
 	} else {
-		QMessageBox::information(this, tr("Attach"), tr("Failed to attach to process, please check privileges and try again."));
+		QMessageBox::critical(this, tr("Attach"), tr("Failed to attach to process, please check privileges and try again."));
 	}
 
 	update_gui();

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -411,7 +411,7 @@ IBreakpoint::pointer create_breakpoint(address_t address) {
 
 
 	} else {
-		QMessageBox::information(
+		QMessageBox::critical(
 			0,
 			QT_TRANSLATE_NOOP("edb", "Error Setting Breakpoint"),
 			QT_TRANSLATE_NOOP("edb", "Sorry, but setting a breakpoint which is not in a valid region is not allowed."));
@@ -486,7 +486,7 @@ bool eval_expression(const QString &expression, address_t *value) {
 		*value = address;
 		return true;
 	} else {
-		QMessageBox::information(debugger_ui, QT_TRANSLATE_NOOP("edb", "Error In Expression!"), err.what());
+		QMessageBox::critical(debugger_ui, QT_TRANSLATE_NOOP("edb", "Error In Expression!"), err.what());
 		return false;
 	}
 }
@@ -1326,7 +1326,7 @@ QVector<quint8> read_pages(address_t address, size_t page_count) {
 
 
 			} catch(const std::bad_alloc &) {
-				QMessageBox::information(0,
+				QMessageBox::critical(0,
 					QT_TRANSLATE_NOOP("edb", "Memroy Allocation Error"),
 					QT_TRANSLATE_NOOP("edb", "Unable to satisfy memory allocation request for requested region->"));
 			}


### PR DESCRIPTION
First commit removes explicit check for existence of the file to run, allowing `execv()` to report exact errors instead of blurry "please check privileges".
Second commit switches the error message boxes to real errors (and warnings to real warnings) instead of information. This makes the type of message immediately obvious to the user by its icon (and maybe sound).
Third one gives the exact errors for `attach()` similarly to already done `open()`.