### PR TITLE
Return RBP as frame pointer register

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformState.cpp
@@ -959,7 +959,7 @@ Register PlatformState::instruction_pointer_register() const {
 // Desc: returns what is conceptually the frame pointer for this platform
 //------------------------------------------------------------------------------
 edb::address_t PlatformState::frame_pointer() const {
-	return stack_pointer();
+	return gp_register(X86::RBP).valueAsAddress();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
RSP isn't a frame pointer register on x86(_64), RBP is.