### PR TITLE
Add option to disable jump draw

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -78,6 +78,7 @@ public:
 	int                   data_row_width;
 	StartupWindowLocation startup_window_location;
     bool                  function_offsets_in_hex;
+	bool                  show_jump_arrow;
 
 	// debugging tab
 	InitialBreakpoint initial_breakpoint;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -113,7 +113,9 @@ void Configuration::readSettings() {
 	data_word_width         = settings.value("appearance.data.word_width", 1).value<int>();
 	data_row_width          = settings.value("appearance.data.row_width", 16).value<int>();
 	show_address_separator  = settings.value("appearance.address_colon.enabled", true).toBool();
+	show_jump_arrow         = settings.value("appearance.show_jump_arrow.enabled", true).toBool();
     function_offsets_in_hex = settings.value("appearance.function_offsets_in_hex.enabled", false).toBool();
+	
 	settings.endGroup();
 
 	settings.beginGroup("Debugging");
@@ -228,6 +230,7 @@ void Configuration::writeSettings() {
 	settings.setValue("appearance.data.word_width", data_word_width);
 	settings.setValue("appearance.data.row_width", data_row_width);
 	settings.setValue("appearance.address_colon.enabled", show_address_separator);
+	settings.setValue("appearance.show_jump_arrow.enabled", show_jump_arrow);
     settings.setValue("appearance.function_offsets_in_hex.enabled", function_offsets_in_hex);
 	settings.endGroup();
 

--- a/src/DialogOptions.cpp
+++ b/src/DialogOptions.cpp
@@ -200,6 +200,8 @@ void DialogOptions::showEvent(QShowEvent *event) {
 
 	ui.chkAddressColon->setChecked(config.show_address_separator);
 
+	ui.chkShowJumpArrow->setChecked(config.show_jump_arrow);
+
 	ui.signalsMessageBoxEnable->setChecked(config.enable_signals_message_box);
 
 	ui.chkTabBetweenMnemonicAndOperands->setChecked(config.tab_between_mnemonic_and_operands);
@@ -281,6 +283,7 @@ void DialogOptions::closeEvent(QCloseEvent *event) {
 	config.default_breakpoint_type = ui.cmbDefaultBreakpointType->itemData(ui.cmbDefaultBreakpointType->currentIndex()).value<IBreakpoint::TypeId>();
 
 	config.function_offsets_in_hex = ui.chkHexOffsets->isChecked();
+	config.show_jump_arrow         = ui.chkShowJumpArrow->isChecked();
 
 	config.zeros_are_filling     = ui.chkZerosAreFilling->isChecked();
 	config.show_register_badges = ui.chkRegisterBadges->isChecked();

--- a/src/DialogOptions.ui
+++ b/src/DialogOptions.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>681</width>
-    <height>541</height>
+    <height>643</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -621,6 +621,16 @@
         <widget class="QCheckBox" name="chkRegisterBadges">
          <property name="text">
           <string>Show when registers are pointing to a visible address</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkShowJumpArrow">
+         <property name="text">
+          <string>Show jump arrows</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -1283,7 +1283,7 @@ void QDisassemblyView::drawJumpArrows(QPainter &painter, const DrawingContext *c
 		return a.distance < b.distance;
 	});
 
-	auto isLineOverlap = [&](int line1_head, int line1_tail, int line2_head, int line2_tail, bool edge_overlap = true) -> bool {
+	auto isLineOverlap = [&](int line1_head, int line1_tail, int line2_head, int line2_tail, bool edge_overlap) -> bool {
 
 		int jump1_arrow_min = std::min(line1_head, line1_tail);
 		int jump1_arrow_max = std::max(line1_head, line1_tail);
@@ -1725,7 +1725,7 @@ int QDisassemblyView::line1() const {
 
 		// allocate space for register badge
 		// 4 (maximum register name for GPR) + overhead
-		return (edb::v1::config().show_register_badges) ? (5 * font_width_ + font_width_/2) : 0;
+		return edb::v1::config().show_register_badges ? (5 * font_width_ + font_width_/2) : 0;
 
 	} else if(line1_ == 0) {
 		return 15 * font_width_;

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -1370,7 +1370,8 @@ void QDisassemblyView::drawJumpArrows(QPainter &painter, const DrawingContext *c
 		// if direct jmp is selected, then draw arrow in red
 		if (is_unconditional_jump(instructions_[jump_arrow.src_line]) && 
 			(ctx->selected_line == jump_arrow.src_line || 
-			(ctx->selected_line == jump_arrow.dst_line && show_addresses_[jump_arrow.dst_line] != current_address_ ))) {
+			(ctx->selected_line == jump_arrow.dst_line && 
+			(jump_arrow.dst_in_viewport && show_addresses_[jump_arrow.dst_line] != current_address_ )))) {
 			arrow_color = Qt::red;
 		}
 

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -1724,8 +1724,8 @@ int QDisassemblyView::line1() const {
 	if(!edb::v1::config().show_jump_arrow) {
 
 		// allocate space for register badge
-		// 5 (maximum register name length i can find off) + overhead
-		return (edb::v1::config().show_register_badges) ? (6 * font_width_ + font_width_/2) : 0;
+		// 4 (maximum register name for GPR) + overhead
+		return (edb::v1::config().show_register_badges) ? (5 * font_width_ + font_width_/2) : 0;
 
 	} else if(line1_ == 0) {
 		return 15 * font_width_;

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -1568,7 +1568,8 @@ void QDisassemblyView::paintEvent(QPaintEvent *) {
 		lines_to_render,
 		selected_line,
 		line_height,
-		group
+		group,
+		std::map<int, int> ()
 	};
 
 	drawHeaderAndBackground(painter, &context, binary_info);

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -1345,7 +1345,7 @@ void QDisassemblyView::drawJumpArrows(QPainter &painter, const DrawingContext *c
 		}
 
 		// first-fit search for horizontal length position to place new arrow
-		for (int current_selected_len = start_at_block; current_selected_len < line1(); current_selected_len += size_block) {
+		for (int current_selected_len = start_at_block; ; current_selected_len += size_block) {
 
 			bool is_length_good = true;
 			

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -55,6 +55,7 @@ private:
 		int selected_line;
 		int line_height;
 		QPalette::ColorGroup group;
+		std::map<int, int> line_badge_width;  // for jmp drawing
 	};
 
 public:
@@ -133,7 +134,7 @@ private:
 
 	void drawInstruction(QPainter &painter, const edb::Instruction &inst, const DrawingContext *ctx, int y, bool selected);
 	void drawHeaderAndBackground(QPainter &painter, const DrawingContext *ctx, const std::unique_ptr<IBinary> &binary_info);
-	int drawRegiserBadges(QPainter &painter, const DrawingContext *ctx);
+	void drawRegiserBadges(QPainter &painter, DrawingContext *ctx);
 	void drawSymbolNames(QPainter &painter, const DrawingContext *ctx);
 	void drawSidebarElements(QPainter &painter, const DrawingContext *ctx);
 	void drawInstructionBytes(QPainter &painter, const DrawingContext *ctx);


### PR DESCRIPTION
Changes made:

1. Added option to disable jump draw

![image](https://user-images.githubusercontent.com/2675341/68048246-2187c100-fd1b-11e9-97ac-1f519b2540a4.png)

2. Fixed possible crashing when accessing show_addresses_ function 

3. Dock registers badge at the left side of line1

![image](https://user-images.githubusercontent.com/2675341/68048401-7297b500-fd1b-11e9-9288-9e2024204a88.png)

Any comments is really appreciated. :)