### PR TITLE
Mem Regions window: dblclick shows in CPU if --x

### DIFF
--- a/src/DialogMemoryRegions.cpp
+++ b/src/DialogMemoryRegions.cpp
@@ -220,7 +220,11 @@ void DialogMemoryRegions::view_in_dump() {
 void DialogMemoryRegions::on_regions_table_doubleClicked(const QModelIndex &index) {
 	Q_UNUSED(index);
 	if(std::shared_ptr<IRegion> region = selected_region()) {
-		edb::v1::dump_data(region->start(), true);
+		if (region->executable()) {
+			edb::v1::jump_to_address(region->start());
+		} else {
+			edb::v1::dump_data(region->start(), true);
+		}
 	}
 }
 


### PR DESCRIPTION
If a region appears to be a code region, show it in the CPU view when double-clicked instead of the data-dump view.