### PR TITLE
Change qjson4 url to https instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/eteran/qhexview.git
 [submodule "src/qjson4"]
 	path = src/qjson4
-	url = git://github.com/eteran/qjson4.git
+	url = https://github.com/eteran/qjson4.git


### PR DESCRIPTION
This is good for people behind an http proxy who want to install the debugger from source.
The git based url requires SSH access which is not possible over http/s proxies usually.