### PR TITLE
Fix incorrect entry point detection for ELF32/64

### DIFF
--- a/plugins/BinaryInfo/ELF32.cpp
+++ b/plugins/BinaryInfo/ELF32.cpp
@@ -78,7 +78,7 @@ bool ELF32::native() const {
 edb::address_t ELF32::entry_point() {
 	read_header();
 	if(header_) {
-		return header_->e_entry;
+		return header_->e_entry + region_->start();
 	}
 	return 0;
 }

--- a/plugins/BinaryInfo/ELF64.cpp
+++ b/plugins/BinaryInfo/ELF64.cpp
@@ -78,7 +78,7 @@ bool ELF64::native() const {
 edb::address_t ELF64::entry_point() {
 	read_header();
 	if(header_) {
-		return header_->e_entry;
+		return header_->e_entry + region_->start();
 	}
 	return 0;
 }


### PR DESCRIPTION
ELF32 and ELF64 incorrectly return the offset to the entrypoint instead of the actual entrypoint address (in my example it tried to add a breakpoint to 0x580 instead of 0x55550580). This breaks `Debugger::set_initial_breakpoint`'s attempt at setting a breakpoint on the application's entrypoint, forcing the developer to step through the linux loader code for a long time.