### PR TITLE
A bit more ARM-related fixes

### DIFF
--- a/include/arch/arm-generic/ArchDefs.h
+++ b/include/arch/arm-generic/ArchDefs.h
@@ -1,6 +1,8 @@
 /*
 Copyright (C) 2006 - 2015 Evan Teran
                           evan.teran@gmail.com
+Copyright (C) 2017 Ruslan Kabatsayev
+                   b7.10110111@gmail.com
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -16,18 +18,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ARCHTYPES_20071127_H_
-#define ARCHTYPES_20071127_H_
+#ifndef ARCH_DEFS_20170807_H_
+#define ARCH_DEFS_20170807_H_
 
-#include "ArchDefs.h"
-#include "Instruction.h"
-#include "Types.h"
+#include <cstdint>
 
-namespace edb {
+#if INTPTR_MAX == INT32_MAX
+#define EDB_ARM32
+static constexpr bool EDB_IS_64_BIT = false;
+static constexpr bool EDB_IS_32_BIT = true;
 
-typedef CapstoneEDB::Instruction  Instruction;
-typedef CapstoneEDB::Operand      Operand;
+#elif INTPTR_MAX == INT64_MAX
 
-}
+#define EDB_ARM64
+static constexpr bool EDB_IS_64_BIT = true;
+static constexpr bool EDB_IS_32_BIT = false;
+#endif
 
 #endif

--- a/include/arch/x86-generic/ArchDefs.h
+++ b/include/arch/x86-generic/ArchDefs.h
@@ -1,6 +1,8 @@
 /*
 Copyright (C) 2006 - 2015 Evan Teran
                           evan.teran@gmail.com
+Copyright (C) 2017 Ruslan Kabatsayev
+                   b7.10110111@gmail.com
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -16,18 +18,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ARCHTYPES_20071127_H_
-#define ARCHTYPES_20071127_H_
+#ifndef ARCH_DEFS_20170807_H_
+#define ARCH_DEFS_20170807_H_
 
-#include "ArchDefs.h"
-#include "Instruction.h"
-#include "Types.h"
+#include <cstdint>
 
-namespace edb {
+#if INTPTR_MAX == INT32_MAX
+#define EDB_X86
+static constexpr bool EDB_IS_64_BIT = false;
+static constexpr bool EDB_IS_32_BIT = true;
 
-typedef CapstoneEDB::Instruction  Instruction;
-typedef CapstoneEDB::Operand      Operand;
+#elif INTPTR_MAX == INT64_MAX
 
-}
+#define EDB_X86_64
+static constexpr bool EDB_IS_64_BIT = true;
+static constexpr bool EDB_IS_32_BIT = false;
+#endif
 
 #endif

--- a/include/arch/x86-generic/ArchTypes.h
+++ b/include/arch/x86-generic/ArchTypes.h
@@ -19,20 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef ARCHTYPES_20071127_H_
 #define ARCHTYPES_20071127_H_
 
+#include "ArchDefs.h"
 #include "Instruction.h"
 #include "Types.h"
-
-#if INTPTR_MAX == INT32_MAX
-#define EDB_X86
-static constexpr bool EDB_IS_64_BIT = false;
-static constexpr bool EDB_IS_32_BIT = true;
-
-#elif INTPTR_MAX == INT64_MAX
-
-#define EDB_X86_64
-static constexpr bool EDB_IS_64_BIT = true;
-static constexpr bool EDB_IS_32_BIT = false;
-#endif
 
 namespace edb {
 

--- a/plugins/InstructionInspector/Plugin.cpp
+++ b/plugins/InstructionInspector/Plugin.cpp
@@ -460,6 +460,7 @@ InstructionDialog::InstructionDialog(QWidget* parent)
 				for(int r=0;r<insn->detail->regs_write_count;++r)
 					add({printReg(disasm->handle(), insn->detail->regs_write[r]).c_str()},regsWritten);
 			}
+#if defined EDB_X86 || defined EDB_X86_64
 			add({"Prefixes",printBytes(insn->detail->x86.prefix,sizeof insn->detail->x86.prefix,false).c_str()});
 			add({"Opcode",printBytes(insn->detail->x86.opcode,sizeof insn->detail->x86.opcode).c_str()});
 			if(insn->detail->x86.rex)
@@ -523,6 +524,7 @@ InstructionDialog::InstructionDialog(QWidget* parent)
 					add({"AVX Broadcast",printAVX_Bcast(operand.avx_bcast).c_str()},curOpItem);
 				add({"AVX opmask",(operand.avx_zero_opmask ? "zeroing" : "merging")},curOpItem);
 			}
+#endif
 		}
 		tree->expandAll();
 		tree->resizeColumnToContents(0);

--- a/plugins/InstructionInspector/Plugin.cpp
+++ b/plugins/InstructionInspector/Plugin.cpp
@@ -51,13 +51,13 @@ class Disassembler
 public:
 	struct InitFailure
 	{
-		cs_err error;
+		const char* error;
 	};
 	Disassembler(cs_mode mode)
 	{
 		cs_err result=cs_open(CS_ARCH_X86, mode, &csh_);
 		if(result!=CS_ERR_OK)
-			throw InitFailure{result};
+			throw InitFailure{cs_strerror(result)};
 		cs_option(csh_, CS_OPT_DETAIL, CS_OPT_ON);
 		cs_option(csh_,CS_OPT_SYNTAX, edb::v1::config().syntax==Configuration::Syntax::Intel?
 															CS_OPT_SYNTAX_INTEL:
@@ -994,7 +994,7 @@ void Plugin::showDialog() const
 	{
 			QMessageBox::critical(edb::v1::debugger_ui,
 					"Capstone error",
-					"Failed to initialize Capstone, error code "+QString::number(ex.error));
+					QString("Failed to initialize Capstone: ")+ex.error);
 	}
 	catch(...){}
 }

--- a/plugins/OpcodeSearcher/DialogOpcodes.cpp
+++ b/plugins/OpcodeSearcher/DialogOpcodes.cpp
@@ -41,6 +41,10 @@ namespace {
 const int STACK_REG = X86_REG_ESP;
 #elif defined(EDB_X86_64)
 const int STACK_REG = X86_REG_RSP;
+#elif defined EDB_ARM32
+const int STACK_REG = ARM_REG_SP;
+#elif defined EDB_ARM64
+const int STACK_REG = ARM64_REG_SP;
 #endif
 }
 

--- a/src/capstone-edb/include/Instruction.h
+++ b/src/capstone-edb/include/Instruction.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef INSTRUCTION_20150908_H
 #define INSTRUCTION_20150908_H
 
+#include "ArchDefs.h"
 #include "Formatter.h"
 #include "Operand.h"
 #include <capstone/capstone.h>
@@ -67,7 +68,16 @@ public:
 
 public:
 	int operation() const             { return insn_ ? insn_->id                   : 0;             }
-	std::size_t operand_count() const { return insn_ ? insn_->detail->x86.op_count : 0;             }
+	std::size_t operand_count() const
+    {
+#if defined EDB_X86 || defined EDB_X86_64
+        return insn_ ? insn_->detail->x86.op_count : 0;
+#elif defined EDB_ARM32 || defined EDB_ARM64
+        return insn_ ? insn_->detail->arm.op_count : 0;
+#else
+#	error "What to return here?"
+#endif
+    }
 	std::size_t byte_size() const     { return insn_ ? insn_->size                 : 1;             }
 	uint64_t rva() const              { return insn_ ? insn_->address              : rva_;          }
 	std::string mnemonic() const      { return insn_ ? insn_->mnemonic             : std::string(); }

--- a/src/capstone-edb/include/Operand.h
+++ b/src/capstone-edb/include/Operand.h
@@ -2,6 +2,7 @@
 #ifndef OPERAND_H_
 #define OPERAND_H_
 
+#include "ArchDefs.h"
 #include <capstone/capstone.h>
 
 namespace CapstoneEDB {
@@ -17,8 +18,14 @@ class Operand {
 	friend class Formatter;
 	friend class Instruction;
 
+#if defined EDB_X86 || defined EDB_X86_64
+	using op_type=cs_x86_op;
+#elif defined EDB_ARM32 || defined EDB_ARM64
+    using op_type=cs_arm_op;
+#endif
+
 private:
-	Operand(const Instruction *instruction, cs_x86_op *operand, size_t index) : owner_(instruction), operand_(operand), index_(index) {
+	Operand(const Instruction *instruction, op_type *operand, size_t index) : owner_(instruction), operand_(operand), index_(index) {
 	}
 
 public:
@@ -32,8 +39,8 @@ public:
 public:
 	bool valid() const                  { return operand_; }
 	explicit operator bool() const      { return valid();  }
-	const cs_x86_op *operator->() const { return operand_; }
-	const cs_x86_op *native() const     { return operand_; }
+	const op_type *operator->() const   { return operand_; }
+	const op_type *native() const       { return operand_; }
 	int index() const                   { return index_;   }
 
 public:
@@ -43,7 +50,7 @@ public:
 
 private:
 	const Instruction *owner_;
-	cs_x86_op *        operand_;
+	op_type *          operand_;
 	size_t             index_;
 };
 


### PR DESCRIPTION
This mostly makes InstructionInspector at least start on ARM. Also Instruction class is now a bit more ARM-aware. Also, OpcodeSearcher at least now compiles (added missing `STACK_REG`).

There's still some work to do in each of these, but these commits are self-sufficient, so to avoid potential conflicts with your work I request merge.