### PR TITLE
Include Mandatory Header Files

### DIFF
--- a/include/FloatX.h
+++ b/include/FloatX.h
@@ -1,6 +1,7 @@
 #ifndef FLOAT_X_H_20151108
 #define FLOAT_X_H_20151108
 
+#include <cmath>
 #include <type_traits>
 #include <QValidator>
 #include <Types.h>

--- a/plugins/ODbgRegisterView/GPREdit.cpp
+++ b/plugins/ODbgRegisterView/GPREdit.cpp
@@ -1,4 +1,5 @@
 #include "GPREdit.h"
+#include <cmath>
 #include <cstring>
 #include <QApplication>
 #include <QRegExpValidator>

--- a/src/RegisterViewModelBase.cpp
+++ b/src/RegisterViewModelBase.cpp
@@ -6,6 +6,7 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <numeric>
 #include <boost/range/adaptor/reversed.hpp>
 #include <cstdint>
 #include <QBrush>


### PR DESCRIPTION
When compiling edb today, with Debian's "gcc version 5.3.1 20160509 (Debian 5.3.1-19)", I got several errors like "/home/.../edb-debugger/include/FloatX.h:50:57: error: ‘log10’ is not a member of ‘std’".  These stemmed from header files not being included in three specific files.  So, I included them, it compiles and runs, maybe this'll be useful for others.

Not sure why I'm having trouble, when these files don't ever seem to have been included...

My first guess was that my g++ command line was wrong, but it seemed to be correct.  Here it is anyway, for reference, "g++ -c -m64 -pipe -std=c++11 -O2 -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_PLUGIN -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt4/mkspecs/linux-g++-64 -I. -I/usr/include/qt4/QtCore -I/usr/include/qt4/QtGui -I/usr/include/qt4 -I../../include/os/unix -I../../include -I../../include/arch/x86-generic -I.release-shared/moc -o .release-shared/obj/GPREdit.o GPREdit.cpp"

I was originally trying this with qt5 (I think) and having the same problem.