### PR TITLE
Fix git clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cloning
 
 When cloning the repo, please use git's `--recursive` flag to ensure that the sub-modules will be properly cloned and updated to the correct versions. Here is an example:
 
-`git clone --recursive git@github.com:eteran/edb-debugger.git`
+`git clone --recursive https://github.com/eteran/edb-debugger.git`
 
 Compiling
 ---------


### PR DESCRIPTION
Just a simple fix for the README, previous command gave the following error:

```
$ git clone --recursive git@github.com:eteran/edb-debugger.git
Cloning into 'edb-debugger'...
Warning: Permanently added the RSA host key for IP address 'xxxx' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
 
Please make sure you have the correct access rights
and the repository exists.
```
Fixed with:

`git clone --recursive https://github.com/eteran/edb-debugger.git`

Now everyone should be able to clone.