### PR TITLE
Return valid original byte for a failed-to-write breakpoint

### DIFF
--- a/plugins/DebuggerCore/Breakpoint.cpp
+++ b/plugins/DebuggerCore/Breakpoint.cpp
@@ -30,7 +30,7 @@ const quint8 BreakpointInstruction = 0xcc;
 // Name: Breakpoint
 // Desc: constructor
 //------------------------------------------------------------------------------
-Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false) {
+Breakpoint::Breakpoint(edb::address_t address) : original_byte_(0xff), address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false) {
 	enable();
 }
 
@@ -51,8 +51,8 @@ bool Breakpoint::enable() {
 		if(IProcess *process = edb::v1::debugger_core->process()) {
 			quint8 prev[1];
 			if(process->read_bytes(address(), prev, 1)) {
+				original_byte_ = prev[0];
 				if(process->write_bytes(address(), &BreakpointInstruction, 1)) {
-					original_byte_ = prev[0];
 					enabled_ = true;
 					return true;
 				}


### PR DESCRIPTION
This fixes #431. Also, if the breakpoint fails to even read the byte, it'll now return `0xff` as original byte instead of a random value.