### PR TITLE
Fix installation path of the man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,6 @@ endif()
 add_subdirectory(src)
 add_subdirectory(plugins)
 
-install (FILES ${CMAKE_SOURCE_DIR}/edb.1 DESTINATION ${CMAKE_INSTALL_MANDIR})
+install (FILES ${CMAKE_SOURCE_DIR}/edb.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 install (FILES ${CMAKE_SOURCE_DIR}/edb.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/)
 install (FILES ${CMAKE_SOURCE_DIR}/src/images/edb.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps/)


### PR DESCRIPTION
Otherwise on my system, `man edb` doesn't find the man page. And in any case, there's no other `*.1` file in `/usr/share/man`, unlike `/usr/share/man/man1`.