### PR TITLE
Fix calculation of scaled-register-offset memory operands

### DIFF
--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -196,7 +196,7 @@ Status PlatformThread::doStep(const edb::tid_t tid, const long status) {
 
 					const auto effAddr=effAddrR.value();
 					if(process_->read_bytes(effAddr, &addrAfterInsn, addrSize)!=addrSize)
-						return Status(QObject::tr("failed to read memory referred to by LDR operand"));
+						return Status(QObject::tr("failed to read memory referred to by LDR operand (address %1).").arg(effAddr.toPointerString()));
 
 					// FIXME: for ARMv5 or below (without "T" in the name) bits [1:0] are simply ignored, without any mode change
 					if(addrAfterInsn&1)

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -181,6 +181,15 @@ Instruction::Instruction(const void *first, const void *last, uint64_t rva) noex
 	cs_insn *insn = nullptr;
 	if (first < last && cs_disasm(csh, codeBegin, codeEnd - codeBegin, rva, 1, &insn)) {
 		insn_ = insn;
+#if defined EDB_ARM32
+		if(insn_->detail->arm.op_count>=2)
+		{
+			// XXX: this is a work around capstone bug #1013
+			auto& op=insn_->detail->arm.operands[1];
+			if(op.type==ARM_OP_MEM && op.subtracted && op.mem.scale==1)
+				op.mem.scale=-1;
+		}
+#endif
 	} else {
 		insn_ = nullptr;
 	}


### PR DESCRIPTION
The original code appears to have been wrong. Additionally, there's a bug in capstone, for which I added a work around.