### PR TITLE
RFC: introduce DebugEventHandlers (fix #650)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(edb_SRCS
 	CommentServer.cpp
 	Configuration.cpp
 	DataViewInfo.cpp
+	DebugEventHandlers.cpp
 	Debugger.cpp
 	DialogAbout.cpp
 	DialogArguments.cpp

--- a/src/DebugEventHandlers.cpp
+++ b/src/DebugEventHandlers.cpp
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2018 Ivan Sorokin
+                   vanyacpp@gmail.com
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DebugEventHandlers.h"
+#include "Util.h"
+#include "IDebugEventHandler.h"
+
+DebugEventHandlers::DebugEventHandlers()
+	: current_handler_(nullptr)
+{}
+
+DebugEventHandlers::~DebugEventHandlers() {
+	if (current_handler_)
+		EDB_PRINT_AND_DIE("can not destroy debug events container while executing events");
+
+	if (!handlers_.empty())
+		EDB_PRINT_AND_DIE("some debug event handlers weren't property removed");
+}
+
+void DebugEventHandlers::add(IDebugEventHandler *handler) {
+	if (!handler)
+		EDB_PRINT_AND_DIE("event handler can not be nullptr");
+
+	for (auto i = handlers_.begin(), end = handlers_.end(); i != end; ++i)
+		if (*i == handler)
+			EDB_PRINT_AND_DIE("the same event handler is added twice");
+
+	// DebugEventHandlers::add can be called inside DebugEventHandlers::execute.
+	// Let's insert the handler in front so it is not called on the
+	// event currently being executed
+	handlers_.push_front(handler);
+}
+
+void DebugEventHandlers::remove(IDebugEventHandler *handler) {
+	if (!handler)
+		EDB_PRINT_AND_DIE("event handler can not be nullptr");
+
+	auto i = handlers_.begin();
+	for (auto end = handlers_.end(); i != end; ++i)
+		if (*i == handler)
+			break;
+
+	if (i == handlers_.end())
+		EDB_PRINT_AND_DIE("removal of an event that is not present");
+
+	// during execution only deletion of the current handler is supported
+	if (current_handler_ && current_handler_ != handler)
+		EDB_PRINT_AND_DIE("removal of non-current event handler during execution");
+
+	handlers_.erase(i);
+}
+
+edb::EVENT_STATUS DebugEventHandlers::execute(const std::shared_ptr<IDebugEvent> &event) {
+	if (current_handler_)
+		EDB_PRINT_AND_DIE("recursive debug event execution is not allowed");
+
+	// if somehow no handler is run, then let's just assume we should stop...
+	edb::EVENT_STATUS status = edb::DEBUG_STOP;
+
+	try {
+		// loop through all of the handlers, stopping when one thinks that it handled
+		// the event
+		for (auto i = handlers_.begin(), end = handlers_.end(); i != end;) {
+			// increment before processing, so if it's deleted it's not a problem
+			current_handler_ = *i++;
+			status = current_handler_->handle_event(event);
+			if (status != edb::DEBUG_NEXT_HANDLER) {
+				break;
+			}
+		}
+	}
+	catch (...) {
+		// reset current_handler_ to nullptr even if an exception was thrown
+		current_handler_ = nullptr;
+		throw;
+	}
+	current_handler_ = nullptr;
+
+	// if this assert fails, the bottom handler (which is owned by us) did something terribly wrong :-/
+	if (status == edb::DEBUG_NEXT_HANDLER)
+		EDB_PRINT_AND_DIE("the last event handler returned DEBUG_NEXT_HANDLER");
+
+	return status;
+}

--- a/src/DebugEventHandlers.h
+++ b/src/DebugEventHandlers.h
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2018 Ivan Sorokin
+                   vanyacpp@gmail.com
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEBUGEVENTS_20180312_H_
+#define DEBUGEVENTS_20180312_H_
+
+#include <list>
+#include <memory>
+#include "Types.h"
+
+class IDebugEventHandler;
+class IDebugEvent;
+
+/*
+This class is a container of IDebugEventHandler*. It supports three
+operations:
+1. add -- Adding IDebugEventHandler*
+2. remove -- Removing IDebugEventHandler*
+3. execute -- Iterating over added handlers and calling them
+
+The reason why a simple standard container is not enough is that
+handlers can be added/removed while the list is being iterated on.
+Naive implement would cause accessing an invalid iterator in this
+case.
+
+This class supports adding new handlers during iteration. Removing
+during iteration is also supported, but is restricted: only the
+handler that is currectly being executed can be removed.
+
+In order to support removing handlers during iteration the iterator
+is incremented before calling corresponding handler.
+
+Recursive calls to execute are forbidden.
+
+Contract violations of this class are unrecoverable and cause
+program termination (std::abort is called).
+*/
+class DebugEventHandlers {
+public:
+	DebugEventHandlers();
+	DebugEventHandlers(DebugEventHandlers const&) = delete;
+	DebugEventHandlers& operator=(DebugEventHandlers const&) = delete;
+	~DebugEventHandlers();
+
+	void add(IDebugEventHandler *handler);
+	void remove(IDebugEventHandler *handler);
+	edb::EVENT_STATUS execute(const std::shared_ptr<IDebugEvent> &event);
+
+private:
+	/*
+	list of registed handlers
+	*/
+	std::list<IDebugEventHandler*> handlers_;
+
+	/*
+	the current handler that is being executed
+	nullptr means that none is being executed at the moment
+	*/
+	IDebugEventHandler* current_handler_;
+};
+
+#endif

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -486,6 +486,7 @@ Debugger::~Debugger() {
 	// kill our xterm and wait for it to die
 	tty_proc_->kill();
 	tty_proc_->waitForFinished(3000);
+	edb::v1::remove_debug_event_handler(this);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
OK. Here is my proposed fix for #650.

This problem is solved by introducing an class called
DebugEventHandlers. It holds IDebugEventHandler* and allows removing
when execute_debug_event_handlers is being in progress.

Here is the copy of its description:

DebugEventHandlers is a container of IDebugEventHandler*. It
supports three operations:
1. add -- Adding IDebugEventHandler*
2. remove -- Removing IDebugEventHandler*
3. execute -- Iterating over added handlers and calling them

The reason why a simple standard container is not enough is
that handlers can be added/removed while the list is being
iterated on. Naive implement would cause accessing an invalid
iterator in this case.

In order to support handler removal during iteration this class
keeps an extra bool (inside_execute_) -- whether execution of
handlers is in progress. If it is true then the elements of list
are not erased immediately. Instead they are marked for pending
removal by zeroing their handler pointer.

In order to support handler adding during iteration this class
uses std::list. std::list allows inserting elements without
invalidating iterators to existing elements. Newly added handlers
are inserted into the beginning of the list, so they are not
called on the event that is being executed.