### PR TITLE
Fix: Appveyor should use most recent micro version of Qt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ environment:
       BOOST_INCLUDEDIR: C:\Libraries\boost_1_64_0
       CAPSTONE_ARCHIVE: capstone-3.0.5-rc2-win64
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
-      QT_BASEDIR: C:\Qt\5.9.1\msvc2017_64
+      QT_BASEDIR: C:\Qt\5.9\msvc2017_64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       BOOST_INCLUDEDIR: C:\Libraries\boost_1_63_0
       CAPSTONE_ARCHIVE: capstone-3.0.5-rc2-win32
       CMAKE_GENERATOR: Visual Studio 14 2015
-      QT_BASEDIR: C:\Qt\5.9.1\msvc2015
+      QT_BASEDIR: C:\Qt\5.9\msvc2015
 
 configuration:
   - Debug


### PR DESCRIPTION
The AppVeyor infrastructure only keeps the most recent micro version of a specific Qt minor version. Thus, hardcoding a specific micro version will eventually fail on AppVeyor. Therefore, we should only use a specific minor version, which will be kept for a long time on the AppVeyor infrastructure.