### PR TITLE
Improve arrow-key selection navigation somewhat

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -231,56 +231,67 @@ void QDisassemblyView::resetColumns() {
 // Name: keyPressEvent
 //------------------------------------------------------------------------------
 void QDisassemblyView::keyPressEvent(QKeyEvent *event) {
-    if (event->matches(QKeySequence::MoveToStartOfDocument)) {
-        verticalScrollBar()->setValue(0);
-    } else if (event->matches(QKeySequence::MoveToEndOfDocument)) {
-        verticalScrollBar()->setValue(verticalScrollBar()->maximum());
-    } else if (event->matches(QKeySequence::MoveToNextLine)) {
-        const edb::address_t next_address = following_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
-        if (!addressShown(next_address))
-            scrollTo(next_address);
-        setSelectedAddress(next_address);
-    } else if (event->matches(QKeySequence::MoveToPreviousLine)) {
-        const edb::address_t prev_address = previous_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
-        if (!addressShown(prev_address))
-            scrollTo(prev_address);
-        setSelectedAddress(prev_address);
-    } else if (event->matches(QKeySequence::MoveToNextPage)) {
-        scrollbar_action_triggered(QAbstractSlider::SliderPageStepAdd);
-    } else if (event->matches(QKeySequence::MoveToPreviousPage)) {
-        scrollbar_action_triggered(QAbstractSlider::SliderPageStepSub);
-    } else if (event->key() == Qt::Key_Return) {
-        const edb::address_t address = selectedAddress();
-        if (address == 0)
-            return;
-        quint8 buf[edb::Instruction::MAX_SIZE + 1];
-        int buf_size = sizeof(buf);
-        if (edb::v1::get_instruction_bytes(address, buf, &buf_size)) {
-            edb::Instruction inst(buf, buf + buf_size, address);
-            if (inst) {
-                if(is_call(inst) || is_jump(inst)) {
-                    if(inst.operand_count() != 1) {
-                        return;
-                    }
-                    const edb::Operand &oper = inst.operands()[0];
-                    if(oper.type() == edb::Operand::TYPE_REL) {
-                        const edb::address_t target = oper.relative_target();
-                        edb::v1::jump_to_address(target);
-                    }
-                }
-            }
-        }
-    } else if (event->key() == Qt::Key_Minus) {
-        edb::address_t prev_addr = history_.getPrev();
-        if (prev_addr != 0) {
-            edb::v1::jump_to_address(prev_addr);
-        }
-    } else if (event->key() == Qt::Key_Plus) {
-        edb::address_t next_addr = history_.getNext();
-        if (next_addr != 0) {
-            edb::v1::jump_to_address(next_addr);
-        }
-    }
+	if (event->matches(QKeySequence::MoveToStartOfDocument)) {
+		verticalScrollBar()->setValue(0);
+	} else if (event->matches(QKeySequence::MoveToEndOfDocument)) {
+		verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+	} else if (event->matches(QKeySequence::MoveToNextLine)) {
+		const int idx = show_addresses_.indexOf(selectedAddress());
+		if (idx > 0 && idx < show_addresses_.size()-1) {
+			setSelectedAddress(show_addresses_[idx + 1]);
+		} else {
+			const edb::address_t next_address = following_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
+			if (!addressShown(next_address))
+				scrollTo(show_addresses_.size() > 1 ? show_addresses_[show_addresses_.size()/3] : next_address);
+			setSelectedAddress(next_address);
+		}
+	} else if (event->matches(QKeySequence::MoveToPreviousLine)) {
+		const int idx = show_addresses_.indexOf(selectedAddress());
+		if (idx > 0) {
+			// we already know the previous instruction
+			setSelectedAddress(show_addresses_[idx - 1]);
+		} else {
+			const edb::address_t prev_address = previous_instructions(selectedAddress()-address_offset_, 1) + address_offset_;
+			if (!addressShown(prev_address))
+				scrollTo(prev_address);
+			setSelectedAddress(prev_address);
+		}
+	} else if (event->matches(QKeySequence::MoveToNextPage)) {
+		scrollbar_action_triggered(QAbstractSlider::SliderPageStepAdd);
+	} else if (event->matches(QKeySequence::MoveToPreviousPage)) {
+		scrollbar_action_triggered(QAbstractSlider::SliderPageStepSub);
+	} else if (event->key() == Qt::Key_Return) {
+		const edb::address_t address = selectedAddress();
+		if (address == 0)
+			return;
+		quint8 buf[edb::Instruction::MAX_SIZE + 1];
+		int buf_size = sizeof(buf);
+		if (edb::v1::get_instruction_bytes(address, buf, &buf_size)) {
+			edb::Instruction inst(buf, buf + buf_size, address);
+			if (inst) {
+				if(is_call(inst) || is_jump(inst)) {
+					if(inst.operand_count() != 1) {
+						return;
+					}
+					const edb::Operand &oper = inst.operands()[0];
+					if(oper.type() == edb::Operand::TYPE_REL) {
+						const edb::address_t target = oper.relative_target();
+						edb::v1::jump_to_address(target);
+					}
+				}
+			}
+		}
+	} else if (event->key() == Qt::Key_Minus) {
+		edb::address_t prev_addr = history_.getPrev();
+		if (prev_addr != 0) {
+			edb::v1::jump_to_address(prev_addr);
+		}
+	} else if (event->key() == Qt::Key_Plus) {
+		edb::address_t next_addr = history_.getNext();
+		if (next_addr != 0) {
+			edb::v1::jump_to_address(next_addr);
+		}
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I recommend viewing the diff with ?w=1 at the end of the URL to ignore whitespace.

This changeset makes it so that using the arrow keys to navigate within the current viewport does not need to call previous_instruction or forward_instruction.

It also makes it so that using the arrow keys to navigate downward past the viewport's bottom no longer causes the viewport view to shift down by a whole page; now we only scroll down 1/3rd of the viewport. This makes it less likely to get lost. This still isn't as great as I'd like it to be, but this will have to do for now since making it scroll the viewport down one instruction seems to have issues relating to instructions that were disassembled incorrectly.