### PR TITLE
Properly update font in register view when settings are changed

### DIFF
--- a/plugins/ODbgRegisterView/RegisterView.cpp
+++ b/plugins/ODbgRegisterView/RegisterView.cpp
@@ -364,6 +364,16 @@ void ODBRegView::mousePressEvent(QMouseEvent *event) {
 	}
 }
 
+void ODBRegView::updateFont() {
+	QFont font;
+	if(!font.fromString(edb::v1::config().registers_font))
+	{
+		font = QFont("Monospace");
+		font.setStyleHint(QFont::TypeWriter);
+	}
+	setFont(font);
+}
+
 void ODBRegView::fieldSelected() {
 	Q_FOREACH(const auto field, valueFields())
 		if (sender() != field)
@@ -415,19 +425,11 @@ ODBRegView::RegisterGroupType findGroup(QString const &str) {
 }
 
 void ODBRegView::settingsUpdated() {
-	// TODO(eteran/ruslan): this slot is now triggered whenever the settings
-	// dialog is closed, so it's a good spot to update the fonts and anything
-	// else which may be effected by user config
-	// this half works, but doesn't update the spacing between items yet
-#if 0
-		QFont font;
-		if(!font.fromString(edb::v1::config().registers_font))
-		{
-			font = QFont("Monospace");
-			font.setStyleHint(QFont::TypeWriter);
-		}
-		setFont(font);
-#endif
+	// this slot is now triggered whenever the settings dialog is closed,
+	// so it's a good spot to update the fonts and anything else which
+	// may be affected by user config
+	updateFont();
+	modelReset();
 }
 
 ODBRegView::ODBRegView(QString const &settingsGroup, QWidget *parent)
@@ -444,16 +446,7 @@ ODBRegView::ODBRegView(QString const &settingsGroup, QWidget *parent)
 
 	connect(&edb::v1::config(), SIGNAL(settingsUpdated()), this, SLOT(settingsUpdated()));
 
-	{
-		// TODO: get some signal to change font on the fly
-		// NOTE: on getting this signal all the fields must be resized and moved
-		QFont font;
-		if (!font.fromString(edb::v1::config().registers_font)) {
-			font = QFont("Monospace");
-			font.setStyleHint(QFont::TypeWriter);
-		}
-		setFont(font);
-	}
+	updateFont();
 
 	const auto canvas = new Canvas(this);
 	setWidget(canvas);

--- a/plugins/ODbgRegisterView/RegisterView.h
+++ b/plugins/ODbgRegisterView/RegisterView.h
@@ -103,6 +103,7 @@ private:
 	void        updateFieldsPalette();
 	void keyPressEvent(QKeyEvent *event) override;
 	void mousePressEvent(QMouseEvent *event) override;
+	void updateFont();
 
 private:
 	QList<RegisterGroup *> groups;


### PR DESCRIPTION
At the moment register view font is not updated when settings are changed. This commit fixes that.

Although the change works, could you please review it, because I'm not sure the author intended it to be updated this way.
