### PR TITLE
Fix usage of PTRACE_O_EXITKILL

### DIFF
--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -60,6 +60,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PTRACE_O_TRACECLONE (1 << PTRACE_EVENT_CLONE)
 #endif
 
+#ifndef PTRACE_O_EXITKILL
+#define PTRACE_O_EXITKILL	(1 << 20)
+#endif
+
 namespace DebuggerCore {
 
 namespace {
@@ -442,11 +446,9 @@ int DebuggerCore::attach_thread(edb::tid_t tid) {
 				qDebug("[DebuggerCore] failed to set PTRACE_O_TRACECLONE: [%d] %s", tid, strerror(errno));
 			}
 			
-#ifdef PTRACE_O_EXITKILL
 			if(ptrace_set_options(tid, PTRACE_O_EXITKILL) == -1) {
 				qDebug("[DebuggerCore] failed to set PTRACE_O_EXITKILL: [%d] %s", tid, strerror(errno));
 			}
-#endif
 			return 0;
 		}
 		else if(ret==-1) {

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -446,8 +446,12 @@ int DebuggerCore::attach_thread(edb::tid_t tid) {
 				qDebug("[DebuggerCore] failed to set PTRACE_O_TRACECLONE: [%d] %s", tid, strerror(errno));
 			}
 			
-			if(ptrace_set_options(tid, PTRACE_O_EXITKILL) == -1) {
-				qDebug("[DebuggerCore] failed to set PTRACE_O_EXITKILL: [%d] %s", tid, strerror(errno));
+			if(edb::v1::config().close_behavior==Configuration::Kill ||
+			   (edb::v1::config().close_behavior==Configuration::KillIfLaunchedDetachIfAttached &&
+				  last_means_of_capture()==MeansOfCapture::Launch)) {
+				if(ptrace_set_options(tid, PTRACE_O_EXITKILL) == -1) {
+					qDebug("[DebuggerCore] failed to set PTRACE_O_EXITKILL: [%d] %s", tid, strerror(errno));
+				}
 			}
 			return 0;
 		}


### PR DESCRIPTION
It's defined in <linux/ptrace.h> instead of <sys/ptrace.h>, but the former lacks some defines like PTRACE_PEEKUSER and also conflicts with the latter. So it's better to just copy-paste the definition of the constant.