### PR TITLE
Fix crash when PlatformState::gp_register() on ARM is passed an invaid GPR index

### DIFF
--- a/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/arm-generic/PlatformState.cpp
@@ -292,8 +292,9 @@ void PlatformState::set_register(const QString &name, edb::reg_t value) {
  */
 Register PlatformState::gp_register(size_t n) const {
 #ifdef EDB_ARM32
-	assert(n < GPR::GPRegNames.size());
-	return make_Register<32>(gpr.GPRegNames[n].front(), gpr.GPRegs[n], Register::TYPE_GPR);
+	if(n < GPR::GPRegNames.size())
+		return make_Register<32>(gpr.GPRegNames[n].front(), gpr.GPRegs[n], Register::TYPE_GPR);
+	return Register();
 #else
 	return Register(); // FIXME: stub
 #endif


### PR DESCRIPTION
It's expected to handle such inputs, and in x86 code it does handle them well, so should in ARM too.

Closes #713 