### PR TITLE
Fix segfault in Analyzer Widget

### DIFF
--- a/plugins/Analyzer/AnalyzerWidget.cpp
+++ b/plugins/Analyzer/AnalyzerWidget.cpp
@@ -36,7 +36,7 @@ namespace Analyzer {
 //------------------------------------------------------------------------------
 // Name:
 //------------------------------------------------------------------------------
-AnalyzerWidget::AnalyzerWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f), mouse_pressed_(false) {
+AnalyzerWidget::AnalyzerWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f), mouse_pressed_(false), cache_(nullptr) {
 
 	QFontMetrics fm(font());
 


### PR DESCRIPTION
Forgot to initialize the `QPixmap* cache_` polnter to `nullptr`. It must not have crashed on my system because of a different memory allocator, but when I tried on my laptop running an older debian it crashed quickly.