### PR TITLE
Analysis improvements

### DIFF
--- a/plugins/Analyzer/Analyzer.cpp
+++ b/plugins/Analyzer/Analyzer.cpp
@@ -521,16 +521,6 @@ void Analyzer::collect_functions(Analyzer::RegionData *data) {
 		}
 	}
 
-	qDebug() << "----------Basic Blocks----------";
-	for(auto it = basic_blocks.begin(); it != basic_blocks.end(); ++it) {
-		qDebug("%s:", qPrintable(it.key().toPointerString()));
-
-		for(auto &&inst : it.value()) {
-			qDebug("\t%s: %s", qPrintable(edb::address_t(inst->rva()).toPointerString()), edb::v1::formatter().to_string(*inst).c_str());
-		}
-	}
-	qDebug() << "----------Basic Blocks----------";
-
 	qSwap(data->basic_blocks, basic_blocks);
 	qSwap(data->functions, functions);
 }

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 #include <cstdint>
+#include <QString>
 
 namespace CapstoneEDB {
 
@@ -112,7 +113,6 @@ private:
 class Instruction
 {
 	friend class Operand;
-    friend class Formatter;
 public:
 	using Operation=Capstone::x86_insn;
 	enum Prefix {
@@ -266,6 +266,8 @@ private:
 	FormatOptions options_={SyntaxIntel,LowerCase,SmallNumAsDec,false,true};
 
 	void checkCapitalize(std::string& str,bool canContainHex=true) const;
+	QString adjustInstructionText(const Instruction& instruction) const;
+
 };
 
 // TODO: move into Instruction class and remove from global scope


### PR DESCRIPTION
So it turns out that capstone-edb was string-formatting instructions in the `Instruction` constructor, even if the consumer of the instructions had no intention of ever using those strings for anything. By moving this string formatting into the Formatter (where it probably should have always been), we can improve performance for those use cases.

Notably, in my tests, this improves analysis performance by about *3.7x*.

```
[Analyzer] elapsed: 117828 ms
[Analyzer] elapsed: 31546 ms
```