### PR TITLE
Cache Syntax Highlighting results

### DIFF
--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -199,7 +199,8 @@ QDisassemblyView::QDisassemblyView(QWidget * parent) : QAbstractScrollArea(paren
 		selecting_address_(false),
         breakpoint_renderer_(QLatin1String(":/debugger/images/breakpoint.svg")),
         current_renderer_(QLatin1String(":/debugger/images/arrow-right.svg")),
-        current_bp_renderer_(QLatin1String(":/debugger/images/arrow-right-red.svg")) {
+        current_bp_renderer_(QLatin1String(":/debugger/images/arrow-right-red.svg")),
+	syntax_cache_(256) {
 
 	setShowAddressSeparator(true);
 
@@ -606,11 +607,12 @@ bool targetIsLocal(edb::address_t targetAddress,edb::address_t insnAddress) {
 // Name: draw_instruction
 // Desc:
 //------------------------------------------------------------------------------
-int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction &inst, int y, int line_height, int l2, int l3, bool selected) const {
+int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction &inst, int y, int line_height, int l2, int l3, bool selected) {
 
 	const bool is_filling = edb::v1::arch_processor().is_filling(inst);
 	int x                 = font_width_ + font_width_ + l2 + (font_width_ / 2);
 	const int ret         = inst.size();
+	const int inst_pixel_width = l3 - x;
 
 	if(inst) {
 		QString opcode = QString::fromStdString(edb::v1::formatter().to_string(inst));
@@ -624,7 +626,7 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 				painter.setPen(filling_dis_color);
 			}
 
-			opcode = painter.fontMetrics().elidedText(opcode, Qt::ElideRight, (l3 - l2) - font_width_ * 2);
+			opcode = painter.fontMetrics().elidedText(opcode, Qt::ElideRight, inst_pixel_width);
 
 			painter.drawText(
 				x,
@@ -663,41 +665,49 @@ int QDisassemblyView::draw_instruction(QPainter &painter, const edb::Instruction
 				}
 			}
 
-			opcode = painter.fontMetrics().elidedText(opcode, Qt::ElideRight, (l3 - l2) - font_width_ * 2);
+			opcode = painter.fontMetrics().elidedText(opcode, Qt::ElideRight, inst_pixel_width);
 
 			if(syntax_highlighting_enabled) {
 				painter.setPen(default_dis_color);
 			}
 
 
-			QRectF rectangle(x, y, opcode.length() * font_width_, line_height);
 
 			if(syntax_highlighting_enabled) {
+				QPixmap* map = syntax_cache_[opcode];
+				if (map == nullptr) {
+					// create the text layout
+					QTextLayout textLayout(opcode, painter.font());
 
-				// create the text layout
-				QTextLayout textLayout(opcode, painter.font());
+					textLayout.setTextOption(QTextOption(Qt::AlignVCenter));
 
-				textLayout.setTextOption(QTextOption(Qt::AlignVCenter));
+					textLayout.beginLayout();
 
-				textLayout.beginLayout();
+					// generate the lines one at a time
+					// setting the positions as we go
+					Q_FOREVER {
+						QTextLine line = textLayout.createLine();
 
-				// generate the lines one at a time
-				// setting the positions as we go
-				Q_FOREVER {
-					QTextLine line = textLayout.createLine();
+						if (!line.isValid()) {
+							break;
+						}
 
-					if (!line.isValid()) {
-						break;
+						line.setPosition(QPoint(0, 0));
 					}
 
-					line.setPosition(QPoint(0, 0));
+					textLayout.endLayout();
+
+					map = new QPixmap(opcode.length() * font_width_, line_height);
+					map->fill(Qt::transparent);
+					QPainter cache_painter(map);
+
+					// now the render the text at the location given
+					textLayout.draw(&cache_painter, QPoint(0, 0), highlighter_->highlightBlock(opcode));
+					syntax_cache_.insert(opcode, map);
 				}
-
-				textLayout.endLayout();
-
-				// now the render the text at the location given
-				textLayout.draw(&painter, QPoint(x, y), highlighter_->highlightBlock(opcode), rectangle);
+				painter.drawPixmap(x, y, *map);
 			} else {
+				QRectF rectangle(x, y, opcode.length() * font_width_, line_height);
 				painter.drawText(rectangle, Qt::AlignVCenter, opcode);
 			}
 		}

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -96,7 +96,7 @@ private:
 	edb::address_t following_instructions(edb::address_t current_address, int count);
 	int address_length() const;
 	int auto_line1() const;
-	int draw_instruction(QPainter &painter, const edb::Instruction &inst, int y, int line_height, int l2, int l3, bool selected) const;
+	int draw_instruction(QPainter &painter, const edb::Instruction &inst, int y, int line_height, int l2, int l3, bool selected);
 	Result<int> get_instruction_size(edb::address_t address) const;
 	Result<int> get_instruction_size(edb::address_t address, quint8 *buf, int *size) const;
 	int line1() const;
@@ -134,6 +134,7 @@ private:
 	QSvgRenderer                      current_renderer_;
 	QSvgRenderer                      current_bp_renderer_;
 	QVector<quint8>                   instruction_buffer_;
+	QCache<QString, QPixmap>          syntax_cache_;
 };
 
 #endif


### PR DESCRIPTION
This improves rendering performance pretty significantly when scrolling around and clicking on stuff without jumping the viewport around a lot.

My paint times on my beefy machine went from 8-13ms to 2-3ms when the cache was getting hit consistently. This effectively eliminates a lot of the extra CPU cost of using syntax highlighting vs not using it. This reduced paint time also means that weaker machines will be more likely to keep up with 60fps (one frame every 16ms).