### PR TITLE
Fix processes with hyphens failing get_user_stat

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformCommon.cpp
@@ -59,7 +59,7 @@ int get_user_stat(const QString &path, struct user_stat *user_stat) {
 		const QString line = in.readLine();
 		if(!line.isNull()) {
 			char ch;
-			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_ #~/-\\.]%c %c %d %d %d %d %d %u %llu %llu %llu %llu %llu %llu %lld %lld %lld %lld %lld %lld %llu %llu %lld %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %d %d %u %u %llu %llu %lld",
+			r = sscanf(qPrintable(line), "%d %c%255[0-9a-zA-Z_- #~/\\.]%c %c %d %d %d %d %d %u %llu %llu %llu %llu %llu %llu %lld %lld %lld %lld %lld %lld %llu %llu %lld %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %llu %d %d %u %u %llu %llu %lld",
 					&user_stat->pid,
 					&ch, // consume the (
 					user_stat->comm,


### PR DESCRIPTION
I am on a roll today (fixing bugs that I introduced)!

It looks like the meaning of the hyphen character is position-dependent: when I added the dot character to the scanf expression a few weeks ago, I added it adjacent to the hyphen which apparently changed its meaning to a range, which did not include the hyphen. This caused an infinite loop when trying to attach to a process which had a parent process whose name had hyphens in it. I am not entirely sure what the deal with that was.