### PR TITLE
Draw jump lines on left-side of disassembly view

### DIFF
--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -101,11 +101,12 @@ private:
 	boost::optional<unsigned int> get_line_of_address(edb::address_t addr) const;
 	edb::address_t address_from_coord(int x, int y) const;
 	int address_length() const;
-	int auto_line1() const;
+	int auto_line2() const;
 	int draw_instruction(QPainter &painter, const edb::Instruction &inst, int y, int line_height, int l2, int l3, bool selected);	
 	int line1() const;
 	int line2() const;
 	int line3() const;
+	int line4() const;
 	int line_height() const;
 	int previous_instructions(int current_address, int count);
 	int previous_instruction(IAnalyzer *analyzer, int current_address);
@@ -130,10 +131,12 @@ private:
 	int            line1_                        = 0;
 	int            line2_                        = 0;
 	int            line3_                        = 0;
+	int            line4_                        = 0;
 	int            selected_instruction_size_    = 0;
 	bool           moving_line1_                 = false;
 	bool           moving_line2_                 = false;
 	bool           moving_line3_                 = false;
+	bool           moving_line4_                 = false;
 	bool           selecting_address_            = false;
 	bool           partial_last_line_            = false;
 
@@ -150,6 +153,23 @@ private:
 	QSvgRenderer                          current_bp_renderer_;
 	std::vector<quint8>                   instruction_buffer_;
 	QCache<QString, QPixmap>              syntax_cache_;
+
+private:
+
+	struct JumpArrow {
+
+		int src_line;
+		edb::address_t target;
+
+		// if target is visible in viewport
+		bool dst_in_viewport;
+
+		// if dst_in_viewport is false, then this param is ignored
+		int dst_line;
+
+		// if dst_in_viewport is false, then the value here should be near INT_MAX
+		size_t distance;
+	};
 };
 
 #endif


### PR DESCRIPTION
Added feature for drawing jump lines on the left side of disassembly view. Kinda missing this one when I was using EDB. (in Windows my goto debugger is x64dbg, so was inspired by that)

![image](https://user-images.githubusercontent.com/2675341/67485112-00303080-f69c-11e9-89aa-c5d3b16c5ee6.png)

Any comment is really appreciated :) (as I have not majorly tested this one yet - only on x86-64 Linux).