### PR TITLE
install logo file as edb.png

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,4 +53,4 @@ add_subdirectory(plugins)
 
 install (FILES ${CMAKE_SOURCE_DIR}/edb.1 DESTINATION ${CMAKE_INSTALL_MANDIR})
 install (FILES ${CMAKE_SOURCE_DIR}/edb.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/)
-install (FILES ${CMAKE_SOURCE_DIR}/src/images/edb48-logo.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/)
+install (FILES ${CMAKE_SOURCE_DIR}/src/images/edb48-logo.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/edb.png)


### PR DESCRIPTION
The desktop file expects an icon called edb, not edb48-logo

https://github.com/eteran/edb-debugger/blob/master/edb.desktop#L6