### PR TITLE
Fix+improvements in formatting SIMD values in Analysis

### DIFF
--- a/src/arch/x86-generic/ArchProcessor.cpp
+++ b/src/arch/x86-generic/ArchProcessor.cpp
@@ -792,7 +792,7 @@ void analyze_operands(const State &state, const edb::Instruction &inst, QStringL
 						{
 							const edb::value64 value(target);
 							QString valueStr;
-							if(is_fpu_taking_float(inst) || is_SIMD_SS(operand))
+							if(is_fpu_taking_float(inst) || is_SIMD_SD(operand))
 								valueStr=formatFloat(value);
 							else if(is_fpu_taking_integer(inst))
 							{

--- a/src/capstone-edb/Instruction.cpp
+++ b/src/capstone-edb/Instruction.cpp
@@ -83,9 +83,10 @@ bool KxRegisterPresent(const Instruction &insn) {
 	return false;
 }
 
-std::size_t simdOperandNormalizedNumberInInstruction(const Instruction &insn, const Operand &operand) {
+std::size_t simdOperandNormalizedNumberInInstruction(const Instruction &insn, const Operand &operand, bool canBeNonSIMD=false) {
 
-	assert(!apriori_not_simd(insn, operand));
+	if(!canBeNonSIMD)
+		assert(!apriori_not_simd(insn, operand));
 
 	std::size_t number       = operand.index();
 	const auto  operandCount = insn.operand_count();
@@ -1025,6 +1026,41 @@ bool is_SIMD_SD(const Operand &operand) {
 		return number == 1;
 	default:
 		return false;
+	}
+}
+
+bool is_SIMD_SI(const Operand &operand) {
+
+	const Instruction &insn = *operand.owner();
+	const auto number = simdOperandNormalizedNumberInInstruction(insn, operand, true);
+
+	switch (insn->id) {
+	case X86_INS_VCVTSI2SS:
+	case X86_INS_VCVTSI2SD:
+		return number==2;
+	case X86_INS_CVTSI2SS:
+	case X86_INS_CVTSI2SD:
+		return number==1;
+	case X86_INS_CVTSS2SI:
+	case X86_INS_VCVTSS2SI:
+	case X86_INS_CVTSD2SI:
+	case X86_INS_VCVTSD2SI:
+		return number==0;
+	}
+}
+
+bool is_SIMD_USI(const Operand &operand) {
+
+	const Instruction &insn = *operand.owner();
+	const auto number = simdOperandNormalizedNumberInInstruction(insn, operand, true);
+
+	switch (insn->id) {
+	case X86_INS_VCVTUSI2SS:
+	case X86_INS_VCVTUSI2SD:
+		return number==2;
+	case X86_INS_VCVTSS2USI:
+	case X86_INS_VCVTSD2USI:
+		return number==0;
 	}
 }
 

--- a/src/capstone-edb/include/Inspection.h
+++ b/src/capstone-edb/include/Inspection.h
@@ -71,6 +71,8 @@ bool is_SIMD_PD(const Operand &operand);
 bool is_SIMD_PS(const Operand &operand);
 bool is_SIMD_SD(const Operand &operand);
 bool is_SIMD_SS(const Operand &operand);
+bool is_SIMD_SI(const Operand &operand);
+bool is_SIMD_USI(const Operand &operand);
 
 }
 


### PR DESCRIPTION
One bug is fixed, and additionally, SIMD scalar integer operands are now formatted according to their signedness as decimal numbers.