### PR TITLE
Improve Analysis ("Basic blocks") Performance

### DIFF
--- a/plugins/Analyzer/Analyzer.cpp
+++ b/plugins/Analyzer/Analyzer.cpp
@@ -812,22 +812,20 @@ Result<edb::address_t> Analyzer::find_containing_function(edb::address_t address
 //------------------------------------------------------------------------------
 bool Analyzer::will_return(edb::address_t address) const {
 
-	const QList<Symbol::pointer> symbols = edb::v1::symbol_manager().symbols();
-	for(const Symbol::pointer &symbol: symbols) {
-		if(symbol->address == address) {
-			const QString symname = symbol->name_no_prefix;
-			const QString func_name = symname.mid(0, symname.indexOf("@"));
+	const Symbol::pointer symbol = edb::v1::symbol_manager().find(address);
+	if(symbol) {
+		const QString symname = symbol->name_no_prefix;
+		const QString func_name = symname.mid(0, symname.indexOf("@"));
 
-			if(func_name == "__assert_fail" || func_name == "abort" || func_name == "_exit" || func_name == "_Exit" || func_name == "_dl_signal_error" || func_name == "_dl_signal_cerror") {
-				return false;
-			}
+		if(func_name == "__assert_fail" || func_name == "abort" || func_name == "_exit" || func_name == "_Exit" || func_name == "_dl_signal_error" || func_name == "_dl_signal_cerror") {
+			return false;
+		}
 
 #ifdef Q_OS_LINUX
-			if(func_name == "_Unwind_Resume") {
-				return false;
-			}
-#endif
+		if(func_name == "_Unwind_Resume") {
+			return false;
 		}
+#endif
 	}
 
 


### PR DESCRIPTION
Fixes #488

Basic blocks was calling `will_return` frequently which was doing a linear search through the symbols map when a faster map lookup was available. Changing this reduced my analysis time to 20 seconds (from 170). 