### PR TITLE
Varying breakpoint types, changing thread state, more complete single-stepping

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CONFIGURATION_20061031_H_
 
 #include "API.h"
+#include "IBreakpoint.h"
 #include <QObject>
 #include <QString>
 #include <QList>
@@ -87,6 +88,7 @@ public:
 	bool              disableASLR;
 	bool              disableLazyBinding;
     bool              break_on_library_load;
+	IBreakpoint::TypeId default_breakpoint_type;
 	QString           tty_command;
 
 	// disassembly tab

--- a/include/IBreakpoint.h
+++ b/include/IBreakpoint.h
@@ -57,6 +57,9 @@ public:
 	virtual const quint8* original_bytes() const = 0;
 	virtual size_t size() const = 0;
 	virtual TypeId type() const = 0;
+	/** number of bytes to go back to restart original
+		instruction after hitting the breakpoint */
+	virtual size_t rewind_size() const = 0;
 
 public:
 	virtual bool enable() = 0;

--- a/include/IBreakpoint.h
+++ b/include/IBreakpoint.h
@@ -75,4 +75,6 @@ public:
 
 };
 
+Q_DECLARE_METATYPE(IBreakpoint::TypeId);
+
 #endif

--- a/include/IBreakpoint.h
+++ b/include/IBreakpoint.h
@@ -39,6 +39,15 @@ protected:
 public:
 	virtual ~IBreakpoint() = default;
 
+	enum class TypeId : int
+	{
+		Automatic, // should be the default if the user hasn't chosen anything other
+	};
+	struct BreakpointType {
+		TypeId type;
+		QString description;
+	};
+
 public:
 	virtual edb::address_t address() const = 0;
 	virtual quint64 hit_count() const = 0;
@@ -47,6 +56,7 @@ public:
 	virtual bool internal() const = 0;
 	virtual const quint8* original_bytes() const = 0;
 	virtual size_t size() const = 0;
+	virtual TypeId type() const = 0;
 
 public:
 	virtual bool enable() = 0;
@@ -54,6 +64,7 @@ public:
 	virtual void hit() = 0;
 	virtual void set_one_time(bool value) = 0;
 	virtual void set_internal(bool value) = 0;
+	virtual void set_type(TypeId type) = 0;
 
 public:
 	QString condition;

--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -100,6 +100,7 @@ public:
 	virtual BreakpointList               backup_breakpoints() const = 0;
 	virtual std::shared_ptr<IBreakpoint> add_breakpoint(edb::address_t address) = 0;
 	virtual std::shared_ptr<IBreakpoint> find_breakpoint(edb::address_t address) = 0;
+	virtual std::shared_ptr<IBreakpoint> find_triggered_breakpoint(edb::address_t address) = 0;
 	virtual void                         clear_breakpoints() = 0;
 	virtual void                         remove_breakpoint(edb::address_t address) = 0;
 	virtual std::vector<IBreakpoint::BreakpointType> supported_breakpoint_types() const = 0;

--- a/include/IDebugger.h
+++ b/include/IDebugger.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "OSTypes.h"
 #include "Types.h"
+#include "IBreakpoint.h"
 #include <QByteArray>
 #include <QHash>
 #include <QMap>
@@ -28,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QtPlugin>
 #include <memory>
 
-class IBreakpoint;
 class IDebugEvent;
 class IProcess;
 class IState;
@@ -102,6 +102,7 @@ public:
 	virtual std::shared_ptr<IBreakpoint> find_breakpoint(edb::address_t address) = 0;
 	virtual void                         clear_breakpoints() = 0;
 	virtual void                         remove_breakpoint(edb::address_t address) = 0;
+	virtual std::vector<IBreakpoint::BreakpointType> supported_breakpoint_types() const = 0;
 
 public:
 	virtual IState *create_state() const = 0;

--- a/include/Types.h
+++ b/include/Types.h
@@ -72,6 +72,9 @@ protected:
 	template <class Data>
 	explicit ValueBase(const Data& data, std::size_t offset = 0) {
 		static_assert(sizeof(Data) >= sizeof(ValueType), "ValueBase can only be constructed from large enough variable");
+#if defined __GNUG__ && __GNUC__ >= 5 || !defined __GNUG__ || defined __clang__ && __clang_major__*100+__clang_minor__>=306
+		static_assert(std::is_trivially_copyable<Data>::value, "ValueBase can only be constructed from trivially copiable data");
+#endif
 
 		assert(sizeof(Data) - offset >= sizeof(ValueType)); // check bounds, this can't be done at compile time
 

--- a/include/Util.h
+++ b/include/Util.h
@@ -41,6 +41,17 @@ enum class NumberDisplayMode {
 
 namespace util {
 
+// Used to interconvert between abstract enum defined in an interface and actual enumerators in implementation
+template<typename AbstractEnum, typename ConcreteEnum>
+class AbstractEnumData {
+	AbstractEnum data;
+public:
+	AbstractEnumData(AbstractEnum a) : data(a) {}
+	AbstractEnumData(ConcreteEnum c) : data(static_cast<AbstractEnum>(c)) {}
+	operator AbstractEnum() const { return data; }
+	operator ConcreteEnum() const { return static_cast<ConcreteEnum>(data); }
+};
+
 // Until EDB switches to C++14, this will be useful
 template<typename T, typename ...Args>
 std::unique_ptr<T> make_unique( Args&& ...args )

--- a/include/edb.h
+++ b/include/edb.h
@@ -78,6 +78,7 @@ EDB_EXPORT QAbstractScrollArea *disassembly_widget();
 
 // breakpoint managment
 EDB_EXPORT std::shared_ptr<IBreakpoint> find_breakpoint(address_t address);
+EDB_EXPORT std::shared_ptr<IBreakpoint> find_triggered_breakpoint(address_t address);
 EDB_EXPORT QString get_breakpoint_condition(address_t address);
 EDB_EXPORT address_t disable_breakpoint(address_t address);
 EDB_EXPORT address_t enable_breakpoint(address_t address);

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -162,4 +162,8 @@ bool DebuggerCoreBase::attached() const {
 	return pid() != 0;
 }
 
+auto DebuggerCoreBase::supported_breakpoint_types() const -> std::vector<IBreakpoint::BreakpointType> {
+	return Breakpoint::supported_types();
+}
+
 }

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -87,6 +87,25 @@ std::shared_ptr<IBreakpoint> DebuggerCoreBase::find_breakpoint(edb::address_t ad
 
 
 //------------------------------------------------------------------------------
+// Name: find_breakpoint
+// Desc: similarly to find_breakpoint, finds a breakpoint near given address. But
+// 		 unlike find_breakpoint, this function looks for a breakpoint which ends
+// 		 up at this address after being triggered, instead of just starting there.
+//------------------------------------------------------------------------------
+std::shared_ptr<IBreakpoint> DebuggerCoreBase::find_triggered_breakpoint(edb::address_t address) {
+	if(attached()) {
+		for(const auto size : Breakpoint::possible_rewind_sizes()) {
+			const auto bpAddr=address-size;
+			const auto bp=find_breakpoint(bpAddr);
+			if(bp && bp->address()==bpAddr)
+				return bp;
+		}
+	}
+	return nullptr;
+}
+
+
+//------------------------------------------------------------------------------
 // Name: remove_breakpoint
 // Desc: removes the breakpoint at the given address, this is a no-op if there
 //       is no breakpoint present.

--- a/plugins/DebuggerCore/DebuggerCoreBase.h
+++ b/plugins/DebuggerCore/DebuggerCoreBase.h
@@ -45,6 +45,7 @@ public:
 	virtual BreakpointList backup_breakpoints() const override;
 	virtual std::shared_ptr<IBreakpoint> add_breakpoint(edb::address_t address) override;
 	virtual std::shared_ptr<IBreakpoint> find_breakpoint(edb::address_t address) override;
+	virtual std::shared_ptr<IBreakpoint> find_triggered_breakpoint(edb::address_t address) override;
 	virtual void clear_breakpoints() override;
 	virtual void remove_breakpoint(edb::address_t address) override;
 	virtual void end_debug_session() override;

--- a/plugins/DebuggerCore/DebuggerCoreBase.h
+++ b/plugins/DebuggerCore/DebuggerCoreBase.h
@@ -49,6 +49,8 @@ public:
 	virtual void remove_breakpoint(edb::address_t address) override;
 	virtual void end_debug_session() override;
 
+	virtual std::vector<IBreakpoint::BreakpointType> supported_breakpoint_types() const override;
+
 public:
 	virtual edb::pid_t pid() const;
 

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -50,15 +50,14 @@ Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0
 }
 
 auto Breakpoint::supported_types() -> std::vector<BreakpointType> {
-	const auto makeBP=[](TypeId id, QString const& s){ return BreakpointType{static_cast<IBreakpoint::TypeId>(id),s}; };
 	std::vector<BreakpointType> types = {
-		makeBP(TypeId::Automatic,QObject::tr("Automatic")),
-		makeBP(TypeId::ARM32,QObject::tr("Always ARM32 UDF")),
-		makeBP(TypeId::Thumb2Byte,QObject::tr("Always Thumb UDF")),
-		makeBP(TypeId::Thumb4Byte,QObject::tr("Always Thumb2 UDF.W")),
-		makeBP(TypeId::UniversalThumbARM32,QObject::tr("Universal ARM/Thumb UDF(+B .-2)")),
-		makeBP(TypeId::ARM32BKPT,QObject::tr("ARM32 BKPT (may be slow)")),
-		makeBP(TypeId::ThumbBKPT,QObject::tr("Thumb BKPT (may be slow)")),
+		BreakpointType{Type{TypeId::Automatic          },QObject::tr("Automatic")},
+		BreakpointType{Type{TypeId::ARM32              },QObject::tr("Always ARM32 UDF")},
+		BreakpointType{Type{TypeId::Thumb2Byte         },QObject::tr("Always Thumb UDF")},
+		BreakpointType{Type{TypeId::Thumb4Byte         },QObject::tr("Always Thumb2 UDF.W")},
+		BreakpointType{Type{TypeId::UniversalThumbARM32},QObject::tr("Universal ARM/Thumb UDF(+B .-2)")},
+		BreakpointType{Type{TypeId::ARM32BKPT          },QObject::tr("ARM32 BKPT (may be slow)")},
+		BreakpointType{Type{TypeId::ThumbBKPT          },QObject::tr("Thumb BKPT (may be slow)")},
 	};
 	return types;
 }
@@ -71,10 +70,9 @@ void Breakpoint::set_type(TypeId type) {
 	}
 }
 
-void Breakpoint::set_type(IBreakpoint::TypeId type_) {
-	const auto type=static_cast<TypeId>(type_);
+void Breakpoint::set_type(IBreakpoint::TypeId type) {
 	disable();
-	if(type>=TypeId::TYPE_COUNT)
+	if(Type{type}>=TypeId::TYPE_COUNT)
 		throw breakpoint_creation_error();
 	set_type(type);
 }
@@ -100,7 +98,7 @@ bool Breakpoint::enable() {
 				original_bytes_ = prev;
 
 				const std::vector<quint8>* bpBytes=nullptr;
-				switch(type_)
+				switch(TypeId{type_})
 				{
 				case TypeId::Automatic:
 					if(edb::v1::debugger_core->cpu_mode()==IDebugger::CPUMode::Thumb) {

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -178,4 +178,8 @@ size_t Breakpoint::rewind_size() const {
 	return 0;
 }
 
+std::vector<size_t> Breakpoint::possible_rewind_sizes() {
+	return {0}; // Even BKPT stops before the instruction, let alone UDF
+}
+
 }

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -49,12 +49,34 @@ Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0
 	}
 }
 
+auto Breakpoint::supported_types() -> std::vector<BreakpointType> {
+	const auto makeBP=[](TypeId id, QString const& s){ return BreakpointType{static_cast<IBreakpoint::TypeId>(id),s}; };
+	std::vector<BreakpointType> types = {
+		makeBP(TypeId::Automatic,QObject::tr("Automatic")),
+		makeBP(TypeId::ARM32,QObject::tr("Always ARM32 UDF")),
+		makeBP(TypeId::Thumb2Byte,QObject::tr("Always Thumb UDF")),
+		makeBP(TypeId::Thumb4Byte,QObject::tr("Always Thumb2 UDF.W")),
+		makeBP(TypeId::UniversalThumbARM32,QObject::tr("Universal ARM/Thumb UDF(+B .-2)")),
+		makeBP(TypeId::ARM32BKPT,QObject::tr("ARM32 BKPT (may be slow)")),
+		makeBP(TypeId::ThumbBKPT,QObject::tr("Thumb BKPT (may be slow)")),
+	};
+	return types;
+}
+
 void Breakpoint::set_type(TypeId type) {
 	disable();
 	type_=type;
 	if(!enable()) {
 		throw breakpoint_creation_error();
 	}
+}
+
+void Breakpoint::set_type(IBreakpoint::TypeId type_) {
+	const auto type=static_cast<TypeId>(type_);
+	disable();
+	if(type>=TypeId::TYPE_COUNT)
+		throw breakpoint_creation_error();
+	set_type(type);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IDebugger.h"
 #include "IProcess.h"
 #include "edb.h"
+#include "Configuration.h"
 
 namespace DebuggerCorePlugin {
 
@@ -42,7 +43,7 @@ const std::vector<quint8> BreakpointInstructionARM32BKPT_LE  = { 0x70, 0x00, 0x2
 // Name: Breakpoint
 // Desc: constructor
 //------------------------------------------------------------------------------
-Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false), type_(TypeId::Automatic) {
+Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false), type_(edb::v1::config().default_breakpoint_type) {
 
 	if(!enable()) {
 		throw breakpoint_creation_error();

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -30,6 +30,12 @@ const std::vector<quint8> BreakpointInstructionThumb_LE  = { 0x01, 0xde };      
 // correctly use it see GDB's thumb_get_next_pcs_raw function and comments
 // around arm_linux_thumb2_le_breakpoint array.
 const std::vector<quint8> BreakpointInstructionThumb2_LE = { 0xf0, 0xf7, 0x00, 0xa0 }; // udf.w #0
+// This one generates SIGILL both in ARM32 and Thumb mode. In ARM23 mode it's decoded as UDF 0xDDE0, while
+// in Thumb it's a sequence `1: UDF 0xF0; B 1b`, which does stop the process even if it lands in the
+// middle (on the second half-word), although the signal still occurs at the first half-word.
+const std::vector<quint8> BreakpointInstructionUniversalThumbARM_LE = { 0xf0, 0xde, 0xfd, 0xe7 };
+const std::vector<quint8> BreakpointInstructionThumbBKPT_LE  = { 0x00, 0xbe }; // bkpt #0
+const std::vector<quint8> BreakpointInstructionARM32BKPT_LE  = { 0x70, 0x00, 0x20, 0xe1 }; // bkpt #0
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -172,4 +172,10 @@ void Breakpoint::set_internal(bool value) {
 	internal_ = value;
 }
 
+size_t Breakpoint::rewind_size() const {
+	// We are currently using undefined instructions as breakpoints. They result in
+	// faults, so don't let instruction pointer past them.
+	return 0;
+}
+
 }

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.cpp
@@ -71,6 +71,8 @@ bool Breakpoint::enable() {
 					original_bytes_.resize(size);
 				}
 
+				// FIXME: we don't check whether this breakpoint will overlap any of the existing breakpoints
+
 				if(process->write_bytes(address(), bpBytes, size)) {
 					enabled_ = true;
 					return true;

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -27,19 +27,19 @@ namespace DebuggerCorePlugin {
 class Breakpoint : public IBreakpoint {
 public:
 	enum class TypeId {
-		Automatic,
+		Automatic=IBreakpoint::TypeId::Automatic,
 		ARM32,
 		Thumb2Byte,
 		Thumb4Byte,
 		UniversalThumbARM32,
 		ARM32BKPT,
 		ThumbBKPT,
+
+		TYPE_COUNT
 	};
 public:
 	Breakpoint(edb::address_t address);
 	virtual ~Breakpoint();
-	TypeId type() const { return type_; }
-	void set_type(TypeId type);
 
 public:
 	virtual edb::address_t address() const override { return address_; }
@@ -49,6 +49,9 @@ public:
 	virtual bool internal() const          override { return internal_; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
+	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+
+	static std::vector<BreakpointType> supported_types();
 
 public:
 	virtual bool enable() override;
@@ -56,6 +59,8 @@ public:
 	virtual void hit() override;
 	virtual void set_one_time(bool value) override;
 	virtual void set_internal(bool value) override;
+	virtual void set_type(IBreakpoint::TypeId type) override;
+	void set_type(TypeId type);
 
 private:
 	std::vector<quint8> original_bytes_;

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BREAKPOINT_20060720_H_
 
 #include "IBreakpoint.h"
+#include "Util.h"
 #include <array>
 
 namespace DebuggerCorePlugin {
@@ -37,6 +38,7 @@ public:
 
 		TYPE_COUNT
 	};
+	using Type=util::AbstractEnumData<IBreakpoint::TypeId, TypeId>;
 public:
 	Breakpoint(edb::address_t address);
 	virtual ~Breakpoint();
@@ -49,7 +51,7 @@ public:
 	virtual bool internal() const          override { return internal_; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
-	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+	virtual IBreakpoint::TypeId type() const override { return type_; }
 	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
@@ -71,7 +73,7 @@ private:
 	bool                  enabled_ ;
 	bool                  one_time_;
 	bool                  internal_;
-	TypeId                type_;
+	Type                  type_;
 };
 
 }

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -53,6 +53,7 @@ public:
 	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
+	static std::vector<size_t> possible_rewind_sizes();
 
 public:
 	virtual bool enable() override;

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -50,6 +50,7 @@ public:
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
 	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
 

--- a/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/arm-generic/Breakpoint.h
@@ -26,8 +26,20 @@ namespace DebuggerCorePlugin {
 
 class Breakpoint : public IBreakpoint {
 public:
+	enum class TypeId {
+		Automatic,
+		ARM32,
+		Thumb2Byte,
+		Thumb4Byte,
+		UniversalThumbARM32,
+		ARM32BKPT,
+		ThumbBKPT,
+	};
+public:
 	Breakpoint(edb::address_t address);
 	virtual ~Breakpoint();
+	TypeId type() const { return type_; }
+	void set_type(TypeId type);
 
 public:
 	virtual edb::address_t address() const override { return address_; }
@@ -52,6 +64,7 @@ private:
 	bool                  enabled_ ;
 	bool                  one_time_;
 	bool                  internal_;
+	TypeId                type_;
 };
 
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace DebuggerCorePlugin {
 
 namespace {
-constexpr std::array<quint8, 1> BreakpointInstruction = { 0xcc };
+const std::vector<quint8> BreakpointInstruction = { 0xcc };
 }
 
 //------------------------------------------------------------------------------
@@ -32,8 +32,6 @@ constexpr std::array<quint8, 1> BreakpointInstruction = { 0xcc };
 // Desc: constructor
 //------------------------------------------------------------------------------
 Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false) {
-
-	std::fill(original_bytes_.begin(), original_bytes_.end(), 0xff);
 
 	if(!enable()) {
 		throw breakpoint_creation_error();
@@ -55,7 +53,7 @@ Breakpoint::~Breakpoint() {
 bool Breakpoint::enable() {
 	if(!enabled()) {
 		if(IProcess *process = edb::v1::debugger_core->process()) {
-			std::array<quint8, 1> prev;
+			std::vector<quint8> prev(1);
 			if(process->read_bytes(address(), &prev[0], prev.size())) {
 				original_bytes_ = prev;
 				if(process->write_bytes(address(), &BreakpointInstruction[0], BreakpointInstruction.size())) {

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IDebugger.h"
 #include "IProcess.h"
 #include "edb.h"
+#include "Configuration.h"
 
 namespace DebuggerCorePlugin {
 
@@ -41,7 +42,7 @@ const std::vector<quint8> BreakpointInstructionUD0   = {0x0f, 0xff};
 // Name: Breakpoint
 // Desc: constructor
 //------------------------------------------------------------------------------
-Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false), type_(TypeId::Automatic) {
+Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false), type_(edb::v1::config().default_breakpoint_type) {
 
 	if(!enable()) {
 		throw breakpoint_creation_error();

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -49,20 +49,19 @@ Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0
 }
 
 auto Breakpoint::supported_types() -> std::vector<BreakpointType> {
-	const auto makeBP=[](TypeId id, QString const& s){ return BreakpointType{static_cast<IBreakpoint::TypeId>(id),s}; };
 	std::vector<BreakpointType> types = {
-		makeBP(TypeId::Automatic,QObject::tr("Automatic")),
-		makeBP(TypeId::INT3 ,    QObject::tr("INT3")),
-		makeBP(TypeId::INT1 ,    QObject::tr("INT1 (ICEBP)")),
-		makeBP(TypeId::HLT  ,    QObject::tr("HLT")),
-		makeBP(TypeId::CLI  ,    QObject::tr("CLI")),
-		makeBP(TypeId::STI  ,    QObject::tr("STI")),
-		makeBP(TypeId::INSB ,    QObject::tr("INSB")),
-		makeBP(TypeId::INSD ,    QObject::tr("INSD")),
-		makeBP(TypeId::OUTSB,    QObject::tr("OUTSB")),
-		makeBP(TypeId::OUTSD,    QObject::tr("OUTSD")),
-		makeBP(TypeId::UD2  ,    QObject::tr("UD2 (2-byte)")),
-		makeBP(TypeId::UD0  ,    QObject::tr("UD0 (2-byte)")),
+		BreakpointType{Type{TypeId::Automatic},QObject::tr("Automatic")},
+		BreakpointType{Type{TypeId::INT3     },QObject::tr("INT3")},
+		BreakpointType{Type{TypeId::INT1     },QObject::tr("INT1 (ICEBP)")},
+		BreakpointType{Type{TypeId::HLT      },QObject::tr("HLT")},
+		BreakpointType{Type{TypeId::CLI      },QObject::tr("CLI")},
+		BreakpointType{Type{TypeId::STI      },QObject::tr("STI")},
+		BreakpointType{Type{TypeId::INSB     },QObject::tr("INSB")},
+		BreakpointType{Type{TypeId::INSD     },QObject::tr("INSD")},
+		BreakpointType{Type{TypeId::OUTSB    },QObject::tr("OUTSB")},
+		BreakpointType{Type{TypeId::OUTSD    },QObject::tr("OUTSD")},
+		BreakpointType{Type{TypeId::UD2      },QObject::tr("UD2 (2-byte)")},
+		BreakpointType{Type{TypeId::UD0      },QObject::tr("UD0 (2-byte)")},
 	};
 	return types;
 }
@@ -76,10 +75,9 @@ void Breakpoint::set_type(TypeId type) {
 	}
 }
 
-void Breakpoint::set_type(IBreakpoint::TypeId type_) {
-	const auto type=static_cast<TypeId>(type_);
+void Breakpoint::set_type(IBreakpoint::TypeId type) {
 	disable();
-	if(type>=TypeId::TYPE_COUNT)
+	if(Type{type}>=TypeId::TYPE_COUNT)
 		throw breakpoint_creation_error();
 	set_type(type);
 }
@@ -103,7 +101,7 @@ bool Breakpoint::enable() {
 			if(process->read_bytes(address(), &prev[0], prev.size())) {
 				original_bytes_ = prev;
 				const std::vector<quint8>* bpBytes=nullptr;
-				switch(type_)
+				switch(TypeId{type_})
 				{
 				case TypeId::Automatic:
 				case TypeId::INT3:  bpBytes=&BreakpointInstructionINT3;  break;

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -132,4 +132,10 @@ void Breakpoint::set_internal(bool value) {
 	internal_ = value;
 }
 
+size_t Breakpoint::rewind_size() const {
+	// TODO: make the logic more complete for multibyte breakpoints as well as for
+	// 		 those resulting in #GP, #UD etc. instead of the usual #BP.
+	return 1;
+}
+
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -138,4 +138,8 @@ size_t Breakpoint::rewind_size() const {
 	return 1;
 }
 
+std::vector<size_t> Breakpoint::possible_rewind_sizes() {
+	return {1,0,2}; // e.g. int3/int1, cli/sti/hlt/etc., int 0x1/int 0x3
+}
+
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -31,11 +31,37 @@ const std::vector<quint8> BreakpointInstruction = { 0xcc };
 // Name: Breakpoint
 // Desc: constructor
 //------------------------------------------------------------------------------
-Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false) {
+Breakpoint::Breakpoint(edb::address_t address) : address_(address), hit_count_(0), enabled_(false), one_time_(false), internal_(false), type_(TypeId::Automatic) {
 
 	if(!enable()) {
 		throw breakpoint_creation_error();
 	}
+}
+
+auto Breakpoint::supported_types() -> std::vector<BreakpointType> {
+	const auto makeBP=[](TypeId id, QString const& s){ return BreakpointType{static_cast<IBreakpoint::TypeId>(id),s}; };
+	std::vector<BreakpointType> types = {
+		makeBP(TypeId::Automatic,QObject::tr("Automatic")),
+		makeBP(TypeId::INT3 ,    QObject::tr("INT3")),
+	};
+	return types;
+}
+
+
+void Breakpoint::set_type(TypeId type) {
+	disable();
+	type_=type;
+	if(!enable()) {
+		throw breakpoint_creation_error();
+	}
+}
+
+void Breakpoint::set_type(IBreakpoint::TypeId type_) {
+	const auto type=static_cast<TypeId>(type_);
+	disable();
+	if(type>=TypeId::TYPE_COUNT)
+		throw breakpoint_creation_error();
+	set_type(type);
 }
 
 //------------------------------------------------------------------------------

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -48,7 +48,7 @@ public:
 	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
-
+	static std::vector<size_t> possible_rewind_sizes();
 
 public:
 	virtual bool enable() override;

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -29,6 +29,16 @@ public:
 	enum class TypeId {
 		Automatic=IBreakpoint::TypeId::Automatic,
 		INT3,
+		INT1,
+		HLT,
+		CLI,
+		STI,
+		INSB,
+		INSD,
+		OUTSB,
+		OUTSD,
+		UD2,
+		UD0,
 
 		TYPE_COUNT
 	};

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -26,6 +26,13 @@ namespace DebuggerCorePlugin {
 
 class Breakpoint : public IBreakpoint {
 public:
+	enum class TypeId {
+		Automatic=IBreakpoint::TypeId::Automatic,
+		INT3,
+
+		TYPE_COUNT
+	};
+public:
 	Breakpoint(edb::address_t address);
 	virtual ~Breakpoint();
 
@@ -37,6 +44,10 @@ public:
 	virtual bool internal() const          override { return internal_; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
+	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+
+	static std::vector<BreakpointType> supported_types();
+
 
 public:
 	virtual bool enable() override;
@@ -44,6 +55,8 @@ public:
 	virtual void hit() override;
 	virtual void set_one_time(bool value) override;
 	virtual void set_internal(bool value) override;
+	virtual void set_type(IBreakpoint::TypeId type) override;
+	void set_type(TypeId type);
 
 private:
 	std::vector<quint8>   original_bytes_;
@@ -52,6 +65,7 @@ private:
 	bool                  enabled_ ;
 	bool                  one_time_;
 	bool                  internal_;
+	TypeId                type_;
 };
 
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -45,6 +45,7 @@ public:
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
 	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
 

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define X86BREAKPOINT_20060720_H_
 
 #include "IBreakpoint.h"
+#include "Util.h"
 #include <array>
 
 namespace DebuggerCorePlugin {
@@ -42,6 +43,7 @@ public:
 
 		TYPE_COUNT
 	};
+	using Type=util::AbstractEnumData<IBreakpoint::TypeId, TypeId>;
 public:
 	Breakpoint(edb::address_t address);
 	virtual ~Breakpoint();
@@ -54,7 +56,7 @@ public:
 	virtual bool internal() const          override { return internal_; }
 	virtual size_t size() const            override { return original_bytes_.size(); }
 	virtual const quint8* original_bytes() const override { return &original_bytes_[0]; }
-	virtual IBreakpoint::TypeId type() const override { return static_cast<IBreakpoint::TypeId>(type_); }
+	virtual IBreakpoint::TypeId type() const override { return type_; }
 	virtual size_t rewind_size() const override;
 
 	static std::vector<BreakpointType> supported_types();
@@ -76,7 +78,7 @@ private:
 	bool                  enabled_ ;
 	bool                  one_time_;
 	bool                  internal_;
-	TypeId                type_;
+	Type                  type_;
 };
 
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.h
@@ -46,7 +46,7 @@ public:
 	virtual void set_internal(bool value) override;
 
 private:
-	std::array<quint8, 1> original_bytes_;
+	std::vector<quint8>   original_bytes_;
 	edb::address_t        address_;
 	quint64               hit_count_;
 	bool                  enabled_ ;

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -504,7 +504,7 @@ std::shared_ptr<IDebugEvent> DebuggerCore::handle_event(edb::tid_t tid, int stat
 		const auto& thread=*it;
 		if(thread->singleStepBreakpoint) {
 
-			remove_breakpoint(thread->singleStepBreakpoint);
+			remove_breakpoint(thread->singleStepBreakpoint->address());
 			thread->singleStepBreakpoint=nullptr;
 		}
 	}

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -196,4 +196,16 @@ void PlatformState::fillFrom(user_regs const& regs)
 	gpr.filled=true;
 }
 
+void PlatformState::fillStruct(user_regs& regs) const
+{
+	util::markMemory(&regs, sizeof(regs));
+	if(gpr.filled)
+	{
+		for(unsigned i=0;i<gpr.GPRegs.size();++i)
+			regs.uregs[i]=gpr.GPRegs[i];
+		regs.uregs[16]=gpr.cpsr;
+		// FIXME: uregs[17] is not filled
+	}
+}
+
 }

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -74,6 +74,7 @@ Register PlatformState::instruction_pointer_register() const
 Register PlatformState::flags_register() const
 {
 #ifdef EDB_ARM32
+	if(!gpr.filled) return Register();
 	return make_Register<32>("cpsr", gpr.cpsr, Register::TYPE_GPR);
 #else
 	return Register();  // FIXME: stub

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -146,19 +146,37 @@ void PlatformState::set_debug_register(size_t n, edb::reg_t value)
 }
 void PlatformState::set_flags(edb::reg_t flags)
 {
-	// FIXME: stub
+	gpr.cpsr=flags;
 }
 void PlatformState::set_instruction_pointer(edb::address_t value)
 {
-	// FIXME: stub
+	gpr.GPRegs[GPR::PC]=value;
 }
 void PlatformState::set_register(const Register &reg)
 {
-	// FIXME: stub
+	if(!reg) return;
+	const auto name=reg.name().toLower();
+	if(name=="cpsr")
+	{
+		set_flags(reg.value<edb::reg_t>());
+		return;
+	}
+	const auto gprFoundIt=findGPR(name);
+	if(gprFoundIt!=GPR::GPRegNames.end())
+	{
+		const auto index=gprFoundIt-GPR::GPRegNames.begin();
+		assert(index<16);
+		gpr.GPRegs[index]=reg.value<edb::reg_t>();
+		return;
+	}
 }
 void PlatformState::set_register(const QString &name, edb::reg_t value)
 {
-	// FIXME: stub
+#ifdef EDB_ARM32
+	const QString regName = name.toLower();
+	set_register(make_Register<32>(regName, value, Register::TYPE_GPR));
+	// FIXME: this doesn't take into account any 64-bit registers - possibly FPU data?
+#endif
 }
 Register PlatformState::gp_register(size_t n) const
 {

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "edb.h"
 #include <cstddef>
 #include <sys/user.h>
+#include <vector>
 
 namespace DebuggerCorePlugin {
 
@@ -73,7 +74,8 @@ private:
 			LR=14,
 			PC=15,
 		};
-		static const std::array<const char *, GPR_COUNT> GPRegNames;
+		using RegNameVariants=std::vector<const char *>;
+		static const std::array<RegNameVariants, GPR_COUNT> GPRegNames;
 
 		bool filled=false;
 		std::array<edb::reg_t, GPR_COUNT> GPRegs;
@@ -82,6 +84,8 @@ private:
 		void clear();
 		bool empty() const;
 	} gpr;
+private:
+	auto findGPR(QString const& name) const -> decltype(gpr.GPRegNames.begin());
 };
 
 }

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
@@ -63,6 +63,7 @@ public:
 	Register gp_register(size_t n) const override;
 
 	void fillFrom(user_regs const& regs);
+	void fillStruct(user_regs& regs) const;
 private:
 	struct GPR {
 		enum NamedGPRIndex : size_t {

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -250,6 +250,8 @@ Status PlatformThread::doStep(const edb::tid_t tid, const long status) {
 				}
 			}
 
+			if(singleStepBreakpoint)
+				return Status(QObject::tr("internal EDB error: single-step breakpoint still present"));
 			singleStepBreakpoint=core_->add_breakpoint(addrAfterInsn);
 			if(!singleStepBreakpoint)
 				return Status(QObject::tr("failed to set breakpoint at address %1.").arg(addrAfterInsn.toPointerString()));

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -254,6 +254,7 @@ Status PlatformThread::doStep(const edb::tid_t tid, const long status) {
 				return Status(QObject::tr("internal EDB error: single-step breakpoint still present"));
 			if(const auto oldBP=core_->find_breakpoint(addrAfterInsn))
 			{
+				// TODO: EDB should support overlapping breakpoints
 				if(!oldBP->enabled())
 					return Status(QObject::tr("a disabled breakpoint is present at address %1, can't set one for single step.").arg(addrAfterInsn.toPointerString()));
 			}

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -113,6 +113,11 @@ void PlatformThread::set_state(const State &state) {
 
 	if(auto state_impl = static_cast<PlatformState *>(state.impl_)) {
 
+		user_regs regs;
+		state_impl->fillStruct(regs);
+		if(ptrace(PTRACE_SETREGS, tid_, 0, &regs) == -1) {
+			perror("PTRACE_SETREGS failed");
+		}
 	}
 }
 

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1342,7 +1342,7 @@ void Debugger::follow_register_in_dump(bool tabbed) {
 		if(!edb::v1::dump_data(*address, tabbed)) {
 			QMessageBox::critical(this,
 				tr("No Memory Found"),
-				tr("There appears to be no memory at that location (<strong>%1</strong>)").arg(edb::v1::format_pointer(address)));
+				tr("There appears to be no memory at that location (<strong>%1</strong>)").arg(edb::v1::format_pointer(address.value())));
 		}
 	}
 }

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -383,7 +383,6 @@ Debugger::Debugger(QWidget *parent) : QMainWindow(parent),
 	gotoRIPAction_               = createAction(tr("&Goto %1").arg("EIP"),                           QKeySequence(tr("*")),        SLOT(mnuCPUJumpToEIP()));
 #elif defined(EDB_ARM32) || defined(EDB_ARM64)
 	setRIPAction_                = createAction(tr("&Set %1 to this Instruction").arg("PC"),         QKeySequence(tr("Ctrl+*")),   SLOT(mnuCPUSetEIP()));
-    setRIPAction_->setDisabled(true); // FIXME(ARM): this just stubs it out since it likely won't really work
 	gotoRIPAction_               = createAction(tr("&Goto %1").arg("PC"),                           QKeySequence(tr("*")),        SLOT(mnuCPUJumpToEIP()));
 #else
 #error "This doesn't initialize actions and will lead to crash"

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -236,6 +236,18 @@ void DialogOptions::showEvent(QShowEvent *event) {
             item->setData(Qt::UserRole, it.key());
 		}	
 	}
+
+	if(const auto core = edb::v1::debugger_core) {
+		const auto& bps = core->supported_breakpoint_types();
+		const auto combo=ui->cmbDefaultBreakpointType;
+		combo->clear();
+		const auto chosen=config.default_breakpoint_type;
+		for(const auto& type : bps) {
+			combo->addItem(type.description, QVariant::fromValue(type.type));
+			if(type.type==chosen)
+				combo->setCurrentIndex(combo->count()-1);
+		}
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -275,6 +287,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	config.disableASLR			 = ui->chkDisableASLR->isChecked();
 	config.disableLazyBinding	 = ui->chkDisableLazyBinding->isChecked();
 	config.break_on_library_load = ui->chkBreakOnLibraryLoad->isChecked();
+	config.default_breakpoint_type = ui->cmbDefaultBreakpointType->itemData(ui->cmbDefaultBreakpointType->currentIndex()).value<IBreakpoint::TypeId>();
 
     config.function_offsets_in_hex = ui->chkHexOffsets->isChecked();
 

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -417,6 +417,36 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Default &amp;breakpoint type</string>
+           </property>
+           <property name="buddy">
+            <cstring>cmbDefaultBreakpointType</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cmbDefaultBreakpointType"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="label_5">

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -1050,6 +1050,8 @@ bool modifies_pc(const Instruction &insn) {
 		const auto& op=arm.operands[i];
 		if(op.access==CS_AC_WRITE && op.type==CS_OP_REG && op.reg==ARM_REG_PC)
 			return true;
+		if(op.type==ARM_OP_MEM && insn.native()->detail->arm.writeback && op.mem.base==ARM_REG_PC)
+			return true;
 	}
 	return false;
 #else

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1376,6 +1376,17 @@ std::shared_ptr<IBreakpoint> find_breakpoint(address_t address) {
 }
 
 //------------------------------------------------------------------------------
+// Name: find_triggered_breakpoint
+// Desc:
+//------------------------------------------------------------------------------
+std::shared_ptr<IBreakpoint> find_triggered_breakpoint(address_t address) {
+	if(debugger_core) {
+		return debugger_core->find_triggered_breakpoint(address);
+	}
+	return nullptr;
+}
+
+//------------------------------------------------------------------------------
 // Name: pointer_size
 // Desc:
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
* Now it's possible to choose from a bunch of breakpoint types for both x86 and ARM targets. This mostly works, but if the breakpoint used generates something other than `SIGTRAP`, EDB doesn't yet remove it, even if it's a single-shot breakpoint, and notifies of the signal, which it shouldn't.
* It's now possible to set registers, not only view them. Register editor on ARM still presents somewhat wrong edit dialogs, inherited from x86 version.
* `BX` and `BLX` instructions are now supported for single-stepping.