### PR TITLE
fix leaking menus in Debugger::on_cpuView_customContextMenuRequested

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1685,10 +1685,10 @@ void Debugger::mnuStackPop() {
 void Debugger::on_cpuView_customContextMenuRequested(const QPoint &pos) {
 	QMenu menu;
 
-	auto displayMenu = new QMenu(tr("Display"));
+	auto displayMenu = new QMenu(tr("Display"), &menu);
 	displayMenu->addAction(QIcon::fromTheme(QString::fromUtf8("view-restore")), tr("Restore Column Defaults"), ui.cpuView, SLOT(resetColumns()));
 
-	auto editMenu = new QMenu(tr("&Edit"));
+	auto editMenu = new QMenu(tr("&Edit"), &menu);
 	editMenu->addAction(editBytesAction_);
 	editMenu->addAction(fillWithZerosAction_);
 	editMenu->addAction(fillWithNOPsAction_);


### PR DESCRIPTION
As they were reported by leak sanitizer:

Indirect leak of 144 byte(s) in 3 object(s) allocated from:
    #0 0x7fcf36539d80 in operator new(unsigned long) (/nix/store/784rh7jrfhagbkydjfrv68h9x3g4gqmk-gcc-8.3.0-lib/lib/libasan.so.5+0xedd80)
    #1 0x69f35a in Debugger::on_cpuView_customContextMenuRequested(QPoint const&) /home/ivan/d/edb-debugger/src/Debugger.cpp:1688

Indirect leak of 144 byte(s) in 3 object(s) allocated from:
    #0 0x7fcf36539d80 in operator new(unsigned long) (/nix/store/784rh7jrfhagbkydjfrv68h9x3g4gqmk-gcc-8.3.0-lib/lib/libasan.so.5+0xedd80)
    #1 0x69f666 in Debugger::on_cpuView_customContextMenuRequested(QPoint const&) /home/ivan/d/edb-debugger/src/Debugger.cpp:1691