### PR TITLE
Implement bare minimum PE32

### DIFF
--- a/plugins/BinaryInfo/PE32.h
+++ b/plugins/BinaryInfo/PE32.h
@@ -24,6 +24,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace BinaryInfo {
 
+class PEBinaryException : public std::exception {
+	public:
+	enum reasonEnum {
+		INVALID_ARGUMENTS = 1,
+		READ_FAILURE = 2,
+		INVALID_PE = 3,
+		INVALID_ARCHITECTURE = 4
+	};
+		PEBinaryException(reasonEnum reason);
+
+		virtual const char * what();
+
+	private:
+		reasonEnum reason_;
+};
+
 class PE32 : public IBinary {
 public:
 	PE32(const IRegion::pointer &region);
@@ -39,6 +55,8 @@ public:
 
 private:
 	IRegion::pointer region_;
+	IMAGE_DOS_HEADER dos_;
+	IMAGE_NT_HEADERS32 pe_;
 };
 
 }

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -827,9 +827,10 @@ std::unique_ptr<IBinary> get_binary_info(const IRegion::pointer &region) {
 		}
 	}
 
+#if 0
 	qDebug() << "Failed to find any binary parser for region"
 		<< QString::number(region->start(), 16);
-
+#endif
 	return nullptr;
 }
 


### PR DESCRIPTION
I'm not sure if this is enough to actually be able to run edb on windows, but this does successfully decode the header of a 32bit windows application running under wine on my machine.

I also removed a debug string I had added because it was never actually triggering before because every single region that should have had no binary at all was instead being picked up as PE32 since it had no sanity checks at all.