### PR TITLE
Reg badges

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -89,6 +89,7 @@ public:
 
 	// disassembly tab
 	Syntax            syntax;
+	bool show_register_badges;
 	bool 			  syntax_highlighting_enabled;
 	bool              zeros_are_filling;
 	bool              uppercase_disassembly;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -116,6 +116,7 @@ void Configuration::read_settings() {
 	uppercase_disassembly = settings.value("disassembly.uppercase.enabled", false).value<bool>();
 	small_int_as_decimal  = settings.value("disassembly.small_int_as_decimal.enabled", false).value<bool>();
 	tab_between_mnemonic_and_operands=settings.value("disassembly.tab_between_mnemonic_and_operands.enabled", false).value<bool>();
+	show_register_badges = settings.value("disassembly.show_register_badges.enabled", true).value<bool>();
 	show_local_module_name_in_jump_targets = settings.value("disassembly.show_local_module_name_in_jump_targets.enabled", true).value<bool>();
 	show_symbolic_addresses = settings.value("disassembly.show_symbolic_addresses.enabled", true).value<bool>();
 	simplify_rip_relative_targets = settings.value("disassembly.simplify_rip_relative_targets.enabled", true).value<bool>();

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -177,6 +177,7 @@ void DialogOptions::showEvent(QShowEvent *event) {
 	ui->chkDisableLazyBinding->setChecked(config.disableLazyBinding);
 
 	ui->chkZerosAreFilling->setChecked(config.zeros_are_filling);
+	ui->chkRegisterBadges->setChecked(config.show_register_badges);
 	ui->chkUppercase->setChecked(config.uppercase_disassembly);
 	ui->chkSmallIntAsDecimal->setChecked(config.small_int_as_decimal);
 	ui->chkSyntaxHighlighting->setChecked(config.syntax_highlighting_enabled);
@@ -254,6 +255,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	config.disableLazyBinding	 = ui->chkDisableLazyBinding->isChecked();
 	
 	config.zeros_are_filling     = ui->chkZerosAreFilling->isChecked();
+	config.show_register_badges = ui->chkRegisterBadges->isChecked();
 	config.uppercase_disassembly = ui->chkUppercase->isChecked();
 	config.small_int_as_decimal  = ui->chkSmallIntAsDecimal->isChecked();
 	config.syntax_highlighting_enabled = ui->chkSyntaxHighlighting->isChecked();

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -573,6 +573,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="chkRegisterBadges">
+         <property name="text">
+          <string>Show when registers are pointing to a visible address</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="chkUppercase">
          <property name="text">
           <string>Disassemble in uppercase</string>

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -106,6 +106,7 @@ private:
 	void updateScrollbars();
 	void updateSelectedAddress(QMouseEvent *event);
 	void paint_line_bg(QPainter &painter, QBrush brush, int line, int num_lines = 1);
+	bool get_line_of_address(edb::address_t addr, unsigned int& line) const;
 
 private:
 	IRegion::pointer                  region_;


### PR DESCRIPTION
This adds register badges as described in #486 

 * I look for both registers and the values pointed to by registers. The latter might not be very useful but I don't think it hurts anything.
 * If multiple registers point to the same place we append the strings together (badge says `eax, ebx`. this will definitely make us paint over the addresses, though. 
 * They are always white text on blue background. We should probably figure out how we can use the palette to make these badges themeable instead.
 * I changed the line1/line2/line3 resize code so that if the user moves the mouse quickly, instead of ignoring the resize, we resize to the minimum.