### PR TITLE
fix warning message printed in ODBRegView::modelReset

### DIFF
--- a/plugins/ODbgRegisterView/RegisterView.cpp
+++ b/plugins/ODbgRegisterView/RegisterView.cpp
@@ -453,12 +453,8 @@ void ODBRegView::modelReset() {
 
 	const auto layout = static_cast<QVBoxLayout *>(widget()->layout());
 
-	// layout contains not only groups, so delete all items too
-	while (const auto item = layout->takeAt(0)) {
-		delete item;
-	}
-
-	const auto flagsAndSegments = new QHBoxLayout(this);
+	const auto flagsAndSegments = new QHBoxLayout();
+	flagsAndSegments_.reset(flagsAndSegments);
 
 	// (3/2+1/2)-letter — Total of 2-letter spacing. Fourth half-letter is from flag values extension.
 	// Segment extensions at LHS of the widget don't influence minimumSize request, so no need to take

--- a/plugins/ODbgRegisterView/RegisterView.h
+++ b/plugins/ODbgRegisterView/RegisterView.h
@@ -23,6 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPersistentModelIndex>
 #include <QScrollArea>
 #include <QString>
+#include <QHBoxLayout>
+
+#include <memory>
 
 namespace ODbgRegisterView {
 
@@ -99,6 +102,7 @@ private Q_SLOTS:
 private:
 	RegisterViewModelBase::Model *model_ = nullptr;
 	QList<RegisterGroup *> groups_;
+	std::unique_ptr<QHBoxLayout> flagsAndSegments_;
 	std::vector<RegisterGroupType> visibleGroupTypes_;
 	QList<QAction *> menuItems_;
 	DialogEditGPR *dialogEditGpr_;


### PR DESCRIPTION
After commit 562eb3c2bd3853ac53e031963dd38a744367f821 a message

```
   QLayout: Attempting to add QLayout "" to ODbgRegisterView::ODBRegView "ODBRegView", which already has a layout
```

was printed everytime ODBRegView::modelReset is called.

This commit tries to fix this.