### PR TITLE
Make the entries think they were tabbed into Up/Down arrows

### DIFF
--- a/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.cpp
+++ b/plugins/ODbgRegisterView/EntryGridKeyUpDownEventFilter.cpp
@@ -45,7 +45,7 @@ bool entryGridKeyUpDownEventFilter(QWidget* parent, QObject* obj, QEvent* event)
 	const auto x=pos.x();
 	const auto bestNeighbor=*std::min_element(neighbors.begin(),neighbors.end(), [x](QLineEdit*a,QLineEdit*b)
 			{ return std::abs(x - a->x()) < std::abs(x - b->x()); });
-	bestNeighbor->setFocus(Qt::OtherFocusReason);
+	bestNeighbor->setFocus(Qt::TabFocusReason);
 	return true;
 }
 }


### PR DESCRIPTION
This way the contents of the new cell are selected as if we pressed Tab while being in a cell to the left of the new one. This makes navigation consistent between Tab/Shift-Tab/Up/Down directions.