### PR TITLE
EDB and DebuggerCore on Windows x86 with MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,18 @@
 version: "{build}"
 
-image: Visual Studio 2017
-
-platform: x64
-
 environment:
-  BOOST_INCLUDEDIR: C:\Libraries\boost_1_64_0
   CAPSTONE_SDK: C:\capstone\sdk
-  QT_BASEDIR: C:\Qt\5.9.1\msvc2017_64
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BOOST_INCLUDEDIR: C:\Libraries\boost_1_64_0
+      CAPSTONE_ARCHIVE: capstone-3.0.5-rc2-win64
+      CMAKE_GENERATOR: Visual Studio 15 2017 Win64
+      QT_BASEDIR: C:\Qt\5.9.1\msvc2017_64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      BOOST_INCLUDEDIR: C:\Libraries\boost_1_63_0
+      CAPSTONE_ARCHIVE: capstone-3.0.5-rc2-win32
+      CMAKE_GENERATOR: Visual Studio 14 2015
+      QT_BASEDIR: C:\Qt\5.9.1\msvc2015
 
 configuration:
   - Debug
@@ -18,17 +23,17 @@ install:
   - ps: new-item -itemtype directory -path C:\capstone\sdk\include\capstone
   - ps: new-item -itemtype directory -path C:\capstone\sdk\lib
   - ps: "[Environment]::CurrentDirectory = 'C:\\capstone'"
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/aquynh/capstone/releases/download/3.0.5-rc2/capstone-3.0.5-rc2-win64.zip', 'capstone.zip')
+  - ps: (new-object net.webclient).DownloadFile("https://github.com/aquynh/capstone/releases/download/3.0.5-rc2/${env:CAPSTONE_ARCHIVE}.zip", 'capstone.zip')
   - ps: expand-archive C:\capstone\capstone.zip -destinationpath C:\capstone
-  - ps: copy-item C:\capstone\capstone-3.0.5-rc2-win64\include\*.h C:\capstone\sdk\include\capstone
-  - ps: copy-item C:\capstone\capstone-3.0.5-rc2-win64\capstone.lib C:\capstone\sdk\lib\capstone_dll.lib
+  - ps: copy-item C:\capstone\${env:CAPSTONE_ARCHIVE}\include\*.h C:\capstone\sdk\include\capstone
+  - ps: copy-item C:\capstone\${env:CAPSTONE_ARCHIVE}\capstone.lib C:\capstone\sdk\lib\capstone_dll.lib
   
 before_build:
   - cmd: git submodule update --init
   - cmd: cd C:\projects
   - cmd: md build
   - cmd: cd build
-  - cmd: cmake -Wno-dev -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%configuration% -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DCAPSTONE_SDK="%CAPSTONE_SDK%" -DQt5Core_DIR="%QT_BASEDIR%\lib\cmake\Qt5Core" -DQt5_DIR="%QT_BASEDIR%\lib\cmake\Qt5" ..\edb-debugger
+  - cmd: cmake -Wno-dev -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DCAPSTONE_SDK="%CAPSTONE_SDK%" -DQt5Core_DIR="%QT_BASEDIR%\lib\cmake\Qt5Core" -DQt5_DIR="%QT_BASEDIR%\lib\cmake\Qt5" ..\edb-debugger
 
 build_script:
   - cmd: msbuild C:\projects\build\edb.sln /t:edb /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,9 @@ configuration:
   - Release
 
 install:
-  - ps: new-item -itemtype directory -path C:\capstone\sdk
-  - ps: new-item -itemtype directory -path C:\capstone\sdk\include\capstone
-  - ps: new-item -itemtype directory -path C:\capstone\sdk\lib
+  - ps: new-item -itemtype directory -path C:\capstone\sdk | out-null
+  - ps: new-item -itemtype directory -path C:\capstone\sdk\include\capstone | out-null
+  - ps: new-item -itemtype directory -path C:\capstone\sdk\lib | out-null
   - ps: "[Environment]::CurrentDirectory = 'C:\\capstone'"
   - ps: (new-object net.webclient).DownloadFile("https://github.com/aquynh/capstone/releases/download/3.0.5-rc2/${env:CAPSTONE_ARCHIVE}.zip", 'capstone.zip')
   - ps: expand-archive C:\capstone\capstone.zip -destinationpath C:\capstone

--- a/plugins/DebuggerCore/win32/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/win32/DebuggerCore.cpp
@@ -267,8 +267,8 @@ std::shared_ptr<IDebugEvent> DebuggerCore::wait_debug_event(int msecs) {
 				break;
 			case CREATE_PROCESS_DEBUG_EVENT:
 				CloseHandle(de.u.CreateProcessInfo.hFile);
-				start_address = edb::address_t(de.u.CreateProcessInfo.lpStartAddress);
-				image_base    = edb::address_t(de.u.CreateProcessInfo.lpBaseOfImage);
+				start_address = edb::address_t::fromZeroExtended(de.u.CreateProcessInfo.lpStartAddress);
+				image_base    = edb::address_t::fromZeroExtended(de.u.CreateProcessInfo.lpBaseOfImage);
 				break;
 			case LOAD_DLL_DEBUG_EVENT:
 				CloseHandle(de.u.LoadDll.hFile);
@@ -775,9 +775,9 @@ QList<std::shared_ptr<IRegion>> DebuggerCore::memory_regions() const {
 
 				if(info.State == MEM_COMMIT) {
 
-					const auto start   = edb::address_t(info.BaseAddress);
-					const auto end     = edb::address_t(info.BaseAddress) + info.RegionSize;
-					const auto base    = edb::address_t(info.AllocationBase);
+					const auto start   = edb::address_t::fromZeroExtended(info.BaseAddress);
+					const auto end     = edb::address_t::fromZeroExtended(info.BaseAddress) + info.RegionSize;
+					const auto base    = edb::address_t::fromZeroExtended(info.AllocationBase);
 					const QString name = QString();
 					const IRegion::permissions_t permissions = info.Protect; // let std::shared_ptr<IRegion> handle permissions and modifiers
 
@@ -876,7 +876,7 @@ QList<Module> DebuggerCore::loaded_modules() const {
         if(Module32First(hModuleSnap, &me32)) {
 			do {
 				Module module;
-				module.base_address = edb::address_t(me32.modBaseAddr);
+				module.base_address = edb::address_t::fromZeroExtended(me32.modBaseAddr);
 				module.name         = QString::fromWCharArray(me32.szModule);
 				ret.push_back(module);
 			} while(Module32Next(hModuleSnap, &me32));


### PR DESCRIPTION
This enables building an x86 version of EDB and the DebuggerCore plugin on Windows with CMake and Visual Studio 2017 (AppVeyor uses Visual Studio 2015 since Qt 5.9.1 x86 is not available in the Visual Studio 2017 image).

Note: The functionality of the plugin is far from complete, but the existing code compiles again.