### PR TITLE
uninitialized array in DialogEditSIMDRegister

### DIFF
--- a/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
+++ b/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
@@ -192,6 +192,11 @@ void DialogEditSIMDRegister::updateIntegralEntries(const std::array<NumberEdit *
 }
 
 void DialogEditSIMDRegister::updateAllEntriesExcept(NumberEdit *notUpdated) {
+
+	if (!reg) {
+		return;
+	}
+
 	updateIntegralEntries<std::uint8_t>(bytes, notUpdated);
 	updateIntegralEntries<std::uint16_t>(words, notUpdated);
 	updateIntegralEntries<std::uint32_t>(dwords, notUpdated);

--- a/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
+++ b/plugins/ODbgRegisterView/DialogEditSIMDRegister.cpp
@@ -100,7 +100,10 @@ DialogEditSIMDRegister::DialogEditSIMDRegister(QWidget *parent) : QDialog(parent
 		const auto hexSignRadiosLayout = new QVBoxLayout();
 		radioHex                       = new QRadioButton(tr("Hexadecimal"), this);
 		connect(radioHex, &QRadioButton::toggled, this, &DialogEditSIMDRegister::onHexToggled);
-		radioHex->setChecked(true); // must be after connecting of toggled()
+		// setChecked must be called after connecting of toggled()
+		// in order to set validators for integer editors
+		radioHex->setChecked(true);
+
 		hexSignRadiosLayout->addWidget(radioHex);
 
 		radioSigned = new QRadioButton(tr("Signed"), this);


### PR DESCRIPTION
At program startup (before anything is run), valgrind reports uninitialized variable
with the following callstack (reduced for clarity):

Conditional jump or move depends on uninitialised value(s)
...
QString::arg(long long, int, int, QChar) const
QString::arg(int, int, int, QChar) const
ODbgRegisterView::DialogEditSIMDRegister::formatInteger<unsigned char>
ODbgRegisterView::DialogEditSIMDRegister::updateIntegralEntries<unsigned char>
ODbgRegisterView::DialogEditSIMDRegister::updateAllEntriesExcept
ODbgRegisterView::DialogEditSIMDRegister::onHexToggled
QtPrivate::FunctorCall<...>::call
QtPrivate::FunctionPointer<...>::call
QtPrivate::QSlotObject<...>::impl
QMetaObject::activate(QObject *, int, int, void * *)
QAbstractButton::toggled(bool)
...
QAbstractButton::setChecked(bool)
ODbgRegisterView::DialogEditSIMDRegister::DialogEditSIMDRegister   # radioHex->setChecked(true);
ODbgRegisterView::ODBRegView::ODBRegView
ODbgRegisterView::Plugin::createRegisterView
ODbgRegisterView::Plugin::setupDocks
ODbgRegisterView::Plugin::menu
Debugger::finish_plugin_setup
Debugger::Debugger
(anonymous namespace)::start_debugger
main

The uninitialized value that is used is DialogEditSIMDRegister::value_.

Proper fix might involve connecting onHexToggled after calling setChecked in
DialogEditSIMDRegister constructor. But a comment in the code states that this
is done on purpose.

    connect(radioHex, &QRadioButton::toggled, this, &DialogEditSIMDRegister::onHexToggled);
    radioHex->setChecked(true); // must be after connecting of toggled()

Unfortunately the comment doesn't explain why it must be done this way.

Another possibility is to avoid formatting entries altogether as they are not shown everywhere
(the error occurs at program startup, when register view is empty).

This commit fixes the issue in the most conservative way possible (by filling value_ with zeros).
This makes it appropriate for stable branch (1.0), but for master perhaps a better solution should
be devised.