### PR TITLE
Annotate constants in disassembly if they appear to point to ASCII

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -994,11 +994,12 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 					ascii_address = oper.relative_target();
 				} else if (
 					oper.type() == edb::Operand::TYPE_EXPRESSION &&
+					oper.expression().index == edb::Operand::Register::X86_REG_INVALID &&
 					oper.expression().displacement_type == edb::Operand::DISP_PRESENT)
 				{
 					if (oper.expression().base == edb::Operand::Register::X86_REG_RIP) {
 						ascii_address += address + oper.owner()->size() + oper.expression().displacement;
-					} else if (oper.expression().displacement > 0) {
+					} else if (oper.expression().base == edb::Operand::Register::X86_REG_INVALID && oper.expression().displacement > 0) {
 						ascii_address = oper.expression().displacement;
 					}
 				}

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -980,12 +980,12 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 		QString comment = comments_.value(address, QString(""));
 		if (!comment.isEmpty()) {
 			painter.drawText(
-						l3 + font_width_ + (font_width_ / 2),
-						y,
-						comment.length() * font_width_,
-						line_height,
-						Qt::AlignCenter,
-						comment);
+				l3 + font_width_ + (font_width_ / 2),
+				y,
+				comment.length() * font_width_,
+				line_height,
+				Qt::AlignCenter,
+				comment);
 		}
 
 		y += line_height;


### PR DESCRIPTION
This patch-set annotates constants in the disassembly screen which appear to point to ASCII strings.

![image](https://cloud.githubusercontent.com/assets/1189089/20461384/f07e97dc-aec1-11e6-9ebc-4b476233b81a.png)

An unfortunate limitation of my patchset is that it does not understand the constants inside relative expressions. This appears common on x64 targets. Here's a simple hello world showing that the two LEAs that are RIP-relative are not annotated:

![image](https://cloud.githubusercontent.com/assets/1189089/20461388/43ab9d06-aec2-11e6-8ffb-22aaa80ceb5a.png)

If anyone has any ideas how I can fix this corner case, I'm all ears.