### PR TITLE
Remove enum entry which is not present in Capstone 4 and was never used in Capstone 3

### DIFF
--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -272,8 +272,6 @@ Instruction::Instruction(const void* first, const void* last, uint64_t rva) noex
 					else
 						operand.expr_.segment=Operand::Segment::DS;
 				}
-			case Capstone::X86_OP_FP:
-				break;
 			case Capstone::X86_OP_INVALID:
 				break;
 			default:


### PR DESCRIPTION
Otherwise we have compilation failure.