### PR TITLE
Add FPSCR to Register View

### DIFF
--- a/plugins/DebuggerCore/unix/linux/PlatformThread.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.h
@@ -74,6 +74,9 @@ private:
 	void fillSegmentBases(PlatformState* state);
 	bool fillStateFromPrStatus(PlatformState* state);
 	bool fillStateFromSimpleRegs(PlatformState* state);
+#ifdef EDB_ARM32
+	bool fillStateFromVFPRegs(PlatformState* state);
+#endif
 
 private:
 	unsigned long get_debug_register(std::size_t n);

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -77,6 +77,8 @@ Register PlatformState::value(const QString &reg) const
 	const auto name=reg.toLower();
 	if(name=="cpsr")
 		return flags_register();
+	if(vfp.filled && name=="fpscr")
+		return make_Register<32>("fpscr", vfp.fpscr, Register::TYPE_FPU);
 	const auto gprFoundIt=findGPR(name);
 	if(gprFoundIt!=GPR::GPRegNames.end())
 		return gp_register(gprFoundIt-GPR::GPRegNames.begin());

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -196,6 +196,14 @@ void PlatformState::fillFrom(user_regs const& regs)
 	gpr.filled=true;
 }
 
+void PlatformState::fillFrom(user_vfp const& regs)
+{
+	for(unsigned i=0;i<vfp.d.size();++i)
+		vfp.d[i]=regs.fpregs[i];
+	vfp.fpscr=regs.fpscr;
+	vfp.filled=true;
+}
+
 void PlatformState::fillStruct(user_regs& regs) const
 {
 	util::markMemory(&regs, sizeof(regs));

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -163,6 +163,11 @@ void PlatformState::set_register(const Register &reg)
 		set_flags(reg.value<edb::reg_t>());
 		return;
 	}
+	if(name=="fpscr")
+	{
+		vfp.fpscr=reg.value<decltype(vfp.fpscr)>();
+		return;
+	}
 	const auto gprFoundIt=findGPR(name);
 	if(gprFoundIt!=GPR::GPRegNames.end())
 	{
@@ -215,6 +220,17 @@ void PlatformState::fillStruct(user_regs& regs) const
 			regs.uregs[i]=gpr.GPRegs[i];
 		regs.uregs[16]=gpr.cpsr;
 		// FIXME: uregs[17] is not filled
+	}
+}
+
+void PlatformState::fillStruct(user_vfp& regs) const
+{
+	util::markMemory(&regs, sizeof(regs));
+	if(vfp.filled)
+	{
+		for(unsigned i=0;i<vfp.d.size();++i)
+			regs.fpregs[i]=vfp.d[i];
+		regs.fpscr=vfp.fpscr;
 	}
 }
 

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
@@ -72,6 +72,7 @@ public:
 	void fillFrom(user_regs const& regs);
 	void fillFrom(user_vfp const& regs);
 	void fillStruct(user_regs& regs) const;
+	void fillStruct(user_vfp& regs) const;
 private:
 	struct GPR {
 		enum NamedGPRIndex : size_t {

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.h
@@ -31,6 +31,13 @@ namespace DebuggerCorePlugin {
 
 using std::size_t;
 static constexpr size_t GPR_COUNT=16;
+static constexpr size_t VFPR_COUNT=32;
+
+struct user_vfp
+{
+	unsigned long long fpregs[32];
+	unsigned long fpscr;
+};
 
 class PlatformState : public IState {
 	friend class DebuggerCore;
@@ -63,6 +70,7 @@ public:
 	Register gp_register(size_t n) const override;
 
 	void fillFrom(user_regs const& regs);
+	void fillFrom(user_vfp const& regs);
 	void fillStruct(user_regs& regs) const;
 private:
 	struct GPR {
@@ -85,6 +93,11 @@ private:
 		void clear();
 		bool empty() const;
 	} gpr;
+	struct VFP {
+		std::array<edb::value64, VFPR_COUNT> d;
+		edb::value32 fpscr;
+		bool filled=false;
+	} vfp;
 private:
 	auto findGPR(QString const& name) const -> decltype(gpr.GPRegNames.begin());
 };

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -56,6 +56,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PTRACE_SETREGSET static_cast<__ptrace_request>(0x4205)
 #endif
 
+#ifndef PTRACE_GETWMMXREGS
+#define PTRACE_GETWMMXREGS static_cast<__ptrace_request>(18)
+#define PTRACE_SETWMMXREGS static_cast<__ptrace_request>(19)
+#endif
+
+#ifndef PTRACE_GETVFPREGS
+#define PTRACE_GETVFPREGS static_cast<__ptrace_request>(27)
+#define PTRACE_SETVFPREGS static_cast<__ptrace_request>(28)
+#endif
+
+#ifndef PTRACE_GETHBPREGS
+#define PTRACE_GETHBPREGS static_cast<__ptrace_request>(29)
+#define PTRACE_SETHBPREGS static_cast<__ptrace_request>(30)
+#endif
+
 namespace DebuggerCorePlugin {
 
 //------------------------------------------------------------------------------
@@ -86,6 +101,25 @@ bool PlatformThread::fillStateFromSimpleRegs(PlatformState* state) {
 }
 
 //------------------------------------------------------------------------------
+// Name: fillStateFromVFPRegs
+// Desc:
+//------------------------------------------------------------------------------
+bool PlatformThread::fillStateFromVFPRegs(PlatformState* state) {
+
+	user_vfp fpr;
+	if(ptrace(PTRACE_GETVFPREGS, tid_, 0, &fpr) != -1) {
+		for(unsigned i=0;i<sizeof fpr.fpregs/sizeof*fpr.fpregs;++i)
+			state->fillFrom(fpr);
+		return true;
+	}
+	else {
+		perror("PTRACE_GETVFPREGS failed");
+		return false;
+	}
+
+}
+
+//------------------------------------------------------------------------------
 // Name: get_state
 // Desc:
 //------------------------------------------------------------------------------
@@ -97,6 +131,7 @@ void PlatformThread::get_state(State *state) {
 	if(auto state_impl = static_cast<PlatformState *>(state->impl_)) {
 
 		fillStateFromSimpleRegs(state_impl);
+		fillStateFromVFPRegs(state_impl);
 	}
 }
 

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -150,6 +150,12 @@ void PlatformThread::set_state(const State &state) {
 		if(ptrace(PTRACE_SETREGS, tid_, 0, &regs) == -1) {
 			perror("PTRACE_SETREGS failed");
 		}
+
+		user_vfp fpr;
+		state_impl->fillStruct(fpr);
+		if(ptrace(PTRACE_SETVFPREGS, tid_, 0, &fpr) == -1) {
+			perror("PTRACE_SETVFPREGS failed");
+		}
 	}
 }
 

--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformThread.cpp
@@ -41,11 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // doesn't always seem to be defined in the headers
 #ifndef PTRACE_GET_THREAD_AREA
-#define PTRACE_GET_THREAD_AREA static_cast<__ptrace_request>(25)
-#endif
-
-#ifndef PTRACE_SET_THREAD_AREA
-#define PTRACE_SET_THREAD_AREA static_cast<__ptrace_request>(26)
+#define PTRACE_GET_THREAD_AREA static_cast<__ptrace_request>(22)
 #endif
 
 #ifndef PTRACE_GETSIGINFO

--- a/plugins/ODbgRegisterView/RegisterView.cpp
+++ b/plugins/ODbgRegisterView/RegisterView.cpp
@@ -72,7 +72,8 @@ constexpr auto registerGroupTypeNames = util::make_array<const char *>(
 #elif defined EDB_ARM32
 		"GPR",
 		"CPSR",
-		"ExpandedCPSR"
+		"ExpandedCPSR",
+		"FPSCR"
 #else
 #	error "Not implemented"
 #endif
@@ -488,6 +489,7 @@ ODBRegView::ODBRegView(QString const &settingsGroup, QWidget *parent)
 			RegisterGroupType::GPR,
 			RegisterGroupType::CPSR,
 			RegisterGroupType::ExpandedCPSR,
+			RegisterGroupType::FPSCR,
 #else
 #	error "Not implemented"
 #endif
@@ -679,6 +681,8 @@ RegisterGroup *ODBRegView::makeGroup(RegisterGroupType type) {
 		return createCPSR(model_, widget());
 	case RegisterGroupType::ExpandedCPSR:
 		return createExpandedCPSR(model_, widget());
+	case RegisterGroupType::FPSCR:
+		return createFPSCR(model_, widget());
 #endif
 	default:
 		qWarning() << "Warning: unexpected register group type requested in" << Q_FUNC_INFO;

--- a/plugins/ODbgRegisterView/RegisterView.h
+++ b/plugins/ODbgRegisterView/RegisterView.h
@@ -57,6 +57,7 @@ public:
 			GPR,
 			CPSR,
 			ExpandedCPSR,
+			FPSCR,
 #else
 #	error "Not implemented"
 #endif

--- a/plugins/ODbgRegisterView/armGroups.h
+++ b/plugins/ODbgRegisterView/armGroups.h
@@ -24,6 +24,7 @@ namespace ODbgRegisterView {
 
 RegisterGroup *createCPSR(RegisterViewModelBase::Model *model, QWidget *parent);
 RegisterGroup *createExpandedCPSR(RegisterViewModelBase::Model *model, QWidget *parent);
+RegisterGroup *createFPSCR(RegisterViewModelBase::Model *model, QWidget *parent);
 
 }
 

--- a/src/arch/arm-generic/ArchProcessor.cpp
+++ b/src/arch/arm-generic/ArchProcessor.cpp
@@ -338,6 +338,26 @@ void updateCPSR(RegisterViewModel& model, State const& state) {
 	model.updateCPSR(flags.value<edb::value32>(),comment);
 }
 
+QString fpscrComment(edb::reg_t fpscr) {
+	const auto nzcv=fpscr>>28;
+	switch(nzcv)
+	{
+	case 2: return "(GT)";
+	case 3: return "(Unordered)";
+	case 6: return "(EQ)";
+	case 8: return "(LT)";
+	default: return "";
+	}
+}
+
+void updateVFP(RegisterViewModel& model, State const& state) {
+	const auto fpscr=state["fpscr"];
+	if(fpscr) {
+		const auto comment=fpscrComment(fpscr.valueAsInteger());
+		model.updateFPSCR(fpscr.value<edb::value32>(),comment);
+	}
+}
+
 void ArchProcessor::update_register_view(const QString &default_region_name, const State &state) {
 
 	auto& model = getModel();
@@ -350,6 +370,7 @@ void ArchProcessor::update_register_view(const QString &default_region_name, con
 
 	updateGPRs(model,state,default_region_name);
 	updateCPSR(model,state);
+	updateVFP(model,state);
 
 	if(just_attached_) {
 		model.saveValues();

--- a/src/arch/arm-generic/RegisterViewModel.cpp
+++ b/src/arch/arm-generic/RegisterViewModel.cpp
@@ -83,6 +83,7 @@ std::vector<RegisterViewModelBase::BitFieldDescription> fpscrDescription = {
 enum
 {
 	CPSR_ROW,
+	FPSCR_ROW=0,
 };
 
 QVariant RegisterViewModel::data(QModelIndex const& index, int role) const {
@@ -178,6 +179,11 @@ void RegisterViewModel::updateGPR(std::size_t i, edb::value32 val, QString const
 void RegisterViewModel::updateCPSR(edb::value32 val, QString const& comment)
 {
 	updateRegister<CPSR>(genStatusRegs,CPSR_ROW,val,comment);
+}
+
+void RegisterViewModel::updateFPSCR(edb::value32 val, QString const& comment)
+{
+	updateRegister<FPSCR>(vfpRegs,FPSCR_ROW,val,comment);
 }
 
 void RegisterViewModel::showAll()

--- a/src/arch/arm-generic/RegisterViewModel.cpp
+++ b/src/arch/arm-generic/RegisterViewModel.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using util::make_unique;
 using GPR=RegisterViewModelBase::SimpleRegister<edb::value32>;
 using CPSR=RegisterViewModelBase::FlagsRegister<edb::value32>;
+using FPSCR=RegisterViewModelBase::FlagsRegister<edb::value32>;
 
 std::vector<RegisterViewModelBase::BitFieldDescription> cpsrDescription = {
 	{QLatin1String( "M" ),  0, 5},
@@ -44,6 +45,35 @@ std::vector<RegisterViewModelBase::BitFieldDescription> cpsrDescription = {
 	{QLatin1String("IT0"), 25, 1},
 	{QLatin1String("IT1"), 26, 1},
 	{QLatin1String( "Q" ), 27, 1},
+	{QLatin1String( "V" ), 28, 1},
+	{QLatin1String( "C" ), 29, 1},
+	{QLatin1String( "Z" ), 30, 1},
+	{QLatin1String( "N" ), 31, 1},
+};
+
+static const std::vector<QString> roundingStrings{QObject::tr("Rounding to nearest"),
+												  QObject::tr("Rounding to Plus infinity"),
+												  QObject::tr("Rounding to Minus infinity"),
+												  QObject::tr("Rounding toward zero")};
+
+std::vector<RegisterViewModelBase::BitFieldDescription> fpscrDescription = {
+	{QLatin1String("IOC"), 0,  1},
+	{QLatin1String("DZC"), 1,  1},
+	{QLatin1String("OFC"), 2,  1},
+	{QLatin1String("UFC"), 3,  1},
+	{QLatin1String("IXC"), 4,  1},
+	{QLatin1String("IDC"), 7,  1},
+	{QLatin1String("IOE"), 8,  1},
+	{QLatin1String("DZE"), 9,  1},
+	{QLatin1String("OFE"), 10, 1},
+	{QLatin1String("UFE"), 11, 1},
+	{QLatin1String("IXE"), 12, 1},
+	{QLatin1String("IDE"), 15, 1},
+	{QLatin1String("LEN-1"), 16, 3},
+	{QLatin1String("STR"), 20, 2},
+	{QLatin1String( "RC"), 22, 2, roundingStrings},
+	{QLatin1String( "FZ"), 24, 1},
+	{QLatin1String( "DN"), 25, 1},
 	{QLatin1String( "V" ), 28, 1},
 	{QLatin1String( "C" ), 29, 1},
 	{QLatin1String( "Z" ), 30, 1},
@@ -97,13 +127,21 @@ void addGenStatusRegs(RegisterViewModelBase::Category* cat)
 	cat->addRegister(make_unique<CPSR>("CPSR",cpsrDescription));
 }
 
+void addVFPRegs(RegisterViewModelBase::Category* cat)
+{
+	cat->addRegister(make_unique<FPSCR>("FPSCR",fpscrDescription));
+	// TODO: add data registers: Sn, Dn, Qn...
+}
+
 RegisterViewModel::RegisterViewModel(int cpuSuppFlags, QObject* parent)
 	: RegisterViewModelBase::Model(parent),
 	  gprs(addCategory(tr("General Purpose"))),
-	  genStatusRegs(addCategory(tr("General Status")))
+	  genStatusRegs(addCategory(tr("General Status"))),
+	  vfpRegs(addFPUCategory(tr("VFP")))
 {
 	addGPRs(gprs);
 	addGenStatusRegs(genStatusRegs);
+	addVFPRegs(vfpRegs);
 
 	setCPUMode(CPUMode::UNKNOWN);
 }
@@ -146,6 +184,7 @@ void RegisterViewModel::showAll()
 {
 	gprs->show();
 	genStatusRegs->show();
+	vfpRegs->show();
 }
 
 void RegisterViewModel::setCPUMode(CPUMode newMode)

--- a/src/arch/arm-generic/RegisterViewModel.h
+++ b/src/arch/arm-generic/RegisterViewModel.h
@@ -31,6 +31,7 @@ class RegisterViewModel : public RegisterViewModelBase::Model
 private:
 	RegisterViewModelBase::Category* gprs;
 	RegisterViewModelBase::Category* genStatusRegs;
+	RegisterViewModelBase::Category* vfpRegs;
 public:
 	enum class CPUMode
 	{

--- a/src/arch/arm-generic/RegisterViewModel.h
+++ b/src/arch/arm-generic/RegisterViewModel.h
@@ -46,6 +46,7 @@ public:
 	// Use dataUpdateFinished() to have dataChanged emitted.
 	void updateGPR(std::size_t i, edb::value32 val, QString const& comment=QString());
 	void updateCPSR(edb::value32 val, QString const& comment=QString());
+	void updateFPSCR(edb::value32 val, QString const& comment=QString());
 private:
 	void showAll();
 	CPUMode mode=static_cast<CPUMode>(-1);


### PR DESCRIPTION
VFPvN data registers are still not supported in the Register View. For them there'll need to be some additional work to
1. Check CPU support for formats (`Sn`, `Dn`, `Qn`)
2. Design the layout for this large register file (it doesn't seem a good idea to e.g. show 64 `Sn` registers available on VFPv3 as 64 rows, and even the 32 `Dn` registers as 32 rows).
So this PR only implements display of FPSCR.