### PR TITLE
Deal with long double in MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_build:
   - cmd: cd C:\projects
   - cmd: md build
   - cmd: cd build
-  - cmd: cmake -Wno-dev -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DCAPSTONE_SDK="%CAPSTONE_SDK%" -DQt5Core_DIR="%QT_BASEDIR%\lib\cmake\Qt5Core" -DQt5_DIR="%QT_BASEDIR%\lib\cmake\Qt5" ..\edb-debugger
+  - cmd: cmake -Wno-dev -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=C:\projects\install -DBOOST_INCLUDEDIR="%BOOST_INCLUDEDIR%" -DCAPSTONE_SDK="%CAPSTONE_SDK%" -DQt5Core_DIR="%QT_BASEDIR%\lib\cmake\Qt5Core" -DQt5_DIR="%QT_BASEDIR%\lib\cmake\Qt5" ..\edb-debugger
 
 build_script:
   - cmd: msbuild C:\projects\build\edb.sln /t:edb /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/include/Types.h
+++ b/include/Types.h
@@ -34,6 +34,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class Register;
 
+#ifdef _MSC_VER
+extern "C" void __fastcall long_double_to_double(const void* src, double* dest);
+#endif
+
 namespace edb {
 
 enum EVENT_STATUS {
@@ -255,9 +259,15 @@ struct Value80 : public ValueBase<16,5> {
 	}
 
 	long double toFloatValue() const {
+#ifdef _MSC_VER
+		double d;
+		long_double_to_double(&value_, &d);
+		return d;
+#else
 		long double float80val;
 		std::memcpy(&float80val, &value_, sizeof(value_));
 		return float80val;
+#endif
 	}
 
 	QString toString() const {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,19 @@ if((${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv[0-9]+"))
         )
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+
+  enable_language(ASM_MASM)
+  
+  set(CMAKE_ASM_MASM_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /safeseh")
+  
+  set(edb_SRCS
+    ${edb_SRCS}
+    LongDoubleX86.asm
+  )
+  
+endif()
+
 if(${GRAPHVIZ_FOUND})
 	set(edb_INCLUDES
 		${edb_INCLUDES}

--- a/src/FloatX.cpp
+++ b/src/FloatX.cpp
@@ -278,9 +278,7 @@ double toFloatValue(edb::value64 value)
 
 long double toFloatValue(edb::value80 value)
 {
-	long double result;
-	std::memcpy(&result,&value,sizeof result);
-	return result;
+	return value.toFloatValue();
 }
 
 template<typename Float>

--- a/src/LongDoubleX86.asm
+++ b/src/LongDoubleX86.asm
@@ -1,0 +1,29 @@
+PUBLIC long_double_to_double
+
+ALIAS <@long_double_to_double@8> = <long_double_to_double>
+
+IFDEF EDB_X86
+
+.386
+
+_TEXT SEGMENT
+long_double_to_double PROC NEAR; FASTCALL
+fld TBYTE PTR [ecx]
+fstp QWORD PTR [edx]
+ret
+long_double_to_double ENDP
+_TEXT ENDS
+
+ELSE
+
+_TEXT SEGMENT
+long_double_to_double PROC
+fld TBYTE PTR [rcx]
+fstp QWORD PTR [rdx]
+ret
+long_double_to_double ENDP
+_TEXT ENDS
+
+ENDIF
+
+END


### PR DESCRIPTION
Windows does not support 80bit long doubles natively. Instead a long double is equivalent to the 64bit double. Therefore, the conversion from edb::value80 to a long double in MSVC is not a trivial memcopy. Instead we leverage the FPU directly to load the 80 bits from edb::value80 and store them again in a double, doing the conversion for us.

Note that of course this reduces the precision and for values that can not be represented by a 64bit double it does not work (i.e. exponent too large -> inf, exponent too small -> 0). In order to fully support 80bit doubles, we would need to port a version of sprintf that can deal with these long doubles.