### PR TITLE
Make the desktop's entries somewhat better

### DIFF
--- a/edb.desktop
+++ b/edb.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=edb
-GenericName=edb debugger
-Comment=edb debugger 
+GenericName="Evan's Debugger"
+Comment="edb is a cross platform x86/x86-64 debugger"
 Exec=edb
 Icon=edb
 Terminal=false


### PR DESCRIPTION
Hello fellow contributors of edb. I made a small change in the `edb.desktop` file, if you like it consinder to accept it :)

As of now, the gentoo ebuild of edb-debugger uses `sed` to alter the description inside the `edb.desktop`, so I thought I could share my idea with a PR. This will help both me to clean up future ebuilds and perhaps other users of the software that want a more descriptive `.desktop` file.

Thanks!