### PR TITLE
linuxdeployqt seems to be available only from "continuous" channel now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ after_success:
     - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - unset LD_LIBRARY_PATH
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
-    - pwd
     - find . -name "*.AppImage*"
     - mv $(ls edb*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     - curl --upload-file $(ls ./build/edb*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
     - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage  # Needs Travis token of @eteran!
-    
+    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage.zsync
+
 branches:
     only:
         - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,14 @@ after_success:
     - cp ./edb.desktop ./build
     - find .
     - rm -rf build/src
-    - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage"
+    - #wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage" # Moved
+    - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
     - chmod a+x linuxdeployqt-1-x86_64.AppImage
     - unset LD_LIBRARY_PATH
-    - ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2
+    - # ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2 # Moved
+    - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
+    - bash upload.sh edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ after_success:
     - find . -name "*.AppImage*"
     - mv $(ls edb*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     - curl --upload-file $(ls ./build/edb*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
+    - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
     - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage  # Needs Travis token of @eteran!
     - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage.zsync
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y; fi
     - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y; fi
     - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
-    - sudo add-apt-repository ppa:ximion/packagekit
+    - sudo add-apt-repository ppa:ximion/packagekit -y
     - sudo apt-get update -qq
     - ./travis_install_capstone.sh
 
@@ -41,7 +41,7 @@ install:
     - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54xmlpatterns qt54svg; source /opt/qt54/bin/qt54-env.sh; fi
     - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55xmlpatterns qt55svg; source /opt/qt55/bin/qt55-env.sh; fi
     - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq qt56base qt56xmlpatterns qt56svg; source /opt/qt56/bin/qt56-env.sh; fi
-    - sudo apt-get install appstream
+    - sudo apt-get -y install appstream
 
 before_script:
     - if [ "$QT_BASE" == "48" ]; then mkdir build && cd build && CXX=g++-5 CC=gcc-5 cmake -DQT_VERSION=Qt4 ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,16 @@ script:
 
 after_success:
     - cd ..
+    - find . -type d
+    - find . -name edb.desktop
+    - find . -name edb.appstream.xml
+    - ls -l ./src/images/edb.png ./edb.desktop
+    - cat ./edb/.desktop
     - cp ./src/images/edb.png ./build
     - cp ./edb.desktop ./build
-    - find .
+    - find . -name edb
     - rm -rf build/src
+    - rm -rf build/CMakeFiles
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
     - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - unset LD_LIBRARY_PATH
@@ -65,8 +71,8 @@ after_success:
     - mv $(ls edb*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     - curl --upload-file $(ls ./build/edb*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
     - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage  # Needs Travis token of @eteran!
-    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage.zsync
+    - #bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage  # Needs Travis token of @eteran!
+    - #bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage.zsync
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ after_success:
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
     - pwd
     - find . -name "*.AppImage*"
-    - #mv $(ls ./build/*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
-    - #curl --upload-file $(ls ./build/*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
-    - #bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - mv $(ls edb*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - curl --upload-file $(ls ./build/edb*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
+    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage  # Needs Travis token of @eteran!
     
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
     - if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y; fi
     - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y; fi
     - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
+    - sudo add-apt-repository ppa:ximion/packagekit
     - sudo apt-get update -qq
     - ./travis_install_capstone.sh
 
@@ -40,6 +41,7 @@ install:
     - if [ "$QT_BASE" = "54" ]; then sudo apt-get install -qq qt54base qt54xmlpatterns qt54svg; source /opt/qt54/bin/qt54-env.sh; fi
     - if [ "$QT_BASE" = "55" ]; then sudo apt-get install -qq qt55base qt55xmlpatterns qt55svg; source /opt/qt55/bin/qt55-env.sh; fi
     - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq qt56base qt56xmlpatterns qt56svg; source /opt/qt56/bin/qt56-env.sh; fi
+    - sudo apt-get install appstream
 
 before_script:
     - if [ "$QT_BASE" == "48" ]; then mkdir build && cd build && CXX=g++-5 CC=gcc-5 cmake -DQT_VERSION=Qt4 ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ after_success:
     - rm -rf build/src
     - #wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage" # Moved
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-    - chmod a+x linuxdeployqt-1-x86_64.AppImage
+    - #chmod a+x linuxdeployqt-1-x86_64.AppImage # Moved
+    - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - unset LD_LIBRARY_PATH
-    - # ./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2 # Moved
+    - #./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2 # Moved
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
     - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
     - bash upload.sh edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ after_success:
     - unset LD_LIBRARY_PATH
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
     - find . -name "*.AppImage*"
+    - ls edb*.AppImage*
     - mv $(ls edb*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     - curl --upload-file $(ls ./build/edb*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
     - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,15 +54,13 @@ after_success:
     - cp ./edb.desktop ./build
     - find .
     - rm -rf build/src
-    - #wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage" # Moved
     - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-    - #chmod a+x linuxdeployqt-1-x86_64.AppImage # Moved
     - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - unset LD_LIBRARY_PATH
-    - #./linuxdeployqt-1-x86_64.AppImage ./build/edb -appimage -verbose=2 # Moved
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
-    - curl --upload-file $(ls build*.AppImage) https://transfer.sh/edb-qt$QT_BASE.git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
-    - bash upload.sh edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - mv $(ls ./build/*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - curl --upload-file $(ls ./build/*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
+    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,15 @@ after_success:
     - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
     - unset LD_LIBRARY_PATH
     - ./linuxdeployqt-continuous-x86_64.AppImage ./build/edb -appimage -verbose=2
-    - mv $(ls ./build/*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
-    - curl --upload-file $(ls ./build/*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
-    - bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - pwd
+    - find . -name "*.AppImage*"
+    - #mv $(ls ./build/*.AppImage) ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+    - #curl --upload-file $(ls ./build/*.AppImage) https://transfer.sh/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage # Replace with your deployment mechanism
+    - #bash upload.sh ./build/edb-qt$QT_BASE-continuous-git.$(git rev-parse --short HEAD)-x86_64.AppImage
     
 branches:
     only:
-        - master
+        - #master
         - patch-1
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ after_success:
     
 branches:
     only:
-        - #master
+        - master
         - patch-1
 
 os:


### PR DESCRIPTION
When searching for an AppImage of edb-debugger, I noticed the repo already has a .travis.yml file with the goal to build one. But since a few builds back, the linuxdeployqt download didn't work any more, because the URL has gone away, and only the "continuous" version is available.