### PR TITLE
Fixes to ARM breakpoints

### DIFF
--- a/include/IBreakpoint.h
+++ b/include/IBreakpoint.h
@@ -45,7 +45,6 @@ public:
 	virtual bool enabled() const = 0;
 	virtual bool one_time() const = 0;
 	virtual bool internal() const = 0;
-	virtual quint8 original_byte() const = 0;
 	virtual const quint8* original_bytes() const = 0;
 	virtual size_t size() const = 0;
 

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -24,8 +24,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace DebuggerCorePlugin {
 
 namespace {
-constexpr std::array<quint8, 4> BreakpointInstructionARM_LE   = { 0xFE, 0xDE, 0xFF, 0xE7 }; // UND
-constexpr std::array<quint8, 2> BreakpointInstructionThumb_LE = { 0xBE, 0xBE };             // BKPT
+constexpr std::array<quint8, 4> BreakpointInstructionARM_LE    = { 0xf0, 0x01, 0xf0, 0xe7 }; // udf #0x10
+constexpr std::array<quint8, 2> BreakpointInstructionThumb_LE  = { 0x01, 0xde };             // udf #1
+// We have to sometimes use a 32-bit Thumb-2 breakpoint. For explanation how to
+// correctly use it see GDB's thumb_get_next_pcs_raw function and comments
+// around arm_linux_thumb2_le_breakpoint array.
+constexpr std::array<quint8, 4> BreakpointInstructionThumb2_LE = { 0xf0, 0xf7, 0x00, 0xa0 }; // udf.w #0
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -35,7 +35,6 @@ public:
 	virtual bool enabled() const           override { return enabled_; }
 	virtual bool one_time() const          override { return one_time_; }
 	virtual bool internal() const          override { return internal_; }
-	virtual quint8 original_byte() const   override { return original_bytes_[0]; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
 

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -35,7 +35,6 @@ public:
 	virtual bool enabled() const           override { return enabled_; }
 	virtual bool one_time() const          override { return one_time_; }
 	virtual bool internal() const          override { return internal_; }
-	virtual quint8 original_byte() const   override { return original_bytes_[0]; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
 

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -306,9 +306,13 @@ std::size_t PlatformProcess::read_bytes(edb::address_t address, void* buf, std::
 
 		// replace any breakpoints
 		Q_FOREACH(const std::shared_ptr<IBreakpoint> &bp, core_->breakpoints_) {
-			if(bp->address() >= address && bp->address() < (address + read)) {
-				// show the original bytes in the buffer..
-				ptr[bp->address() - address] = bp->original_byte();
+			auto*const bpBytes=bp->original_bytes();
+			const auto bpAddr=bp->address();
+			// show the original bytes in the buffer..
+			for(size_t i=0; i < bp->size(); ++i) {
+				if(bpAddr + i >= address && bpAddr + i < address + read) {
+					ptr[bpAddr + i - address] = bpBytes[i];
+				}
 			}
 		}
 	}

--- a/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformProcess.cpp
@@ -259,7 +259,7 @@ std::size_t PlatformProcess::read_bytes(edb::address_t address, void* buf, std::
 
 			auto it = core_->breakpoints_.find(address);
 			if(it != core_->breakpoints_.end()) {
-				*ptr = (*it)->original_byte();
+				*ptr = (*it)->original_bytes()[0];
 				return 1;
 			}
 

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -219,9 +219,9 @@ public:
 #if defined(EDB_X86_64) || defined(EDB_X86)
 			edb::address_t prev_address = address - 1;
 #elif defined(EDB_ARM32)
-			                                           // NOTE(eteran): I think we need to look at the flags register to see the mode
-			                                           // then we will know how many bytes to reverse
-            edb::address_t prev_address = address - 4; // FIXME(ARM): Thumb?..
+			// Unlike x86, our ARM breakpoints are undefined instructions, leading to faults. Thus
+			// the address of the breakpoint is the current address itself.
+            edb::address_t prev_address = address;
 #endif
 			std::shared_ptr<IBreakpoint> bp = edb::v1::find_breakpoint(prev_address);
 
@@ -2158,9 +2158,9 @@ edb::EVENT_STATUS Debugger::handle_trap() {
 #if defined(EDB_X86_64) || defined(EDB_X86)
 	const edb::address_t previous_ip = state.instruction_pointer() - 1;
 #elif defined(EDB_ARM32)
-	                                                                    // NOTE(eteran): I think we need to look at the flags register to see the mode
-																		// then we will know how many bytes to reverse
-	const edb::address_t previous_ip = state.instruction_pointer() - 4; // FIXME(ARM): Thumb?..
+	// Unlike x86, our ARM breakpoints are undefined instructions, leading to faults. Thus
+	// the address of the breakpoint is the current address itself.
+	const edb::address_t previous_ip = state.instruction_pointer();
 #endif
 
 	// look it up in our breakpoint list, make sure it is one of OUR int3s!


### PR DESCRIPTION
Although single-stepping doesn't currently work (and will require the same mechanism as in Step Over feature, which currently doesn't work too :) ) due to [this kernel patch](http://lists.infradead.org/pipermail/linux-arm-kernel/2011-February/041324.html), now EDB can at least "run to cursor" repeatedly, and the breakpoints are not shown as garbled code. Also, the breakpoints now result in SIGTRAP instead of SIGILL, which makes it easier to handle them (fewer changes WRT x86).