### PR TITLE
Allow quoting variables in expressions

### DIFF
--- a/include/Expression.tcc
+++ b/include/Expression.tcc
@@ -521,6 +521,22 @@ void Expression<T>::get_token() {
 				token_.set(">", Token::GT, Token::OPERATOR);
 			}
 			break;
+		case '"':
+			++expression_ptr_;
+			// Begin a quoted string
+			{
+				QString temp_string;
+
+				while (expression_ptr_ != expression_.end() && *expression_ptr_ != '"') {
+					temp_string += *expression_ptr_++;
+				}
+				if (expression_ptr_ == expression_.end()) {
+					token_.set("\"" + temp_string, Token::NONE, Token::VARIABLE);
+				} else {
+					token_.set(temp_string, Token::NONE, Token::VARIABLE);
+				}
+			}
+			break;
 		default:
 			// is it a numerical constant?
 			if(expression_ptr_->isDigit()) {


### PR DESCRIPTION
This change makes quoted expressions tokenized as a single variable.

Fixes #400.

Note that this does not make any changes to the expression dialog's auto-completion. After activating an entry in its auto-completer it will immediately say "Invalid Expression" afterward. I wanted to fix this, but I don't see any good ways. Adding quotes around all symbols that have spaces will make them harder to find with the auto-completer. Ideally we would quote variables as they are inserted, but I don't see any clear and obvious correct way of doing that.