### PR TITLE
Fix default plugin path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
 	set(GIT_BRANCH "Unknown")
 endif()
 add_definitions(-DGIT_BRANCH=${GIT_BRANCH})
-add_definitions(-DDEFAULT_PLUGIN_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb)
+add_definitions(-DDEFAULT_PLUGIN_PATH=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb\")
 
 include_directories(
 	"capstone-edb"

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -84,7 +84,7 @@ void Configuration::readSettings() {
 
 
 #ifdef DEFAULT_PLUGIN_PATH
-	const QString default_plugin_path = TOSTRING(DEFAULT_PLUGIN_PATH);
+	const QString default_plugin_path = DEFAULT_PLUGIN_PATH;
 #else
 	const QString edb_lib_dir=QCoreApplication::applicationDirPath()+(EDB_IS_64_BIT ? "/../lib64/edb" : "/../lib/edb");
 	const QString edb_binary_dir=QCoreApplication::applicationDirPath();


### PR DESCRIPTION
The default plugin path is invalid when it embeds other macros like i386.
This was already reported in #134.

To avoid this problem, we define the DEFAULT_PLUGIN_PATH macro as a quoted string ready to be used in the code (the STRINGIFY trick is thus no-longer needed).

Kali bug: https://bugs.kali.org/view.php?id=4265