### PR TITLE
Add support for entering floating-point numbers in hexfloat format in register edit dialogs

### DIFF
--- a/include/Util.h
+++ b/include/Util.h
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <memory>
 #include <sstream>
 #include <type_traits>
+#include <boost/optional.hpp>
 
 enum class NumberDisplayMode {
 	Hex,
@@ -176,6 +177,29 @@ typename std::enable_if<std::is_integral<AsType>::value, QString>::type packedIn
 		result += formatInt(v,mode).rightJustified(fieldWidth);
     }
     return result;
+}
+
+template<typename Float>
+boost::optional<Float> fullStringToFloat(std::string const& s)
+{
+	static_assert(std::is_same<Float, float>::value ||
+				  std::is_same<Float, double>::value ||
+				  std::is_same<Float, long double>::value,
+				  "Floating-point type not supported by this function");
+	try
+	{
+		std::size_t pos;
+		Float value;
+		if(std::is_same<Float, float>::value)
+			value=std::stof (s, &pos);
+		else if(std::is_same<Float, double>::value)
+			value=std::stod (s, &pos);
+		else
+			value=std::stold(s, &pos);
+		if(pos==s.size()) return value;
+	}
+	catch(std::exception&) {}
+	return boost::none;
 }
 
 }

--- a/plugins/ODbgRegisterView/DialogEditFPU.cpp
+++ b/plugins/ODbgRegisterView/DialogEditFPU.cpp
@@ -37,21 +37,14 @@ namespace {
 long double readFloat(const QString &strInput, bool &ok) {
 	ok = false;
 	const QString      str(strInput.toLower().trimmed());
-	std::istringstream stream(str.toStdString());
-	long double        value;
-	stream >> value;
-	if (stream) {
-		// Check that no trailing chars are left
-		char c;
-		stream >> c;
-		if (!stream) {
-			ok = true;
-			return value;
-		}
+	if(const auto value=util::fullStringToFloat<long double>(str.toStdString()))
+	{
+		ok = true;
+		return *value;
 	}
 	// OK, so either it is invalid/unfinished, or it's some special value
 	// We still do want the user to be able to enter common special values
-
+	long double value;
 	static std::array<std::uint8_t, 10> positiveInf{0, 0, 0, 0, 0, 0, 0, 0x80, 0xff, 0x7f};
 	static std::array<std::uint8_t, 10> negativeInf{0, 0, 0, 0, 0, 0, 0, 0x80, 0xff, 0xff};
 	static std::array<std::uint8_t, 10> positiveSNaN{0, 0, 0, 0, 0, 0, 0, 0x90, 0xff, 0x7f};

--- a/src/FloatX.cpp
+++ b/src/FloatX.cpp
@@ -234,8 +234,11 @@ QValidator::State FloatXValidator<Float>::validate(QString& input, int&) const
 	// OK, so we failed to read it or it is unfinished. Let's check whether it's intermediate or invalid.
 	QRegExp basicFormat("[+-]?[0-9]*\\.?[0-9]*(e([+-]?[0-9]*)?)?");
 	QRegExp specialFormat("[+-]?[sq]?nan|[+-]?inf",Qt::CaseInsensitive);
+	QRegExp hexfloatFormat("[+-]?0x[0-9a-f]*\\.?[0-9a-f]*(p([+-]?[0-9]*)?)?",Qt::CaseInsensitive);
 	QRegExp specialFormatUnfinished("[+-]?[sq]?(n(an?)?)?|[+-]?(i(nf?)?)?",Qt::CaseInsensitive);
 
+	if(hexfloatFormat.exactMatch(input))
+		return QValidator::Intermediate;
 	if(basicFormat.exactMatch(input))
 		return QValidator::Intermediate;
 	if(specialFormat.exactMatch(input))


### PR DESCRIPTION
This will allow to enter exact binary representation of floating-point numbers without the need to shift/mask/bias mantissa and exponent into the particular storage format.