### PR TITLE
Don't rely on /proc to get thread's instruction pointer

### DIFF
--- a/include/IThread.h
+++ b/include/IThread.h
@@ -33,7 +33,6 @@ public:
 	virtual edb::tid_t tid() const = 0;
 	virtual QString name() const = 0;
 	virtual int priority() const = 0;
-	virtual edb::address_t instruction_pointer() const = 0;
 	virtual QString runState() const = 0;
 
 public:

--- a/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
+++ b/plugins/DebuggerCore/unix/linux/DebuggerCore.cpp
@@ -553,8 +553,10 @@ std::shared_ptr<IDebugEvent> DebuggerCore::handle_event(edb::tid_t tid, int stat
 		const auto signo = WSTOPSIG(status);
 		if(signo == SIGILL || signo == SIGSEGV) {
 			// no need to peekuser for SIGILL, but have to for SIGSEGV
+			State state;
+			(*it)->get_state(&state);
 			const auto address = signo == SIGILL ? edb::address_t::fromZeroExtended(e->siginfo_.si_addr)
-											   : (*it)->instruction_pointer();
+											   : state.instruction_pointer();
 
 			if(edb::v1::find_triggered_breakpoint(address)) {
 				e->status_ = SIGTRAP << 8 | 0x7f;

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.cpp
@@ -79,21 +79,6 @@ int PlatformThread::priority() const  {
 // Name:
 // Desc:
 //------------------------------------------------------------------------------
-edb::address_t PlatformThread::instruction_pointer() const  {
-	// FIXME(ARM): doesn't work at least on ARM32
-	struct user_stat thread_stat;
-	int n = get_user_task_stat(process_->pid(), tid_, &thread_stat);
-	if(n >= 30) {
-		return thread_stat.kstkeip;
-	}
-
-	return 0;
-}
-
-//------------------------------------------------------------------------------
-// Name:
-// Desc:
-//------------------------------------------------------------------------------
 QString PlatformThread::runState() const  {
 	struct user_stat thread_stat;
 	int n = get_user_task_stat(process_->pid(), tid_, &thread_stat);

--- a/plugins/DebuggerCore/unix/linux/PlatformThread.h
+++ b/plugins/DebuggerCore/unix/linux/PlatformThread.h
@@ -45,7 +45,6 @@ public:
 	edb::tid_t tid() const override;
 	QString name() const override;
 	int priority() const override;
-	edb::address_t instruction_pointer() const override;
 	QString runState() const override;
 
 public:

--- a/src/ThreadsModel.cpp
+++ b/src/ThreadsModel.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ThreadsModel.h"
 #include "IThread.h"
+#include "State.h"
 #include "edb.h"
 
 #include <QtAlgorithms>
@@ -62,13 +63,15 @@ QVariant ThreadsModel::data(const QModelIndex &index, int role) const {
 				return item.thread->priority();
 			case 2:
 				{
+					State state;
+					item.thread->get_state(&state);
 					const QString default_region_name;
-					const QString symname = edb::v1::find_function_symbol(item.thread->instruction_pointer(), default_region_name);
+					const QString symname = edb::v1::find_function_symbol(state.instruction_pointer(), default_region_name);
 
 					if(!symname.isEmpty()) {
-						return QString("%1 <%2>").arg(edb::v1::format_pointer(item.thread->instruction_pointer()), symname);
+						return QString("%1 <%2>").arg(edb::v1::format_pointer(state.instruction_pointer()), symname);
 					} else {
-						return QString("%1").arg(edb::v1::format_pointer(item.thread->instruction_pointer()));
+						return QString("%1").arg(edb::v1::format_pointer(state.instruction_pointer()));
 					}
 				}
 			case 3:


### PR DESCRIPTION
Linux after v4.9 has stopped reporting eip and esp in `/proc/PID/stat`
Refer: torvalds/linux@0a1eb2d474edfe75466be6b4677ad84e5e8ca3f5

Things need to do before merge this PR:
Implement this `TODO` in `get_state`:
https://github.com/eteran/edb-debugger/blob/fb7643f65927b769668e41ea20f008cdb82f7a19/plugins/DebuggerCore/unix/linux/arch/x86-generic/PlatformThread.cpp#L164-L165