### PR TITLE
Add CPU Region information above Disassembly view

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2267,7 +2267,6 @@ void Debugger::update_tab_caption(const std::shared_ptr<QHexView> &view, edb::ad
 // Desc:
 //------------------------------------------------------------------------------
 void Debugger::update_data(const DataViewInfo::pointer &v) {
-
 	Q_ASSERT(v);
 
 	const std::shared_ptr<QHexView> &view = v->view;
@@ -2356,7 +2355,6 @@ IRegion::pointer Debugger::update_cpu_view(const State &state) {
 // Desc:
 //------------------------------------------------------------------------------
 void Debugger::update_data_views() {
-
 	// update all data views with the current region data
 	for(const DataViewInfo::pointer &info: data_regions_) {
 
@@ -2366,6 +2364,24 @@ void Debugger::update_data_views() {
 		} else {
 			clear_data(info);
 		}
+	}
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+
+void Debugger::on_cpuView_regionChanged() {
+	const IRegion::pointer region = edb::v1::current_cpu_view_region();
+	if (region && region->size() != 0) {
+		ui.cpuRegionLabel->setText(QString("CPU: [%1-%2] %3").arg(
+			QString::number(region->start(), 16),
+			QString::number(region->end(), 16),
+			region->name().split(QDir::separator()).last()
+		));
+	} else {
+		ui.cpuRegionLabel->setText("CPU");
 	}
 }
 
@@ -2384,13 +2400,13 @@ void Debugger::refresh_gui() {
 
 	if(edb::v1::debugger_core) {
 		State state;
-				
+
 		if(IProcess *process = edb::v1::debugger_core->process()) {
-			if(IThread::pointer thread = process->current_thread()) {					
+			if(IThread::pointer thread = process->current_thread()) {
 				thread->get_state(&state);
 			}
 		}
-		
+
 		list_model_->setStringList(edb::v1::arch_processor().update_instruction_info(state.instruction_pointer()));
 	}
 }
@@ -2400,12 +2416,11 @@ void Debugger::refresh_gui() {
 // Desc: updates all the different displays
 //------------------------------------------------------------------------------
 void Debugger::update_gui() {
-
 	if(edb::v1::debugger_core) {
-		
+
 		State state;
 		if(IProcess *process = edb::v1::debugger_core->process()) {
-			if(IThread::pointer thread = process->current_thread()) {				
+			if(IThread::pointer thread = process->current_thread()) {
 				thread->get_state(&state);
 			}
 		}

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -135,6 +135,7 @@ public Q_SLOTS:
 	void on_action_Threads_triggered();
 	void on_cpuView_breakPointToggled(edb::address_t);
 	void on_cpuView_customContextMenuRequested(const QPoint &);
+	void on_cpuView_regionChanged();
 	QList<QAction*> getCurrentRegisterContextMenuItems() const;
 	Register active_register() const;
 
@@ -152,6 +153,7 @@ private:
 	void toggle_flag(int);
 
 	void run_to_this_line(bool pass_signal);
+	void update_cpu_region_label();
 	
 private Q_SLOTS:
 	// the manually connected general slots

--- a/src/Debugger.ui
+++ b/src/Debugger.ui
@@ -17,6 +17,9 @@
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
+     <widget class="QLabel" name="cpuRegionLabel" />
+    </item>
+    <item>
      <widget class="QDisassemblyView" name="cpuView" native="true"/>
     </item>
     <item>


### PR DESCRIPTION
This adds a little "you are here" indicator above the CPU region view. The idea is that this will help you tell where you are.

![image](https://cloud.githubusercontent.com/assets/1189089/20721434/59fbb880-b628-11e6-9de0-efc53ca686b0.png)

I'm pretty happy with this except that I can't figure out why my label and the "Registers" label to the right are not vertically aligned with one another. That's a bit nit-picky though so I'm not going to hold up my PR over it.