### PR TITLE
Add some helpful debugging options

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -68,6 +68,7 @@ public:
 	bool              tty_enabled;
 	bool              remove_stale_symbols;
 	bool			  disableASLR;
+	bool			  disableLazyBinding;
 	QString           tty_command;
 
 	// disassembly tab

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -67,6 +67,7 @@ public:
 	bool              find_main;
 	bool              tty_enabled;
 	bool              remove_stale_symbols;
+	bool			  disableASLR;
 	QString           tty_command;
 
 	// disassembly tab

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -648,6 +648,9 @@ QString DebuggerCore::open(const QString &path, const QString &cwd, const QList<
 				perror("Failed to disable ASLR");
 		}
 
+		if(edb::v1::config().disableLazyBinding && setenv("LD_BIND_NOW","1",true)==-1)
+			perror("Failed to disable lazy binding");
+
 		// do the actual exec
 		const QString error=execute_process(path, cwd, args);
 #if defined __GNUG__ && __GNUC__ >= 5 || !defined __GNUG__ || \

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -98,6 +98,7 @@ void Configuration::read_settings() {
 	tty_command          = settings.value("debugger.terminal.command", "/usr/bin/xterm").value<QString>();
 	remove_stale_symbols = settings.value("debugger.remove_stale_symbols.enabled", true).value<bool>();
 	disableASLR			 = settings.value("debugger.disableASLR.enabled", false).value<bool>();
+	disableLazyBinding	 = settings.value("debugger.disableLazyBinding.enabled", false).value<bool>();
 	settings.endGroup();
 
 	settings.beginGroup("Disassembly");
@@ -186,6 +187,7 @@ void Configuration::write_settings() {
 	settings.setValue("debugger.terminal.command", tty_command);
 	settings.setValue("debugger.remove_stale_symbols.enabled", remove_stale_symbols);
 	settings.setValue("debugger.disableASLR.enabled", disableASLR);
+	settings.setValue("debugger.disableLazyBinding.enabled", disableLazyBinding);
 	settings.endGroup();
 
 	settings.beginGroup("Disassembly");

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -97,6 +97,7 @@ void Configuration::read_settings() {
 	tty_enabled          = settings.value("debugger.terminal.enabled", true).value<bool>();
 	tty_command          = settings.value("debugger.terminal.command", "/usr/bin/xterm").value<QString>();
 	remove_stale_symbols = settings.value("debugger.remove_stale_symbols.enabled", true).value<bool>();
+	disableASLR			 = settings.value("debugger.disableASLR.enabled", false).value<bool>();
 	settings.endGroup();
 
 	settings.beginGroup("Disassembly");
@@ -184,6 +185,7 @@ void Configuration::write_settings() {
 	settings.setValue("debugger.terminal.enabled", tty_enabled);
 	settings.setValue("debugger.terminal.command", tty_command);
 	settings.setValue("debugger.remove_stale_symbols.enabled", remove_stale_symbols);
+	settings.setValue("debugger.disableASLR.enabled", disableASLR);
 	settings.endGroup();
 
 	settings.beginGroup("Disassembly");

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -174,6 +174,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	
 	ui->chkDeleteStaleSymbols->setChecked(config.remove_stale_symbols);
 	ui->chkDisableASLR->setChecked(config.disableASLR);
+	ui->chkDisableLazyBinding->setChecked(config.disableLazyBinding);
 
 	ui->chkZerosAreFilling->setChecked(config.zeros_are_filling);
 	ui->chkUppercase->setChecked(config.uppercase_disassembly);
@@ -246,6 +247,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	config.tty_enabled           = ui->chkTTY->isChecked();
 	config.remove_stale_symbols  = ui->chkDeleteStaleSymbols->isChecked();
 	config.disableASLR			 = ui->chkDisableASLR->isChecked();
+	config.disableLazyBinding	 = ui->chkDisableLazyBinding->isChecked();
 	
 	config.zeros_are_filling     = ui->chkZerosAreFilling->isChecked();
 	config.uppercase_disassembly = ui->chkUppercase->isChecked();

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -173,6 +173,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->txtTTY->setText(config.tty_command);
 	
 	ui->chkDeleteStaleSymbols->setChecked(config.remove_stale_symbols);
+	ui->chkDisableASLR->setChecked(config.disableASLR);
 
 	ui->chkZerosAreFilling->setChecked(config.zeros_are_filling);
 	ui->chkUppercase->setChecked(config.uppercase_disassembly);
@@ -244,6 +245,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	config.tty_command           = ui->txtTTY->text();
 	config.tty_enabled           = ui->chkTTY->isChecked();
 	config.remove_stale_symbols  = ui->chkDeleteStaleSymbols->isChecked();
+	config.disableASLR			 = ui->chkDisableASLR->isChecked();
 	
 	config.zeros_are_filling     = ui->chkZerosAreFilling->isChecked();
 	config.uppercase_disassembly = ui->chkUppercase->isChecked();

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -369,6 +369,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkDisableLazyBinding">
+         <property name="text">
+          <string>Disable lazy binding of dynamic symbols</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="label_5">

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -362,6 +362,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkDisableASLR">
+         <property name="text">
+          <string>Disable Address Space Layout Randomization (ASLR)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="label_5">


### PR DESCRIPTION
This adds some options which are often helpful when debugging often-restarted programs: to disable ASLR and to disable lazy binding of dynamically linked functions.