### PR TITLE
Cache analysis bar paint results

### DIFF
--- a/plugins/Analyzer/AnalyzerWidget.cpp
+++ b/plugins/Analyzer/AnalyzerWidget.cpp
@@ -66,42 +66,51 @@ void AnalyzerWidget::paintEvent(QPaintEvent *event) {
 
 	Q_UNUSED(event);
 
-	QPainter painter(this);
-	painter.fillRect(0, 0, width(), height(), QBrush(Qt::black));
-	QFontMetrics fm(font());
-
 	const IRegion::pointer region = edb::v1::current_cpu_view_region();
 	if (!region || region->size() == 0) {
 		return;
 	}
 
+	const QSet<edb::address_t> specified_functions = edb::v1::analyzer()->specified_functions();
+	const IAnalyzer::FunctionMap functions = edb::v1::analyzer()->functions(region);
 	const auto byte_width = static_cast<float>(width()) / region->size();
 
-	const QSet<edb::address_t> specified_functions = edb::v1::analyzer()->specified_functions();
+	if (!cache_ || width() != cache_->width() || height() != cache_->height() || cache_num_funcs_ != functions.size()) {
+		if (cache_) {
+			delete cache_;
+		}
+		cache_ = new QPixmap(width(), height());
+		cache_num_funcs_ = functions.size();
 
-	const IAnalyzer::FunctionMap functions = edb::v1::analyzer()->functions(region);
-	for(auto it = functions.begin(); it != functions.end(); ++it) {
-		const Function &f = it.value();
+		QPainter painter(cache_);
+		painter.fillRect(0, 0, width(), height(), QBrush(Qt::black));
 
-		const int first_offset = (f.entry_address() - region->start()) * byte_width;
-		const int last_offset  = (f.end_address() - region->start()) * byte_width;
+		for(auto it = functions.begin(); it != functions.end(); ++it) {
+			const Function &f = it.value();
 
-		if(!specified_functions.contains(f.entry_address())) {
-			painter.fillRect(first_offset, 0, last_offset - first_offset, height(), QBrush(Qt::darkGreen));
-		} else {
-			painter.fillRect(first_offset, 0, last_offset - first_offset, height(), QBrush(Qt::darkRed));
+			const int first_offset = (f.entry_address() - region->start()) * byte_width;
+			const int last_offset  = (f.end_address() - region->start()) * byte_width;
+
+			if(!specified_functions.contains(f.entry_address())) {
+				painter.fillRect(first_offset, 0, last_offset - first_offset, height(), QBrush(Qt::darkGreen));
+			} else {
+				painter.fillRect(first_offset, 0, last_offset - first_offset, height(), QBrush(Qt::darkRed));
+			}
+		}
+
+		// highlight header of binary (probably not going to be too noticeable but just in case)
+		if(auto binary_info = edb::v1::get_binary_info(region)) {
+			painter.fillRect(0, 0, binary_info->header_size() * byte_width, height(), QBrush(Qt::darkBlue));
 		}
 	}
 
-	// highlight header of binary (probably not going to be too noticeable but just in case)
-	if(auto binary_info = edb::v1::get_binary_info(region)) {
-		painter.fillRect(0, 0, binary_info->header_size() * byte_width, height(), QBrush(Qt::darkBlue));
-	}
-
+	QPainter painter(this);
+	painter.drawPixmap(0, 0, *cache_);
 
 	if(!functions.isEmpty()) {
 		if(auto scroll_area = qobject_cast<QAbstractScrollArea*>(edb::v1::disassembly_widget())) {
 			if(QScrollBar *scrollbar = scroll_area->verticalScrollBar()) {
+				QFontMetrics fm(font());
 				const int offset = (scrollbar->value()) * byte_width;
 
 				const QString triangle(QChar(0x25b4));

--- a/plugins/Analyzer/AnalyzerWidget.cpp
+++ b/plugins/Analyzer/AnalyzerWidget.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPainter>
 #include <QScrollBar>
 #include <QDir>
+#include <QElapsedTimer>
 
 namespace Analyzer {
 
@@ -60,6 +61,8 @@ AnalyzerWidget::AnalyzerWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(par
 // Name:
 //------------------------------------------------------------------------------
 void AnalyzerWidget::paintEvent(QPaintEvent *event) {
+	QElapsedTimer timer;
+	timer.start();
 
 	Q_UNUSED(event);
 
@@ -125,6 +128,10 @@ void AnalyzerWidget::paintEvent(QPaintEvent *event) {
 		);
 	}
 
+	const int renderTime = timer.elapsed();
+	if(renderTime > 8) {
+		qDebug() << "AnalyzerWidget: Painting took longer than desired: " << renderTime << "ms";
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/Analyzer/AnalyzerWidget.h
+++ b/plugins/Analyzer/AnalyzerWidget.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <QWidget>
+#include <QPixmap>
 
 namespace Analyzer {
 
@@ -33,6 +34,8 @@ protected:
 
 private:
 	bool mouse_pressed_;
+	QPixmap* cache_;
+	int cache_num_funcs_;
 };
 
 }


### PR DESCRIPTION
When there are a HUGE number of functions the analysis bar can take up to 35ms to paint on my machine. Since the analysis bar looks exactly the same on basically every render, we instead paint the base analysis bar onto a buffer and cache it. Then, if none of the dimensions or number of functions have changed, we blit the buffer back and then paint the yellow triangle "You are here" indicator over the buffer.

This dramatically improves the performance of the Analyzer bar paint event which now takes 1ms. When combined with my other pull request, I finally get full frame rates while scrolling around in edb after my binary has been analyzed.