### PR TITLE
Let the user use Up/Down arrow keys to go to upper/lower entries in the registry editors

### DIFF
--- a/plugins/ODbgRegisterView/CMakeLists.txt
+++ b/plugins/ODbgRegisterView/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PluginName} SHARED
 	RegisterView.h
 	DialogEditSIMDRegister.cpp
 	NumberEdit.cpp
+	EntryGridKeyUpDownEventFilter.cpp
 )
 
 if(Qt5Core_FOUND)

--- a/plugins/ODbgRegisterView/DialogEditFPU.cpp
+++ b/plugins/ODbgRegisterView/DialogEditFPU.cpp
@@ -29,6 +29,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <iomanip>
 #include <iostream>
 
+#include "EntryGridKeyUpDownEventFilter.h"
+
 namespace ODbgRegisterView {
 namespace {
 
@@ -94,6 +96,9 @@ DialogEditFPU::DialogEditFPU(QWidget *parent) : QDialog(parent), floatEntry(new 
 	hexEntry->setValidator(new QRegExpValidator(QRegExp("[0-9a-fA-F ]{,20}"), this));
 	connect(floatEntry, SIGNAL(defocussed()), this, SLOT(updateFloatEntry()));
 
+	hexEntry->installEventFilter(this);
+	floatEntry->installEventFilter(this);
+
 	const auto okCancel = new QDialogButtonBox(this);
 	okCancel->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
 	connect(okCancel, SIGNAL(accepted()), this, SLOT(accept()));
@@ -113,6 +118,10 @@ void DialogEditFPU::updateFloatEntry() {
 
 void DialogEditFPU::updateHexEntry() {
 	hexEntry->setText(value_.toHexString());
+}
+
+bool DialogEditFPU::eventFilter(QObject* obj, QEvent* event) {
+	return entryGridKeyUpDownEventFilter(this,obj,event);
 }
 
 void DialogEditFPU::set_value(const Register &newReg) {

--- a/plugins/ODbgRegisterView/DialogEditFPU.h
+++ b/plugins/ODbgRegisterView/DialogEditFPU.h
@@ -40,6 +40,8 @@ private Q_SLOTS:
 	void updateFloatEntry();
 	void updateHexEntry();
 
+protected:
+	bool eventFilter(QObject*, QEvent*) override;
 private:
 	static_assert(sizeof(long double) >= 10, "This class will only work with true 80-bit long double");
 	Register reg;

--- a/plugins/ODbgRegisterView/DialogEditGPR.cpp
+++ b/plugins/ODbgRegisterView/DialogEditGPR.cpp
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <tuple>
 #include <type_traits>
 
+#include "EntryGridKeyUpDownEventFilter.h"
+
 namespace ODbgRegisterView {
 
 DialogEditGPR::DialogEditGPR(QWidget *parent) : QDialog(parent) {
@@ -63,6 +65,7 @@ DialogEditGPR::DialogEditGPR(QWidget *parent) : QDialog(parent) {
 				auto &entry = this->entry(static_cast<Row>(FIRST_ENTRY_ROW + f), static_cast<Column>(FIRST_ENTRY_COL + c));
 				entry       = new GPREdit(offsetsInInteger[c], integerSizes[c], formats[f], this);
 				connect(entry, SIGNAL(textEdited(const QString &)), this, SLOT(onTextEdited(const QString &)));
+				entry->installEventFilter(this);
 				allContentsGrid->addWidget(entry, FIRST_ENTRY_ROW + f, FIRST_ENTRY_COL + c);
 			}
 		}
@@ -73,6 +76,7 @@ DialogEditGPR::DialogEditGPR(QWidget *parent) : QDialog(parent) {
 		auto &charHigh = entry(CHAR_ROW, GPR8H_COL);
 		charHigh       = new GPREdit(1, 1, GPREdit::Format::Character, this);
 		connect(charHigh, SIGNAL(textEdited(const QString &)), this, SLOT(onTextEdited(const QString &)));
+		charHigh->installEventFilter(this);
 		allContentsGrid->addWidget(charHigh, CHAR_ROW, GPR8H_COL);
 	}
 
@@ -81,6 +85,7 @@ DialogEditGPR::DialogEditGPR(QWidget *parent) : QDialog(parent) {
 		auto &charLow = entry(CHAR_ROW, GPR8L_COL);
 		charLow       = new GPREdit(0, 1, GPREdit::Format::Character, this);
 		connect(charLow, SIGNAL(textEdited(const QString &)), this, SLOT(onTextEdited(const QString &)));
+		charLow->installEventFilter(this);
 		allContentsGrid->addWidget(charLow, CHAR_ROW, GPR8L_COL);
 	}
 
@@ -267,6 +272,10 @@ void DialogEditGPR::setupFocus() {
 			break;
 		}
 	}
+}
+
+bool DialogEditGPR::eventFilter(QObject* obj, QEvent* event) {
+	return entryGridKeyUpDownEventFilter(this,obj,event);
 }
 
 void DialogEditGPR::set_value(const Register &newReg) {

--- a/plugins/ODbgRegisterView/DialogEditGPR.h
+++ b/plugins/ODbgRegisterView/DialogEditGPR.h
@@ -72,6 +72,8 @@ private:
 		ENTRY_ROWS       = ROW_AFTER_ENTRIES - FIRST_ENTRY_ROW
 	};
 
+protected:
+	bool eventFilter(QObject*, QEvent*) override;
 private:
 	void updateAllEntriesExcept(GPREdit *notUpdated);
 	void hideColumn(Column col);

--- a/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
+++ b/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
@@ -27,9 +27,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QRadioButton>
 #include <QRegExp>
 #include <QRegExpValidator>
+#include <QKeyEvent>
 #include <cstring>
 #include <limits>
 #include <type_traits>
+
+#include "EntryGridKeyUpDownEventFilter.h"
 
 namespace ODbgRegisterView {
 
@@ -45,6 +48,7 @@ void DialogEditSIMDRegister::setupEntries(const QString &label, std::array<Numbe
 		entry                   = new NumberEdit(ENTRIES_FIRST_COL + bytesPerEntry * (numEntries - 1 - entryIndex), bytesPerEntry, this);
 		entry->setNaturalWidthInChars(naturalWidthInChars);
 		connect(entry, SIGNAL(textEdited(const QString &)), this, slot);
+		entry->installEventFilter(this);
 	}
 }
 
@@ -285,6 +289,10 @@ void DialogEditSIMDRegister::hideRows(EntriesRows rowToHide) {
 			item->widget()->hide();
 		}
 	}
+}
+
+bool DialogEditSIMDRegister::eventFilter(QObject* obj, QEvent* event) {
+	return entryGridKeyUpDownEventFilter(this,obj,event);
 }
 
 void DialogEditSIMDRegister::set_value(const Register &newReg) {

--- a/plugins/ODbgRegisterView/DialogEditSIMDRegister.h
+++ b/plugins/ODbgRegisterView/DialogEditSIMDRegister.h
@@ -74,6 +74,8 @@ public:
 	void set_current_element(RegisterViewModelBase::Model::ElementSize size, NumberDisplayMode format, int elementIndex);
 	Register value() const;
 
+protected:
+	bool eventFilter(QObject*, QEvent*) override;
 private:
 	template <std::size_t numEntries>
 	void setupEntries(const QString &label, std::array<NumberEdit *, numEntries> &entries, int row, const char *slot, int naturalWidthInChars);

--- a/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.cpp
+++ b/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.cpp
@@ -1,0 +1,51 @@
+#include "EntryGridKeyUpDownEventFilter.h"
+
+#include <cassert>
+#include <algorithm>
+#include <vector>
+#include <QWidget>
+#include <QKeyEvent>
+#include <QLineEdit>
+
+namespace ODbgRegisterView {
+
+bool entryGridKeyUpDownEventFilter(QWidget* parent, QObject* obj, QEvent* event)
+{
+
+	auto*const entry=qobject_cast<QLineEdit*>(obj);
+	if(!entry) return false;
+	if(event->type()!=QEvent::KeyPress) return false;
+
+	auto*const keyEvent=static_cast<QKeyEvent*>(event);
+	const auto key=keyEvent->key();
+	if(key!=Qt::Key_Up && key!=Qt::Key_Down) return false;
+
+	// subtraction of 1 from x prevents selection of entry to the right-top/bottom instead directly top/bottom
+	const auto pos=entry->pos()-QPoint(1,0);
+	const auto children=parent->findChildren<QLineEdit*>();
+	// Find the neighbors above/below the current entry
+	std::vector<QLineEdit*> neighbors;
+	for(auto*const child : children) {
+
+		if(!child->isVisible()) continue;
+		if(key==Qt::Key_Up && child->y() >= pos.y()) continue;
+		if(key==Qt::Key_Down && child->y() <= pos.y()) continue;
+		neighbors.emplace_back(child);
+	}
+	if(neighbors.empty()) return false;
+	// Bring the vertically closest neighbors to the front
+	const auto y=pos.y();
+	std::sort(neighbors.begin(),neighbors.end(), [y](QLineEdit*a,QLineEdit*b)
+			{ return std::abs(y - a->y()) < std::abs(y - b->y()); });
+	const auto verticallyClosestY=neighbors.front()->y();
+	// Remove those too far vertically, so that they don't interfere with later calculations
+	neighbors.erase(std::remove_if(neighbors.begin(),neighbors.end(),[verticallyClosestY](QLineEdit*e)
+					{ return e->y()!=verticallyClosestY; }),neighbors.end());
+	assert(!neighbors.empty());
+	const auto x=pos.x();
+	const auto bestNeighbor=*std::min_element(neighbors.begin(),neighbors.end(), [x](QLineEdit*a,QLineEdit*b)
+			{ return std::abs(x - a->x()) < std::abs(x - b->x()); });
+	bestNeighbor->setFocus(Qt::OtherFocusReason);
+	return true;
+}
+}

--- a/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.h
+++ b/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.h
@@ -1,0 +1,12 @@
+#ifndef ENTRY_GRID_KEY_UP_DOWN_EVENT_FILTER_H_20170705
+#define ENTRY_GRID_KEY_UP_DOWN_EVENT_FILTER_H_20170705
+
+class QWidget;
+class QObject;
+class QEvent;
+
+namespace ODbgRegisterView {
+bool entryGridKeyUpDownEventFilter(QWidget* parent, QObject* obj, QEvent* event);
+}
+
+#endif


### PR DESCRIPTION
Otherwise it's very inconvenient to use e.g. SIMD register editor when you want to e.g. move focus from float64 entry to integer byte.