### PR TITLE
Set consistent LC_NUMERIC

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -476,6 +476,12 @@ Debugger::Debugger(QWidget *parent) : QMainWindow(parent),
 
 	// let the plugins setup their menus
 	finish_plugin_setup();
+
+	// Make sure number formatting and reading code behaves predictably when using standard C++ facilities.
+	// NOTE: this should only be done after the plugins have finished loading, since some dynamic libraries
+	// (e.g. libkdecore), which are indirectly loaded by the plugins, re-set locale to "" once again. (This
+	// first time is QApplication.)
+	std::setlocale(LC_NUMERIC, "C");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
One of my latest commits which changed the use of `std::istringstream` to parse floating-point numbers to `std::sto...` resulted in breakage of EDB in non-English locales. Namely, if `LC_NUMERIC` is set to something like `ru_RU.UTF-8`, decimal separator is comma. And since `std::stod` and family, unlike `std::istream`, is locale-aware (too aware, unfortunately), the numbers which passed our `FloatXValidator`, appear rejected in `fullStringToFloat`.
To fix this, EDB must set its `LC_NUMERIC` to `"C"`, which is done by this patch.