### PR TITLE
Make most IDebugger and related methods return Status instead of void

### DIFF
--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -74,7 +74,7 @@ public:
 	virtual Status open(const QString &path, const QString &cwd, const QList<QByteArray> &args) = 0;
 	virtual Status open(const QString &path, const QString &cwd, const QList<QByteArray> &args, const QString &tty) = 0;
 	virtual std::shared_ptr<IDebugEvent> wait_debug_event(int msecs) = 0;
-	virtual void detach() = 0;
+	virtual Status detach() = 0;
 	virtual void kill() = 0;
 	virtual void end_debug_session() = 0;
 	virtual void get_state(State *state) = 0;

--- a/include/IProcess.h
+++ b/include/IProcess.h
@@ -62,7 +62,7 @@ public:
 	virtual std::size_t                      read_bytes(edb::address_t address, void *buf, size_t len) const = 0;
 	virtual std::size_t                      read_pages(edb::address_t address, void *buf, size_t count) const = 0;
 	virtual Status                           pause() = 0;
-	virtual void                             resume(edb::EVENT_STATUS status) = 0;
+	virtual Status                           resume(edb::EVENT_STATUS status) = 0;
 	virtual void                             step(edb::EVENT_STATUS status) = 0;
 	virtual bool                             isPaused() const = 0;
 	virtual QMap<edb::address_t, Patch>      patches() const = 0;

--- a/include/IProcess.h
+++ b/include/IProcess.h
@@ -63,7 +63,7 @@ public:
 	virtual std::size_t                      read_pages(edb::address_t address, void *buf, size_t count) const = 0;
 	virtual Status                           pause() = 0;
 	virtual Status                           resume(edb::EVENT_STATUS status) = 0;
-	virtual void                             step(edb::EVENT_STATUS status) = 0;
+	virtual Status                           step(edb::EVENT_STATUS status) = 0;
 	virtual bool                             isPaused() const = 0;
 	virtual QMap<edb::address_t, Patch>      patches() const = 0;
 };

--- a/include/IProcess.h
+++ b/include/IProcess.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "OSTypes.h"
 #include "Types.h"
 #include "Patch.h"
+#include "Status.h"
 #include <QList>
 #include <QMap>
 #include <memory>
@@ -60,7 +61,7 @@ public:
 	virtual std::size_t                      patch_bytes(edb::address_t address, const void *buf, size_t len) = 0;
 	virtual std::size_t                      read_bytes(edb::address_t address, void *buf, size_t len) const = 0;
 	virtual std::size_t                      read_pages(edb::address_t address, void *buf, size_t count) const = 0;
-	virtual void                             pause() = 0;
+	virtual Status                           pause() = 0;
 	virtual void                             resume(edb::EVENT_STATUS status) = 0;
 	virtual void                             step(edb::EVENT_STATUS status) = 0;
 	virtual bool                             isPaused() const = 0;

--- a/include/IThread.h
+++ b/include/IThread.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Types.h"
 #include "OSTypes.h"
+#include "Status.h"
 
 class State;
 
@@ -40,8 +41,8 @@ public:
 	virtual void set_state(const State &state) = 0;
 
 public:
-	virtual void step() = 0;
-	virtual void step(edb::EVENT_STATUS status) = 0;
+	virtual Status step() = 0;
+	virtual Status step(edb::EVENT_STATUS status) = 0;
 	virtual void resume() = 0;
 	virtual void resume(edb::EVENT_STATUS status) = 0;
 	virtual void stop() = 0;

--- a/include/IThread.h
+++ b/include/IThread.h
@@ -45,7 +45,7 @@ public:
 	virtual Status step(edb::EVENT_STATUS status) = 0;
 	virtual Status resume() = 0;
 	virtual Status resume(edb::EVENT_STATUS status) = 0;
-	virtual void stop() = 0;
+	virtual Status stop() = 0;
 
 public:
 	virtual bool isPaused() const = 0;

--- a/include/IThread.h
+++ b/include/IThread.h
@@ -43,8 +43,8 @@ public:
 public:
 	virtual Status step() = 0;
 	virtual Status step(edb::EVENT_STATUS status) = 0;
-	virtual void resume() = 0;
-	virtual void resume(edb::EVENT_STATUS status) = 0;
+	virtual Status resume() = 0;
+	virtual Status resume(edb::EVENT_STATUS status) = 0;
 	virtual void stop() = 0;
 
 public:

--- a/include/Status.h
+++ b/include/Status.h
@@ -24,7 +24,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class EDB_EXPORT Status {
 public:
-	Status() {
+	enum OkType { Ok };
+public:
+	Status(OkType) {
 	}
 
 	explicit Status(const QString &message) : errorMessage_(message) {
@@ -54,7 +56,7 @@ public:
 	Result(const QString &message, const T &value) : status_(message), value_(value) {
 	}
 
-	explicit Result(const T &value) : value_(value) {
+	explicit Result(const T &value) : status_(Status::Ok), value_(value) {
 	}
 
 	Result(const Result &)            = default;

--- a/plugins/DebuggerCore/CMakeLists.txt
+++ b/plugins/DebuggerCore/CMakeLists.txt
@@ -62,6 +62,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 		unix/linux/PlatformProcess.h
 		unix/linux/PlatformRegion.cpp
 		unix/linux/PlatformRegion.h
+		unix/linux/PlatformThread.cpp
 		unix/linux/PlatformThread.h	
 		unix/linux/FeatureDetect.cpp
 		unix/linux/FeatureDetect.h

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -596,7 +596,7 @@ Status DebuggerCore::attach(edb::pid_t pid) {
 		active_thread_  = pid;
 		binary_info_    = edb::v1::get_binary_info(edb::v1::primary_code_region());
 		detectDebuggeeBitness();
-		return Status();
+		return Status::Ok;
 	}
 
     delete process_;
@@ -833,7 +833,7 @@ Status DebuggerCore::open(const QString &path, const QString &cwd, const QList<Q
 
 			detectDebuggeeBitness();
 
-			return Status();
+			return Status::Ok;
 		} while(0);
 		break;
 	}

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -300,12 +300,12 @@ Status DebuggerCore::ptrace_continue(edb::tid_t tid, long status) {
 	//               in the first place if we aren't stopped on this TID :-(
 	if(waited_threads_.contains(tid)) {
 		Q_ASSERT(tid != 0);
-		waited_threads_.remove(tid);
 		if(ptrace(PTRACE_CONT, tid, 0, status)==-1) {
 			const char*const strError=strerror(errno);
 			qWarning() << "Unable to continue thread" << tid << ": PTRACE_CONT failed:" << strError;
 			return Status(strError);
 		}
+		waited_threads_.remove(tid);
 		return Status::Ok;
 	}
 	return Status(QObject::tr("ptrace_continue(): waited_threads_ doesn't contain tid %1").arg(tid));
@@ -321,12 +321,12 @@ Status DebuggerCore::ptrace_step(edb::tid_t tid, long status) {
 	//               in the first place if we aren't stopped on this TID :-(
 	if(waited_threads_.contains(tid)) {
 		Q_ASSERT(tid != 0);
-		waited_threads_.remove(tid);
 		if(ptrace(PTRACE_SINGLESTEP, tid, 0, status)==-1) {
 			const char*const strError=strerror(errno);
 			qWarning() << "Unable to step thread" << tid << ": PTRACE_SINGLESTEP failed:" << strError;
 			return Status(strError);
 		}
+		waited_threads_.remove(tid);
 		return Status::Ok;
 	}
 	return Status(QObject::tr("ptrace_step(): waited_threads_ doesn't contain tid %1").arg(tid));

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -305,16 +305,21 @@ long DebuggerCore::ptrace_continue(edb::tid_t tid, long status) {
 // Name: ptrace_step
 // Desc:
 //------------------------------------------------------------------------------
-long DebuggerCore::ptrace_step(edb::tid_t tid, long status) {
+Status DebuggerCore::ptrace_step(edb::tid_t tid, long status) {
 	// TODO(eteran): perhaps address this at a higher layer?
 	//               I would like to not have these events show up
 	//               in the first place if we aren't stopped on this TID :-(
 	if(waited_threads_.contains(tid)) {
 		Q_ASSERT(tid != 0);
 		waited_threads_.remove(tid);
-		return ptrace(PTRACE_SINGLESTEP, tid, 0, status);
+		if(ptrace(PTRACE_SINGLESTEP, tid, 0, status)==-1) {
+			const char*const strError=strerror(errno);
+			qWarning() << "Unable to step thread" << tid << ": PTRACE_SINGLESTEP failed:" << strError;
+			return Status(strError);
+		}
+		return Status::Ok;
 	}
-	return -1;
+	return Status(QObject::tr("ptrace_step(): waited_threads_ doesn't contain tid %1").arg(tid));
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -89,7 +89,7 @@ private:
 	Status ptrace_getsiginfo(edb::tid_t tid, siginfo_t *siginfo);
 	Status ptrace_continue(edb::tid_t tid, long status);
 	Status ptrace_step(edb::tid_t tid, long status);
-	long ptrace_set_options(edb::tid_t tid, long options);
+	Status ptrace_set_options(edb::tid_t tid, long options);
 	long ptrace_get_event_message(edb::tid_t tid, unsigned long *message);
 	long ptrace_traceme();
 

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -95,7 +95,7 @@ private:
 
 private:
 	void reset();
-	void stop_threads();
+	Status stop_threads();
 	std::shared_ptr<IDebugEvent> handle_event(edb::tid_t tid, int status);
 	int attach_thread(edb::tid_t tid);
     void detectDebuggeeBitness();

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -88,7 +88,7 @@ public:
 private:
 	long ptrace_getsiginfo(edb::tid_t tid, siginfo_t *siginfo);
 	long ptrace_continue(edb::tid_t tid, long status);
-	long ptrace_step(edb::tid_t tid, long status);
+	Status ptrace_step(edb::tid_t tid, long status);
 	long ptrace_set_options(edb::tid_t tid, long options);
 	long ptrace_get_event_message(edb::tid_t tid, unsigned long *message);
 	long ptrace_traceme();

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -87,7 +87,7 @@ public:
 
 private:
 	long ptrace_getsiginfo(edb::tid_t tid, siginfo_t *siginfo);
-	long ptrace_continue(edb::tid_t tid, long status);
+	Status ptrace_continue(edb::tid_t tid, long status);
 	Status ptrace_step(edb::tid_t tid, long status);
 	long ptrace_set_options(edb::tid_t tid, long options);
 	long ptrace_get_event_message(edb::tid_t tid, unsigned long *message);

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -86,7 +86,7 @@ public:
 	virtual IProcess *process() const override;
 
 private:
-	long ptrace_getsiginfo(edb::tid_t tid, siginfo_t *siginfo);
+	Status ptrace_getsiginfo(edb::tid_t tid, siginfo_t *siginfo);
 	Status ptrace_continue(edb::tid_t tid, long status);
 	Status ptrace_step(edb::tid_t tid, long status);
 	long ptrace_set_options(edb::tid_t tid, long options);

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -54,7 +54,7 @@ public:
 	virtual bool has_extension(quint64 ext) const override;
 	virtual std::shared_ptr<IDebugEvent> wait_debug_event(int msecs) override;
 	virtual Status attach(edb::pid_t pid) override;
-	virtual void detach() override;
+	virtual Status detach() override;
 	virtual void kill() override;
 	virtual void get_state(State *state) override;
 	virtual void set_state(const State &state) override;

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.h
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.h
@@ -90,7 +90,7 @@ private:
 	Status ptrace_continue(edb::tid_t tid, long status);
 	Status ptrace_step(edb::tid_t tid, long status);
 	Status ptrace_set_options(edb::tid_t tid, long options);
-	long ptrace_get_event_message(edb::tid_t tid, unsigned long *message);
+	Status ptrace_get_event_message(edb::tid_t tid, unsigned long *message);
 	long ptrace_traceme();
 
 private:

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -799,13 +799,13 @@ Status PlatformProcess::resume(edb::EVENT_STATUS status) {
 // Name: step
 // Desc: steps the currently active thread
 //------------------------------------------------------------------------------
-void PlatformProcess::step(edb::EVENT_STATUS status) {
+Status PlatformProcess::step(edb::EVENT_STATUS status) {
 	// TODO: assert that we are paused
 	Q_ASSERT(core_->process_ == this);
 
 	if(status != edb::DEBUG_STOP) {
 		if(std::shared_ptr<IThread> thread = current_thread()) {
-			thread->step(status);
+			return thread->step(status);
 		}
 	}
 }

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.h
@@ -57,7 +57,7 @@ public:
 
 public:
 	virtual Status pause() override;
-	virtual void resume(edb::EVENT_STATUS status) override;
+	virtual Status resume(edb::EVENT_STATUS status) override;
 	virtual void step(edb::EVENT_STATUS status) override;
 	virtual bool isPaused() const override;
 

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.h
@@ -58,7 +58,7 @@ public:
 public:
 	virtual Status pause() override;
 	virtual Status resume(edb::EVENT_STATUS status) override;
-	virtual void step(edb::EVENT_STATUS status) override;
+	virtual Status step(edb::EVENT_STATUS status) override;
 	virtual bool isPaused() const override;
 
 public:

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.h
@@ -56,7 +56,7 @@ public:
 	virtual QList<Module>                   loaded_modules() const override;
 
 public:
-	virtual void pause() override;
+	virtual Status pause() override;
 	virtual void resume(edb::EVENT_STATUS status) override;
 	virtual void step(edb::EVENT_STATUS status) override;
 	virtual bool isPaused() const override;

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
@@ -149,8 +149,8 @@ QString PlatformThread::runState() const  {
 // Desc: steps this thread one instruction, passing the signal that stopped it
 //       (unless the signal was SIGSTOP)
 //------------------------------------------------------------------------------
-void PlatformThread::step() {
-	core_->ptrace_step(tid_, resume_code(status_));
+Status PlatformThread::step() {
+	return core_->ptrace_step(tid_, resume_code(status_));
 }
 
 //------------------------------------------------------------------------------
@@ -158,9 +158,9 @@ void PlatformThread::step() {
 // Desc: steps this thread one instruction, passing the signal that stopped it
 //       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
 //------------------------------------------------------------------------------
-void PlatformThread::step(edb::EVENT_STATUS status) {
+Status PlatformThread::step(edb::EVENT_STATUS status) {
 	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_step(tid_, code);
+	return core_->ptrace_step(tid_, code);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
@@ -1,0 +1,203 @@
+/*
+Copyright (C) 2015 - 2015 Evan Teran
+                          evan.teran@gmail.com
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PlatformThread.h"
+#include "DebuggerCore.h"
+#include "IProcess.h"
+#include "PlatformCommon.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE        /* or _BSD_SOURCE or _SVID_SOURCE */
+#endif
+
+#include <sys/syscall.h>   /* For SYS_xxx definitions */
+
+namespace DebuggerCorePlugin {
+
+//------------------------------------------------------------------------------
+// Name: PlatformThread
+// Desc:
+//------------------------------------------------------------------------------
+PlatformThread::PlatformThread(DebuggerCore *core, IProcess *process, edb::tid_t tid) : core_(core), process_(process), tid_(tid) {
+	assert(process);
+	assert(core);
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+PlatformThread::~PlatformThread() {
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+edb::tid_t PlatformThread::tid() const {
+	return tid_;
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+QString PlatformThread::name() const  {
+	struct user_stat thread_stat;
+	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
+	if(n >= 2) {
+		return thread_stat.comm;
+	}
+
+	return QString();
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+int PlatformThread::priority() const  {
+	struct user_stat thread_stat;
+	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
+	if(n >= 30) {
+		return thread_stat.priority;
+	}
+
+	return 0;
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+edb::address_t PlatformThread::instruction_pointer() const  {
+	struct user_stat thread_stat;
+	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
+	if(n >= 18) {
+		return thread_stat.kstkeip;
+	}
+
+	return 0;
+}
+
+//------------------------------------------------------------------------------
+// Name:
+// Desc:
+//------------------------------------------------------------------------------
+QString PlatformThread::runState() const  {
+	struct user_stat thread_stat;
+	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
+	if(n >= 3) {
+		switch(thread_stat.state) {           // 03
+		case 'R':
+			return tr("%1 (Running)").arg(thread_stat.state);
+			break;
+		case 'S':
+			return tr("%1 (Sleeping)").arg(thread_stat.state);
+			break;
+		case 'D':
+			return tr("%1 (Disk Sleep)").arg(thread_stat.state);
+			break;
+		case 'T':
+			return tr("%1 (Stopped)").arg(thread_stat.state);
+			break;
+		case 't':
+			return tr("%1 (Tracing Stop)").arg(thread_stat.state);
+			break;
+		case 'Z':
+			return tr("%1 (Zombie)").arg(thread_stat.state);
+			break;
+		case 'X':
+		case 'x':
+			return tr("%1 (Dead)").arg(thread_stat.state);
+			break;
+		case 'W':
+			return tr("%1 (Waking/Paging)").arg(thread_stat.state);
+			break;
+		case 'K':
+			return tr("%1 (Wakekill)").arg(thread_stat.state);
+			break;
+		case 'P':
+			return tr("%1 (Parked)").arg(thread_stat.state);
+			break;
+		default:
+			return tr("%1").arg(thread_stat.state);
+			break;
+		}
+	}
+
+	return tr("Unknown");
+}
+
+//------------------------------------------------------------------------------
+// Name: step
+// Desc: steps this thread one instruction, passing the signal that stopped it
+//       (unless the signal was SIGSTOP)
+//------------------------------------------------------------------------------
+void PlatformThread::step() {
+	core_->ptrace_step(tid_, resume_code(status_));
+}
+
+//------------------------------------------------------------------------------
+// Name: step
+// Desc: steps this thread one instruction, passing the signal that stopped it
+//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
+//------------------------------------------------------------------------------
+void PlatformThread::step(edb::EVENT_STATUS status) {
+	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
+	core_->ptrace_step(tid_, code);
+}
+
+//------------------------------------------------------------------------------
+// Name: resume
+// Desc: resumes this thread, passing the signal that stopped it
+//       (unless the signal was SIGSTOP)
+//------------------------------------------------------------------------------
+void PlatformThread::resume() {
+	core_->ptrace_continue(tid_, resume_code(status_));
+}
+
+//------------------------------------------------------------------------------
+// Name: resume
+// Desc: resumes this thread , passing the signal that stopped it
+//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
+//------------------------------------------------------------------------------
+void PlatformThread::resume(edb::EVENT_STATUS status) {
+	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
+	core_->ptrace_continue(tid_, code);
+}
+
+//------------------------------------------------------------------------------
+// Name: stop
+// Desc:
+//------------------------------------------------------------------------------
+void PlatformThread::stop() {
+	syscall(SYS_tgkill, process_->pid(), tid_, SIGSTOP);
+	// TODO(eteran): should this just be this?
+	//::kill(tid_, SIGSTOP);
+}
+
+//------------------------------------------------------------------------------
+// Name: isPaused
+// Desc: returns true if this thread is currently in the debugger's wait list
+//------------------------------------------------------------------------------
+bool PlatformThread::isPaused() const {
+	return core_->waited_threads_.contains(tid_);
+}
+
+}

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "DebuggerCore.h"
 #include "IProcess.h"
 #include "PlatformCommon.h"
+#include <QDebug>
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE        /* or _BSD_SOURCE or _SVID_SOURCE */
@@ -186,10 +187,16 @@ Status PlatformThread::resume(edb::EVENT_STATUS status) {
 // Name: stop
 // Desc:
 //------------------------------------------------------------------------------
-void PlatformThread::stop() {
-	syscall(SYS_tgkill, process_->pid(), tid_, SIGSTOP);
+Status PlatformThread::stop() {
+	if(syscall(SYS_tgkill, process_->pid(), tid_, SIGSTOP)==-1) {
+
+		const char*const strError=strerror(errno);
+		qWarning() << "Unable to stop thread" << tid_ << ": tgkill failed:" << strError;
+		return Status(strError);
+	}
 	// TODO(eteran): should this just be this?
 	//::kill(tid_, SIGSTOP);
+	return Status::Ok;
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
@@ -168,8 +168,8 @@ Status PlatformThread::step(edb::EVENT_STATUS status) {
 // Desc: resumes this thread, passing the signal that stopped it
 //       (unless the signal was SIGSTOP)
 //------------------------------------------------------------------------------
-void PlatformThread::resume() {
-	core_->ptrace_continue(tid_, resume_code(status_));
+Status PlatformThread::resume() {
+	return core_->ptrace_continue(tid_, resume_code(status_));
 }
 
 //------------------------------------------------------------------------------
@@ -177,9 +177,9 @@ void PlatformThread::resume() {
 // Desc: resumes this thread , passing the signal that stopped it
 //       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
 //------------------------------------------------------------------------------
-void PlatformThread::resume(edb::EVENT_STATUS status) {
+Status PlatformThread::resume(edb::EVENT_STATUS status) {
 	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_continue(tid_, code);
+	return core_->ptrace_continue(tid_, code);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.h
@@ -63,7 +63,7 @@ public:
 	virtual Status step(edb::EVENT_STATUS status) override;
 	virtual Status resume() override;
 	virtual Status resume(edb::EVENT_STATUS status) override;
-	virtual void stop() override;
+	virtual Status stop() override;
 
 public:
 	virtual bool isPaused() const override;

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.h
@@ -61,8 +61,8 @@ public:
 public:
 	virtual Status step() override;
 	virtual Status step(edb::EVENT_STATUS status) override;
-	virtual void resume() override;
-	virtual void resume(edb::EVENT_STATUS status) override;
+	virtual Status resume() override;
+	virtual Status resume(edb::EVENT_STATUS status) override;
 	virtual void stop() override;
 
 public:

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.h
@@ -59,8 +59,8 @@ public:
 	virtual void set_state(const State &state) override;
 
 public:
-	virtual void step() override;
-	virtual void step(edb::EVENT_STATUS status) override;
+	virtual Status step() override;
+	virtual Status step(edb::EVENT_STATUS status) override;
 	virtual void resume() override;
 	virtual void resume(edb::EVENT_STATUS status) override;
 	virtual void stop() override;

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -33,7 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <elf.h>
 #include <linux/uio.h>
 #include <sys/ptrace.h>
-#include <sys/syscall.h>   /* For SYS_xxx definitions */
 #include <sys/user.h>
 
 
@@ -87,160 +86,6 @@ bool PlatformThread::fillStateFromSimpleRegs(PlatformState* state) {
 	}
 }
 
-
-//------------------------------------------------------------------------------
-// Name: PlatformThread
-// Desc:
-//------------------------------------------------------------------------------
-PlatformThread::PlatformThread(DebuggerCore *core, IProcess *process, edb::tid_t tid) : core_(core), process_(process), tid_(tid) {
-	assert(process);
-	assert(core);
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-PlatformThread::~PlatformThread() {
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-edb::tid_t PlatformThread::tid() const {
-	return tid_;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-QString PlatformThread::name() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 2) {
-		return thread_stat.comm;
-	}
-
-	return QString();
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-int PlatformThread::priority() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 30) {
-		return thread_stat.priority;
-	}
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-edb::address_t PlatformThread::instruction_pointer() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 18) {
-		return thread_stat.kstkeip;
-	}
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-QString PlatformThread::runState() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 3) {
-		switch(thread_stat.state) {           // 03
-		case 'R':
-			return tr("%1 (Running)").arg(thread_stat.state);
-			break;
-		case 'S':
-			return tr("%1 (Sleeping)").arg(thread_stat.state);
-			break;
-		case 'D':
-			return tr("%1 (Disk Sleep)").arg(thread_stat.state);
-			break;
-		case 'T':
-			return tr("%1 (Stopped)").arg(thread_stat.state);
-			break;
-		case 't':
-			return tr("%1 (Tracing Stop)").arg(thread_stat.state);
-			break;
-		case 'Z':
-			return tr("%1 (Zombie)").arg(thread_stat.state);
-			break;
-		case 'X':
-		case 'x':
-			return tr("%1 (Dead)").arg(thread_stat.state);
-			break;
-		case 'W':
-			return tr("%1 (Waking/Paging)").arg(thread_stat.state);
-			break;
-		case 'K':
-			return tr("%1 (Wakekill)").arg(thread_stat.state);
-			break;
-		case 'P':
-			return tr("%1 (Parked)").arg(thread_stat.state);
-			break;
-		default:
-			return tr("%1").arg(thread_stat.state);
-			break;
-		}
-	}
-
-	return tr("Unknown");
-}
-
-//------------------------------------------------------------------------------
-// Name: step
-// Desc: steps this thread one instruction, passing the signal that stopped it
-//       (unless the signal was SIGSTOP)
-//------------------------------------------------------------------------------
-void PlatformThread::step() {
-	core_->ptrace_step(tid_, resume_code(status_));
-}
-
-//------------------------------------------------------------------------------
-// Name: step
-// Desc: steps this thread one instruction, passing the signal that stopped it
-//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
-//------------------------------------------------------------------------------
-void PlatformThread::step(edb::EVENT_STATUS status) {
-	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_step(tid_, code);
-}
-
-//------------------------------------------------------------------------------
-// Name: resume
-// Desc: resumes this thread, passing the signal that stopped it
-//       (unless the signal was SIGSTOP)
-//------------------------------------------------------------------------------
-void PlatformThread::resume() {
-	core_->ptrace_continue(tid_, resume_code(status_));
-}
-
-//------------------------------------------------------------------------------
-// Name: resume
-// Desc: resumes this thread , passing the signal that stopped it
-//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
-//------------------------------------------------------------------------------
-void PlatformThread::resume(edb::EVENT_STATUS status) {
-	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_continue(tid_, code);
-}
-
 //------------------------------------------------------------------------------
 // Name: get_state
 // Desc:
@@ -284,24 +129,5 @@ unsigned long PlatformThread::get_debug_register(std::size_t n) {
 long PlatformThread::set_debug_register(std::size_t n, long value) {
 	return 0;
 }
-
-//------------------------------------------------------------------------------
-// Name: stop
-// Desc:
-//------------------------------------------------------------------------------
-void PlatformThread::stop() {
-	syscall(SYS_tgkill, process_->pid(), tid_, SIGSTOP);
-	// TODO(eteran): should this just be this?
-	//::kill(tid_, SIGSTOP);
-}
-
-//------------------------------------------------------------------------------
-// Name: isPaused
-// Desc: returns true if this thread is currently in the debugger's wait list
-//------------------------------------------------------------------------------
-bool PlatformThread::isPaused() const {
-	return core_->waited_threads_.contains(tid_);
-}
-
 
 }

--- a/plugins/DebuggerCore/unix/linux/arch/x86-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/x86-generic/PlatformThread.cpp
@@ -32,7 +32,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <elf.h>
 #include <linux/uio.h>
 #include <sys/ptrace.h>
-#include <sys/syscall.h>   /* For SYS_xxx definitions */
 #include <sys/user.h>
 
 
@@ -160,160 +159,6 @@ bool PlatformThread::fillStateFromSimpleRegs(PlatformState* state) {
 		perror("PTRACE_GETREGS failed");
 		return false;
 	}
-}
-
-
-//------------------------------------------------------------------------------
-// Name: PlatformThread
-// Desc:
-//------------------------------------------------------------------------------
-PlatformThread::PlatformThread(DebuggerCore *core, IProcess *process, edb::tid_t tid) : core_(core), process_(process), tid_(tid) {
-	assert(process);
-	assert(core);
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-PlatformThread::~PlatformThread() {
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-edb::tid_t PlatformThread::tid() const {
-	return tid_;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-QString PlatformThread::name() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 2) {
-		return thread_stat.comm;
-	}
-
-	return QString();
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-int PlatformThread::priority() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 30) {
-		return thread_stat.priority;
-	}
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-edb::address_t PlatformThread::instruction_pointer() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 18) {
-		return thread_stat.kstkeip;
-	}
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
-QString PlatformThread::runState() const  {
-	struct user_stat thread_stat;
-	int n = get_user_stat(QString("/proc/%1/task/%2/stat").arg(process_->pid()).arg(tid_), &thread_stat);
-	if(n >= 3) {
-		switch(thread_stat.state) {           // 03
-		case 'R':
-			return tr("%1 (Running)").arg(thread_stat.state);
-			break;
-		case 'S':
-			return tr("%1 (Sleeping)").arg(thread_stat.state);
-			break;
-		case 'D':
-			return tr("%1 (Disk Sleep)").arg(thread_stat.state);
-			break;
-		case 'T':
-			return tr("%1 (Stopped)").arg(thread_stat.state);
-			break;
-		case 't':
-			return tr("%1 (Tracing Stop)").arg(thread_stat.state);
-			break;
-		case 'Z':
-			return tr("%1 (Zombie)").arg(thread_stat.state);
-			break;
-		case 'X':
-		case 'x':
-			return tr("%1 (Dead)").arg(thread_stat.state);
-			break;
-		case 'W':
-			return tr("%1 (Waking/Paging)").arg(thread_stat.state);
-			break;
-		case 'K':
-			return tr("%1 (Wakekill)").arg(thread_stat.state);
-			break;
-		case 'P':
-			return tr("%1 (Parked)").arg(thread_stat.state);
-			break;
-		default:
-			return tr("%1").arg(thread_stat.state);
-			break;
-		}
-	}
-
-	return tr("Unknown");
-}
-
-//------------------------------------------------------------------------------
-// Name: step
-// Desc: steps this thread one instruction, passing the signal that stopped it
-//       (unless the signal was SIGSTOP)
-//------------------------------------------------------------------------------
-void PlatformThread::step() {
-	core_->ptrace_step(tid_, resume_code(status_));
-}
-
-//------------------------------------------------------------------------------
-// Name: step
-// Desc: steps this thread one instruction, passing the signal that stopped it
-//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
-//------------------------------------------------------------------------------
-void PlatformThread::step(edb::EVENT_STATUS status) {
-	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_step(tid_, code);
-}
-
-//------------------------------------------------------------------------------
-// Name: resume
-// Desc: resumes this thread, passing the signal that stopped it
-//       (unless the signal was SIGSTOP)
-//------------------------------------------------------------------------------
-void PlatformThread::resume() {
-	core_->ptrace_continue(tid_, resume_code(status_));
-}
-
-//------------------------------------------------------------------------------
-// Name: resume
-// Desc: resumes this thread , passing the signal that stopped it
-//       (unless the signal was SIGSTOP, or the passed status != DEBUG_EXCEPTION_NOT_HANDLED)
-//------------------------------------------------------------------------------
-void PlatformThread::resume(edb::EVENT_STATUS status) {
-	const int code = (status == edb::DEBUG_EXCEPTION_NOT_HANDLED) ? resume_code(status_) : 0;
-	core_->ptrace_continue(tid_, code);
 }
 
 //------------------------------------------------------------------------------
@@ -469,24 +314,5 @@ unsigned long PlatformThread::get_debug_register(std::size_t n) {
 long PlatformThread::set_debug_register(std::size_t n, long value) {
 	return ptrace(PTRACE_POKEUSER, tid_, offsetof(struct user, u_debugreg[n]), value);
 }
-
-//------------------------------------------------------------------------------
-// Name: stop
-// Desc:
-//------------------------------------------------------------------------------
-void PlatformThread::stop() {
-	syscall(SYS_tgkill, process_->pid(), tid_, SIGSTOP);
-	// TODO(eteran): should this just be this?
-	//::kill(tid_, SIGSTOP);
-}
-
-//------------------------------------------------------------------------------
-// Name: isPaused
-// Desc: returns true if this thread is currently in the debugger's wait list
-//------------------------------------------------------------------------------
-bool PlatformThread::isPaused() const {
-	return core_->waited_threads_.contains(tid_);
-}
-
 
 }

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -2609,13 +2609,26 @@ void Debugger::resume_execution(EXCEPTION_RESUME pass_exception, DEBUG_MODE mode
 
 			if(mode == MODE_STEP) {
 				reenable_breakpoint_step_ = bp;
-				thread->step(status);
+				const auto stepStatus=thread->step(status);
+				if(!stepStatus) {
+					QMessageBox::critical(this,tr("Error"),tr("Failed to step thread: %1").arg(stepStatus.toString()));
+					return;
+				}
 			} else if(mode == MODE_RUN) {
 				reenable_breakpoint_run_ = bp;
 				if(bp) {
-					thread->step(status);
+					const auto stepStatus=thread->step(status);
+					if(!stepStatus) {
+						QMessageBox::critical(this,tr("Error"),tr("Failed to step thread: %1").arg(stepStatus.toString()));
+						return;
+					}
 				} else {
-					process->resume(status);
+					const auto resumeStatus=process->resume(status);
+					if(!resumeStatus) {
+						QMessageBox::critical(this,tr("Error"),tr("Failed to resume process: %1").arg(resumeStatus.toString()));
+						return;
+					}
+					
 				}
 			}
 


### PR DESCRIPTION
This brings a bit of robustness to the API, as well as to the implementation of Linux-specific parts of DebuggerCore and Debugger itself.
There're still some things to improve: namely, menus change to running state simply when no errors in "continue"/"step" etc. occur. I'd rather have Debugger query DebuggerCore for actual state, and set GUI state based on this. This would make it even more robust. But this seems to require further changes to IDebugger, which I think had better go to another set of commits.
This set of commits also fixes #579.