### PR TITLE
fix warning message printed in ODBRegView::modelReset

### DIFF
--- a/plugins/ODbgRegisterView/RegisterView.cpp
+++ b/plugins/ODbgRegisterView/RegisterView.cpp
@@ -453,12 +453,8 @@ void ODBRegView::modelReset() {
 
 	const auto layout = static_cast<QVBoxLayout *>(widget()->layout());
 
-	// layout contains not only groups, so delete all items too
-	while (const auto item = layout->takeAt(0)) {
-		delete item;
-	}
-
-	const auto flagsAndSegments = new QHBoxLayout(this);
+	const auto flagsAndSegments = new QHBoxLayout();
+	flagsAndSegments_.reset(flagsAndSegments);
 
 	// (3/2+1/2)-letter — Total of 2-letter spacing. Fourth half-letter is from flag values extension.
 	// Segment extensions at LHS of the widget don't influence minimumSize request, so no need to take

--- a/plugins/ODbgRegisterView/RegisterView.h
+++ b/plugins/ODbgRegisterView/RegisterView.h
@@ -23,6 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPersistentModelIndex>
 #include <QScrollArea>
 #include <QString>
+#include <QHBoxLayout>
+
+#include <memory>
 
 namespace ODbgRegisterView {
 
@@ -99,6 +102,7 @@ private Q_SLOTS:
 private:
 	RegisterViewModelBase::Model *model_ = nullptr;
 	QList<RegisterGroup *> groups_;
+	std::unique_ptr<QHBoxLayout> flagsAndSegments_;
 	std::vector<RegisterGroupType> visibleGroupTypes_;
 	QList<QAction *> menuItems_;
 	DialogEditGPR *dialogEditGpr_;


### PR DESCRIPTION
The first attempt to fix #745 was
562eb3c2bd3853ac53e031963dd38a744367f821. Although
technically it suppresses the report of leak
sanitizer, it had two shortcomings:

1. A message "QLayout: Attempting to add QLayout "" to ODbgRegisterView::ODBRegView "ODBRegView", which already has a layout"
   was printed every time ODBRegView::modelReset was called.
2. ODBRegView was assigned as a parent to QHBoxLayout, which means
   that QHBoxLayout won't be destroyed until the program quits,
   while new QHBoxLayout is created everytime the model is reset.
   This can cause unbounded memory usage growth.

This commit tries to address both of these shortcomings.