### PR TITLE
Add navigation history for CPU view

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ set(edb_SRCS
 	SymbolManager.cpp
 	ThreadsModel.cpp
 	widgets/LineEdit.cpp
+	widgets/NavigationHistory.cpp
 	widgets/QDisassemblyView.cpp
 	widgets/RegisterListWidget.cpp
 	widgets/RegisterViewDelegate.cpp

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2330,6 +2330,7 @@ void Debugger::do_jump_to_address(edb::address_t address, const IRegion::pointer
 	if(scrollTo && !ui.cpuView->addressShown(address)) {
 		ui.cpuView->scrollTo(address);
 	}
+        ui.cpuView->setSelectedAddress(address);
 }
 
 //------------------------------------------------------------------------------

--- a/src/widgets/NavigationHistory.cpp
+++ b/src/widgets/NavigationHistory.cpp
@@ -1,0 +1,67 @@
+#include "NavigationHistory.h"
+#include <QDebug>
+
+NavigationHistory::NavigationHistory(int count)
+{
+    max_count_ = count;
+    pos_   = 0;
+}
+
+void NavigationHistory::add(edb::address_t address)
+{
+    if (list_.size() == max_count_)
+    {
+        list_.removeFirst();
+        --pos_;
+    }
+    
+    if (!list_.isEmpty())
+    {
+        if (lastop_ == LASTOP_PREV && address == list_.at(pos_))
+            return;
+        if (lastop_ == LASTOP_NEXT && address == list_.at(pos_-1))
+            return;
+        for (int i = list_.size() - 1; i >= pos_; i--)
+        {
+            if (address == list_.at(i))
+                return;
+        }
+    }
+    
+    pos_ = list_.size();
+    list_.append(address);
+    lastop_ = LASTOP_NONE;
+}
+
+edb::address_t NavigationHistory::getNext()
+{
+    if (list_.isEmpty())
+    {
+        return (edb::address_t)0;
+    }
+    
+    if (pos_ != (list_.size() - 1))
+    {
+        ++pos_;
+    }
+
+    lastop_ = LASTOP_NEXT;
+    return list_.at(pos_);
+    
+}
+
+edb::address_t NavigationHistory::getPrev()
+{
+    if (list_.isEmpty())
+    {
+        return (edb::address_t)0;
+    }
+    
+    if (pos_ != 0)
+    {
+        --pos_;
+    }
+    
+    lastop_ = LASTOP_PREV;
+    return list_.at(pos_);
+}

--- a/src/widgets/NavigationHistory.cpp
+++ b/src/widgets/NavigationHistory.cpp
@@ -1,5 +1,4 @@
 #include "NavigationHistory.h"
-#include <QDebug>
 
 NavigationHistory::NavigationHistory(int count)
 {

--- a/src/widgets/NavigationHistory.h
+++ b/src/widgets/NavigationHistory.h
@@ -1,0 +1,24 @@
+#ifndef NAVIGATIONHISTORY_H_
+#define NAVIGATIONHISTORY_H_
+
+#include "edb.h"
+
+#include <QList>
+
+class NavigationHistory
+{
+    enum LASTOP {LASTOP_NONE = 0, LASTOP_PREV, LASTOP_NEXT};
+public:
+    NavigationHistory(int count = 100);
+    void add(edb::address_t address);
+    edb::address_t getNext();
+    edb::address_t getPrev();
+
+private:
+    QList<edb::address_t> list_;
+    int pos_;
+    int max_count_;
+    int lastop_;
+};
+
+#endif // NAVIGATIONHISTORY_H_

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -230,19 +230,56 @@ QDisassemblyView::~QDisassemblyView() {
 // Name: keyPressEvent
 //------------------------------------------------------------------------------
 void QDisassemblyView::keyPressEvent(QKeyEvent *event) {
-	if (event->matches(QKeySequence::MoveToStartOfDocument)) {
-		verticalScrollBar()->setValue(0);
-	} else if (event->matches(QKeySequence::MoveToEndOfDocument)) {
-		verticalScrollBar()->setValue(verticalScrollBar()->maximum());
-	} else if (event->matches(QKeySequence::MoveToNextLine)) {
-		scrollbar_action_triggered(QAbstractSlider::SliderSingleStepAdd);
-	} else if (event->matches(QKeySequence::MoveToPreviousLine)) {
-		scrollbar_action_triggered(QAbstractSlider::SliderSingleStepSub);
-	} else if (event->matches(QKeySequence::MoveToNextPage)) {
-		scrollbar_action_triggered(QAbstractSlider::SliderPageStepAdd);
-	} else if (event->matches(QKeySequence::MoveToPreviousPage)) {
-		scrollbar_action_triggered(QAbstractSlider::SliderPageStepSub);
-	}
+    if (event->matches(QKeySequence::MoveToStartOfDocument)) {
+        verticalScrollBar()->setValue(0);
+    } else if (event->matches(QKeySequence::MoveToEndOfDocument)) {
+        verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+    } else if (event->matches(QKeySequence::MoveToNextLine)) {
+        const edb::address_t next_address = following_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
+        if (!addressShown(next_address))
+            scrollTo(next_address);
+        setSelectedAddress(next_address);
+    } else if (event->matches(QKeySequence::MoveToPreviousLine)) {
+        const edb::address_t prev_address = previous_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
+        if (!addressShown(prev_address))
+            scrollTo(prev_address);
+        setSelectedAddress(prev_address);
+    } else if (event->matches(QKeySequence::MoveToNextPage)) {
+        scrollbar_action_triggered(QAbstractSlider::SliderPageStepAdd);
+    } else if (event->matches(QKeySequence::MoveToPreviousPage)) {
+        scrollbar_action_triggered(QAbstractSlider::SliderPageStepSub);
+    } else if (event->key() == Qt::Key_Return) {
+        const edb::address_t address = selectedAddress();
+        if (address == 0)
+            return;
+        quint8 buf[edb::Instruction::MAX_SIZE + 1];
+        int buf_size = sizeof(buf);
+        if (edb::v1::get_instruction_bytes(address, buf, &buf_size)) {
+            edb::Instruction inst(buf, buf + buf_size, address);
+            if (inst) {
+                if(is_call(inst) || is_jump(inst)) {
+                    if(inst.operand_count() != 1) {
+                        return;
+                    }
+                    const edb::Operand &oper = inst.operands()[0];
+                    if(oper.general_type() == edb::Operand::TYPE_REL) {
+                        const edb::address_t target = oper.relative_target();
+                        edb::v1::jump_to_address(target);
+                    }
+                }
+            }
+        }
+    } else if (event->key() == Qt::Key_Minus) {
+        edb::address_t prev_addr = history_.getPrev();
+        if (prev_addr != 0) {
+            edb::v1::jump_to_address(prev_addr);
+        }
+    } else if (event->key() == Qt::Key_Plus) {
+        edb::address_t next_addr = history_.getNext();
+        if (next_addr != 0) {
+            edb::v1::jump_to_address(next_addr);
+        }
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -1335,6 +1372,7 @@ edb::address_t QDisassemblyView::selectedAddress() const {
 void QDisassemblyView::setSelectedAddress(edb::address_t address) {
 
 	if(region_) {
+                history_.add(address);
 		const Result<int> size = get_instruction_size(address);
 
 		if(size) {

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -262,7 +262,7 @@ void QDisassemblyView::keyPressEvent(QKeyEvent *event) {
                         return;
                     }
                     const edb::Operand &oper = inst.operands()[0];
-                    if(oper.general_type() == edb::Operand::TYPE_REL) {
+                    if(oper.type() == edb::Operand::TYPE_REL) {
                         const edb::address_t target = oper.relative_target();
                         edb::v1::jump_to_address(target);
                     }

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define QDISASSEMBLYVIEW_20061101_H_
 
 #include "IRegion.h"
+#include "NavigationHistory.h"
 #include "Types.h"
 #include "Status.h"
 #include <QAbstractScrollArea>
@@ -126,6 +127,7 @@ private:
 	bool                              selecting_address_;
 	bool                              show_address_separator_;
 	QHash<edb::address_t, QString>    comments_;
+        NavigationHistory                 history_;
 };
 
 #endif


### PR DESCRIPTION
Saves the last 100(customizable) movements.
Keys for navigation: Enter, Plus, Minus.
Fix scroll up/down to navigate the lines