### PR TITLE
Add missing return statement.

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -808,6 +808,7 @@ Status PlatformProcess::step(edb::EVENT_STATUS status) {
 			return thread->step(status);
 		}
 	}
+	return Status::Ok;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I'm not sure though: what is supposed to be done if the status is `DEBUG_STOP`? Is returning OK status the correct action?