### PR TITLE
Improve the UX of get_expression_from_user

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(edb_SRCS
 	DialogPlugins.cpp
 	DialogThreads.cpp
 	edb.cpp
+	ExpressionDialog.cpp
 	FixedFontSelector.cpp
 	FloatX.cpp
 	Function.cpp

--- a/src/ExpressionDialog.cpp
+++ b/src/ExpressionDialog.cpp
@@ -1,0 +1,81 @@
+#include "ExpressionDialog.h"
+#include "Expression.h"
+
+#include <QPushButton>
+#include <QCompleter>
+
+ExpressionDialog::ExpressionDialog(const QString &title, const QString prompt) :
+	QDialog(edb::v1::debugger_ui),
+	layout_(this),
+	label_text_("Replace me"),
+	button_box_(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal)
+{
+	setWindowTitle(title);
+	label_text_.setText(prompt);
+	connect(&button_box_, SIGNAL(accepted()), this, SLOT(accept()));
+	connect(&button_box_, SIGNAL(rejected()), this, SLOT(reject()));
+
+	layout_.addWidget(&label_text_);
+	layout_.addWidget(&expression_);
+	layout_.addWidget(&label_error_);
+	layout_.addWidget(&button_box_);
+
+	palette_error_.setColor(QPalette::WindowText, Qt::red);
+	label_error_.setPalette(palette_error_);
+
+	button_box_.button(QDialogButtonBox::Ok)->setEnabled(false);
+
+	setLayout(&layout_);
+
+	connect(&expression_, SIGNAL(textChanged(const QString&)), this, SLOT(on_text_changed(const QString&)));
+	expression_.selectAll();
+
+	QList<Symbol::pointer> symbols = edb::v1::symbol_manager().symbols();
+	QList<QString> allLabels;
+
+	for(const Symbol::pointer &sym: symbols)
+	{
+		allLabels.append(sym->name_no_prefix);
+	}
+	allLabels.append(edb::v1::symbol_manager().labels().values());
+
+	QCompleter *completer = new QCompleter(allLabels);
+	expression_.setCompleter(completer);
+	allLabels.clear();
+}
+
+void ExpressionDialog::on_text_changed(const QString& text) {
+	QHash<edb::address_t, QString> labels = edb::v1::symbol_manager().labels();
+	edb::address_t resAddr = labels.key(text);
+
+	bool retval = false;
+
+	if (resAddr)
+	{
+		last_address_ = resAddr;
+		retval = true;
+	}
+	else
+	{
+		Expression<edb::address_t> expr(text, edb::v1::get_variable, edb::v1::get_value);
+		ExpressionError err;
+
+		bool ok;
+		last_address_ = expr.evaluate_expression(&ok, &err);
+		if(ok) {
+			retval = true;
+		} else {
+			label_error_.setText(err.what());
+			retval = false;
+		}
+	}
+
+	button_box_.button(QDialogButtonBox::Ok)->setEnabled(retval);
+	if (retval) {
+		label_error_.clear();
+	}
+}
+
+edb::address_t ExpressionDialog::getAddress() {
+	return last_address_;
+}

--- a/src/ExpressionDialog.h
+++ b/src/ExpressionDialog.h
@@ -1,0 +1,27 @@
+#include "edb.h"
+#include "ISymbolManager.h"
+
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QDialogButtonBox>
+#include <QPalette>
+
+class ExpressionDialog : public QDialog {
+	Q_OBJECT
+	private:
+		QVBoxLayout layout_;
+		QLabel label_text_;
+		QLabel label_error_;
+		QLineEdit expression_;
+		QDialogButtonBox button_box_;
+		QPalette palette_error_;
+		edb::address_t last_address_;
+	public:
+		ExpressionDialog(const QString &title, const QString prompt);
+
+		edb::address_t getAddress();
+	private slots:
+		void on_text_changed(const QString& text);
+};

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "State.h"
 #include "SymbolManager.h"
 #include "version.h"
+#include "ExpressionDialog.h"
 
 #include <QAction>
 #include <QAtomicPointer>
@@ -43,15 +44,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDomDocument>
 #include <QFile>
 #include <QFileInfo>
-#include <QInputDialog>
 #include <QMessageBox>
-#include <QLabel>
 #include <QCoreApplication>
-
 #include <cctype>
 
 IDebugger *edb::v1::debugger_core = 0;
 QWidget   *edb::v1::debugger_ui   = 0;
+
 
 namespace {
 
@@ -500,48 +499,14 @@ bool eval_expression(const QString &expression, address_t *value) {
 // Desc:
 //------------------------------------------------------------------------------
 bool get_expression_from_user(const QString &title, const QString prompt, address_t *value) {
-
     bool retval = false;
+    ExpressionDialog *inputDialog = new ExpressionDialog(title, prompt);
 
-    QInputDialog *inputDialog = new QInputDialog(debugger_ui);
-    QString label = inputDialog->labelText(); // need for create layout
-    inputDialog->setWindowTitle(title);
-    inputDialog->setLabelText(prompt);
-
-    QHash<edb::address_t, QString> labels = edb::v1::symbol_manager().labels();
-    QList<Symbol::pointer> symbols = edb::v1::symbol_manager().symbols();
-
-    QList<QString> allLabels;
-
-    for(const Symbol::pointer &sym: symbols)
+    if(inputDialog->exec())
     {
-        allLabels.append(sym->name_no_prefix);
+        *value = inputDialog->getAddress();
+        retval = true;
     }
-    allLabels.append(edb::v1::symbol_manager().labels().values());
-
-
-    QCompleter *completer = new QCompleter(allLabels);
-    QLineEdit *lineEdit = inputDialog->findChild<QLineEdit*>();
-    if (lineEdit)
-    {
-        lineEdit->setCompleter(completer);
-        if(inputDialog->exec())
-        {
-            QString text = inputDialog->textValue();
-            edb::address_t resAddr = labels.key(text);
-
-            if (resAddr)
-            {
-                *value = resAddr;
-                retval = true;
-            }
-            else
-            {
-                retval = eval_expression(text, value);
-            }
-        }
-    }
-    allLabels.clear();
     delete inputDialog;
     return retval;
 }


### PR DESCRIPTION
Fixes #466.

The expression dialog will now gray out the OK button if the expression is not valid, and will display the error message for the expression in red underneath the text entry field. This gives immediate feedback that the expression is wrong before the user closes the window. This is much better than the previous flow which interrupted the user with a dialog box and then closed the window when they made a mistake.

Even though I got the clipboard feature working that I described in my original issue, I decided it wasn't a good idea; it would be better to instead improve on the Goto dialog to include a history of the last X items the user has searched for which is closer to what the gold standard Ollydbg does.