### PR TITLE
Fixed missing std:: qualifier, and cmath includes in graph source.

### DIFF
--- a/src/graph/GraphNode.cpp
+++ b/src/graph/GraphNode.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPainter>
 #include <QPainterPath>
 #include <QAbstractTextDocumentLayout>
+#include <cmath>
 
 namespace {
 
@@ -101,7 +102,7 @@ GraphNode::~GraphNode() {
 //------------------------------------------------------------------------------
 QRectF GraphNode::boundingRect() const {
 	const int weight = 2;
-	const int width = ::log2(weight) * BorderScaleFactor;
+	const int width = std::log2(weight) * BorderScaleFactor;
 	return picture_.boundingRect().adjusted(-width, -width, +width, +width);
 }
 

--- a/src/graph/GraphWidget.cpp
+++ b/src/graph/GraphWidget.cpp
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QWheelEvent>
 #include <graphviz/gvc.h>
 #include <graphviz/cgraph.h>
+#include <cmath>
 
 namespace {
 


### PR DESCRIPTION
`<cmath>` includes were missing from `GraphNode.cpp` and `GraphWidget.cpp` in `src/graph`
also fixed a missing `std::` in `GraphNode.cpp`
Both of these issues were breaking the build.