### PR TITLE
Build and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ env:
     global:
         - MAKEFLAGS="-j2"
     matrix:
-        - QT_BASE=48
-        - QT_BASE=51
-        - QT_BASE=52
-        - QT_BASE=53
-        - QT_BASE=54
-        - QT_BASE=55
+        #- QT_BASE=48
+        #- QT_BASE=51
+        #- QT_BASE=52
+        #- QT_BASE=53
+        #- QT_BASE=54
+        #- QT_BASE=55
         - QT_BASE=56
 
 sudo: required
@@ -47,6 +47,13 @@ before_script:
 
 script:
     - make
+    - find .
+    - cd ..
+    - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
+    - chmod a+x linuxdeployqt-1-x86_64.AppImage
+    - unset LD_LIBRARY_PATH
+    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb-debugger -appimage -verbose=2
+    - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-debugger.AppImage # Replace with your deployment mechanism
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ before_script:
 
 script:
     - make
-    - if [ "$QT_BASE" = "56" ]; then
     - cd ..
     - cp ./src/images/edb.png ./build
     - cp ./edb.desktop ./build
@@ -58,7 +57,6 @@ script:
     - unset LD_LIBRARY_PATH
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
-    - fi
     
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ env:
     global:
         - MAKEFLAGS="-j2"
     matrix:
-        #- QT_BASE=48
-        #- QT_BASE=51
-        #- QT_BASE=52
-        #- QT_BASE=53
-        #- QT_BASE=54
-        #- QT_BASE=55
+        - QT_BASE=48
+        - QT_BASE=51
+        - QT_BASE=52
+        - QT_BASE=53
+        - QT_BASE=54
+        - QT_BASE=55
         - QT_BASE=56
 
 sudo: required
@@ -54,7 +54,7 @@ script:
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
-    - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-debugger.AppImage # Replace with your deployment mechanism
+    - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ before_script:
 
 script:
     - make
-    - find .
     - cd ..
+    - find .
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
     matrix:
         - QT_BASE=48
         - QT_BASE=51
-        - QT_BASE=52
-        - QT_BASE=53
-        - QT_BASE=54
+        #- QT_BASE=52
+        #- QT_BASE=53
+        #- QT_BASE=54
         - QT_BASE=55
         - QT_BASE=56
 
@@ -32,14 +32,14 @@ before_install:
     - ./travis_install_capstone.sh
 
 install:
-    - if [ "$QT_BASE" = "48" ]; then sudo apt-get install -qq qt4-qmake libqt4-gui libqt4-core libqt4-dev; fi
-    - if [ "$QT_BASE" = "50" ]; then sudo apt-get install -qq qtbase  qtxmlpatterns; source /opt/qt5/bin/qt5-env.sh; fi
-    - if [ "$QT_BASE" = "51" ]; then sudo apt-get install -qq qt51base qt51xmlpatterns; source /opt/qt51/bin/qt51-env.sh; fi
-    - if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq qt52base qt52xmlpatterns; source /opt/qt52/bin/qt52-env.sh; fi
-    - if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq qt53base qt53xmlpatterns; source /opt/qt53/bin/qt53-env.sh; fi
-    - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54xmlpatterns; source /opt/qt54/bin/qt54-env.sh; fi
-    - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55xmlpatterns; source /opt/qt55/bin/qt55-env.sh; fi
-    - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq qt56base qt56xmlpatterns; source /opt/qt56/bin/qt56-env.sh; fi
+    - if [ "$QT_BASE" = "48" ]; then sudo apt-get install -qq libxcb-sync0 qt4-qmake libqt4-gui libqt4-core libqt4-dev; fi
+    - if [ "$QT_BASE" = "50" ]; then sudo apt-get install -qq libxcb-sync0 qtbase  qtxmlpatterns; source /opt/qt5/bin/qt5-env.sh; fi
+    - if [ "$QT_BASE" = "51" ]; then sudo apt-get install -qq libxcb-sync0 qt51base qt51xmlpatterns; source /opt/qt51/bin/qt51-env.sh; fi
+    - if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq libxcb-sync0 libxcb-sync0 qt52base qt52xmlpatterns; source /opt/qt52/bin/qt52-env.sh; fi
+    - if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq libxcb-sync0 qt53base qt53xmlpatterns; source /opt/qt53/bin/qt53-env.sh; fi
+    - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq libxcb-sync0 qt54base qt54xmlpatterns; source /opt/qt54/bin/qt54-env.sh; fi
+    - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq libxcb-sync0 qt55base qt55xmlpatterns; source /opt/qt55/bin/qt55-env.sh; fi
+    - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq libxcb-sync0 qt56base qt56xmlpatterns; source /opt/qt56/bin/qt56-env.sh; fi
 
 before_script:
     - if [ "$QT_BASE" == "48" ]; then mkdir build && cd build && cmake -DQT_VERSION=Qt4 ..; fi
@@ -48,8 +48,10 @@ before_script:
 script:
     - make
     - cd ..
-    - rm -rf build/src
+    - cp ./src/images/edb.png ./build
+    - cp ./edb.desktop ./build
     - find .
+    - rm -rf build/src
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ script:
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH
-    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -bundle-non-qt-libs # Need 2 runs for older Qt versions?!
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
     - fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
     matrix:
         - QT_BASE=48
         - QT_BASE=51
-        #- QT_BASE=52
-        #- QT_BASE=53
-        #- QT_BASE=54
+        - QT_BASE=52
+        - QT_BASE=53
+        - QT_BASE=54
         - QT_BASE=55
         - QT_BASE=56
 
@@ -47,6 +47,7 @@ before_script:
 
 script:
     - make
+    - if [ "$QT_BASE" = "56" ]; then
     - cd ..
     - cp ./src/images/edb.png ./build
     - cp ./edb.desktop ./build
@@ -58,7 +59,8 @@ script:
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -bundle-non-qt-libs # Need 2 runs for older Qt versions?!
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
-
+    - fi
+    
 branches:
     only:
         - master
@@ -78,4 +80,3 @@ addons:
             - gcc-4.8
             - g++-4.8
             - cmake
-            - libxcb-sync0 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,14 @@ before_install:
     - ./travis_install_capstone.sh
 
 install:
-    - if [ "$QT_BASE" = "48" ]; then sudo apt-get install -qq libxcb-sync0 qt4-qmake libqt4-gui libqt4-core libqt4-dev; fi
-    - if [ "$QT_BASE" = "50" ]; then sudo apt-get install -qq libxcb-sync0 qtbase  qtxmlpatterns; source /opt/qt5/bin/qt5-env.sh; fi
-    - if [ "$QT_BASE" = "51" ]; then sudo apt-get install -qq libxcb-sync0 qt51base qt51xmlpatterns; source /opt/qt51/bin/qt51-env.sh; fi
-    - if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq libxcb-sync0 libxcb-sync0 qt52base qt52xmlpatterns; source /opt/qt52/bin/qt52-env.sh; fi
-    - if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq libxcb-sync0 qt53base qt53xmlpatterns; source /opt/qt53/bin/qt53-env.sh; fi
-    - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq libxcb-sync0 qt54base qt54xmlpatterns; source /opt/qt54/bin/qt54-env.sh; fi
-    - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq libxcb-sync0 qt55base qt55xmlpatterns; source /opt/qt55/bin/qt55-env.sh; fi
-    - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq libxcb-sync0 qt56base qt56xmlpatterns; source /opt/qt56/bin/qt56-env.sh; fi
+    - if [ "$QT_BASE" = "48" ]; then sudo apt-get install -qq qt4-qmake libqt4-gui libqt4-core libqt4-dev; fi
+    - if [ "$QT_BASE" = "50" ]; then sudo apt-get install -qq qtbase  qtxmlpatterns; source /opt/qt5/bin/qt5-env.sh; fi
+    - if [ "$QT_BASE" = "51" ]; then sudo apt-get install -qq qt51base qt51xmlpatterns; source /opt/qt51/bin/qt51-env.sh; fi
+    - if [ "$QT_BASE" = "52" ]; then sudo apt-get install -qq qt52base qt52xmlpatterns; source /opt/qt52/bin/qt52-env.sh; fi
+    - if [ "$QT_BASE" = "53" ]; then sudo apt-get install -qq qt53base qt53xmlpatterns; source /opt/qt53/bin/qt53-env.sh; fi
+    - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54xmlpatterns; source /opt/qt54/bin/qt54-env.sh; fi
+    - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55xmlpatterns; source /opt/qt55/bin/qt55-env.sh; fi
+    - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq qt56base qt56xmlpatterns; source /opt/qt56/bin/qt56-env.sh; fi
 
 before_script:
     - if [ "$QT_BASE" == "48" ]; then mkdir build && cd build && cmake -DQT_VERSION=Qt4 ..; fi
@@ -55,6 +55,7 @@ script:
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH
+    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -bundle-non-qt-libs # Need 2 runs for older Qt versions?!
     - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
 
@@ -77,3 +78,4 @@ addons:
             - gcc-4.8
             - g++-4.8
             - cmake
+            - libxcb-sync0 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,12 @@ before_script:
 script:
     - make
     - cd ..
+    - rm -rf build/src
     - find .
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH
-    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb-debugger -appimage -verbose=2
+    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-debugger.AppImage # Replace with your deployment mechanism
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ script:
 branches:
     only:
         - master
+        - patch-1
 
 os:
     - linux


### PR DESCRIPTION
Build and upload an [AppImage](http://appimage.org/) for Qt 5.6 builds (builds prior to  Qt 5.5 are not yet bundled correctly due to what I suspect to be a [linuxdeployqt](https://github.com/probonopd/linuxdeployqt) bug). The URL of the built AppImage can be seen in the build log.