### PR TITLE
Fix /proc/<pid>/stat parse failure when binary name has .

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
@@ -59,7 +59,7 @@ int get_user_stat(const QString &path, struct user_stat *user_stat) {
 		const QString line = in.readLine();
 		if(!line.isNull()) {
 			char ch;
-			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_ #~/-]%c %c %d %d %d %d %d %u %llu %llu %llu %llu %llu %llu %lld %lld %lld %lld %lld %lld %llu %llu %lld %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %d %d %u %u %llu %llu %lld",
+			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_ #~/-\\.]%c %c %d %d %d %d %d %u %llu %llu %llu %llu %llu %llu %lld %lld %lld %lld %lld %lld %llu %llu %lld %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %d %d %u %u %llu %llu %lld",
 					&user_stat->pid,
 					&ch, // consume the (
 					user_stat->comm,


### PR DESCRIPTION
This fixes an issue where my executable named "test2.5" would fail to have any entrypoint detected for it at all. Turns out this was because the parsing of /proc/<pid>/stat was failing its match expression which has a whitelist of sane characters to expect.

I don't feel like this whitelist is a good idea because  binaries can have any name in unix as long as it doesn't contain a NUL or / character. But I'll do the cheap and easy fix for my case instead.