### PR TITLE
Remove "hinted" lookups from (I)Analyzer

### DIFF
--- a/include/IAnalyzer.h
+++ b/include/IAnalyzer.h
@@ -44,12 +44,10 @@ public:
 
 public:
 	virtual AddressCategory category(edb::address_t address) const = 0;
-	virtual AddressCategory category(edb::address_t address, edb::address_t address_hint) const = 0;
 	virtual FunctionMap functions(const IRegion::pointer &region) const = 0;
 	virtual FunctionMap functions() const = 0;
 	virtual QSet<edb::address_t> specified_functions() const { return QSet<edb::address_t>(); }
 	virtual Result<edb::address_t> find_containing_function(edb::address_t address) const = 0;
-	virtual Result<edb::address_t> find_containing_function(edb::address_t address, edb::address_t hint_address) const = 0;
 	virtual void analyze(const IRegion::pointer &region) = 0;
 	virtual void invalidate_analysis() = 0;
 	virtual void invalidate_analysis(const IRegion::pointer &region) = 0;

--- a/plugins/Analyzer/Analyzer.h
+++ b/plugins/Analyzer/Analyzer.h
@@ -63,12 +63,10 @@ private:
 
 public:
 	virtual AddressCategory category(edb::address_t address) const;
-	virtual AddressCategory category(edb::address_t address, edb::address_t address_hint) const;
 	virtual FunctionMap functions(const IRegion::pointer &region) const;
 	virtual FunctionMap functions() const;
 	virtual QSet<edb::address_t> specified_functions() const { return specified_functions_; }
 	virtual Result<edb::address_t> find_containing_function(edb::address_t address) const;
-	virtual Result<edb::address_t> find_containing_function(edb::address_t address, edb::address_t hint_address) const;
 	virtual void analyze(const IRegion::pointer &region);
 	virtual void invalidate_analysis();
 	virtual void invalidate_analysis(const IRegion::pointer &region);
@@ -77,7 +75,6 @@ public:
 private:
 	QByteArray md5_region(const IRegion::pointer &region) const;
 	bool find_containing_function(edb::address_t address, Function *function) const;
-	bool find_containing_function(edb::address_t address, edb::address_t hint_address, Function *function) const;
 	bool is_thunk(edb::address_t address) const;
 	bool will_return(edb::address_t address) const;
 	void bonus_entry_point(RegionData *data) const;

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -294,9 +294,6 @@ edb::address_t QDisassemblyView::previous_instructions(edb::address_t current_ad
 
 	IAnalyzer *const analyzer = edb::v1::analyzer();
 
-	static edb::address_t last_found_function = 0;
-
-
 	for(int i = 0; i < count; ++i) {
 
 		// If we have an analyzer, and the current address is within a function
@@ -311,14 +308,9 @@ edb::address_t QDisassemblyView::previous_instructions(edb::address_t current_ad
 			edb::address_t address = address_offset_ + current_address;
 
 			// find the containing function
-			if(Result<edb::address_t> function_address = analyzer->find_containing_function(address, last_found_function)) {
+			if(Result<edb::address_t> function_address = analyzer->find_containing_function(address)) {
 
-				const IAnalyzer::AddressCategory cat = analyzer->category(address, last_found_function);
-
-				last_found_function = *function_address;
-
-				if(cat != IAnalyzer::ADDRESS_FUNC_START) {
-
+				if(address != *function_address) {
 					edb::address_t function_start = *function_address;
 
 					// disassemble from function start until the NEXT address is where we started


### PR DESCRIPTION
@eteran implemented a hint API on the Analyzer after I suggested it might make the analyzer function lookups faster, and it probably did. However, experience has taught us well, and now we know that `QMap::upperBound` could have been used instead as a much faster way to find the exact entry we were looking for thanks to the fact QMap uses skip lists. So I undid most of that work we did and replaced `find_containing_function`'s iteration with `upperBound` usage. I've tested for correctness but not performance, but I think we can all agree it is hard to imagine performance being any worse after this.