### PR TITLE
RFC: Only syntax-highlight disassembly if the instruction isn't selected

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -563,7 +563,7 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 
 		//return metrics.elidedText(byte_buffer, Qt::ElideRight, maxStringPx);
 
-		const bool syntax_highlighting_enabled=edb::v1::config().syntax_highlighting_enabled;
+		const bool syntax_highlighting_enabled=edb::v1::config().syntax_highlighting_enabled && inst.rva()!=selectedAddress();
 
 		if(is_filling) {
 			if(is_filling && syntax_highlighting_enabled)


### PR DESCRIPTION
Otherwise we have bad readability due to low contrast. I don't have better ideas than to disable syntax highlighting for selected line. See the comparison:

![4](https://cloud.githubusercontent.com/assets/6376882/15155225/312f52c8-16ea-11e6-893f-af0482974764.gif)
