### PR TITLE
Resize 0->l1 area size to contain address badge

### DIFF
--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -125,6 +125,7 @@ private:
 	int                               font_width_;  // width of a character in this font
 	int                               icon_width_;
 	int                               icon_height_;
+	int                               line0_;
 	int                               line1_;
 	int                               line2_;
 	int                               line3_;


### PR DESCRIPTION
`line1`, `line2` and `line3` indicators are now relative to the new `line0` which represents space allocated on the leftmost part of the widget rendering area for various extras (for now, just the register badges).

Fixes #552.