### PR TITLE
fix a bug that symbols aren't loaded when executable path contains whitespace

### DIFF
--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -188,7 +188,9 @@ bool SymbolManager::processSymbolFile(const QString &f, edb::address_t base, con
 		std::string filename;
 
 		if (std::getline(file, date)) {
-			if (file >> md5 >> filename) {
+			file >> md5 >> std::ws;
+			std::getline(file, filename);
+			if (file) {
 
 				const QByteArray file_md5   = QByteArray::fromHex(md5.c_str());
 				const QByteArray actual_md5 = edb::v1::get_file_md5(library_filename);


### PR DESCRIPTION
When program with whitespace in its path is run, edb prints the warning:

```
WARNING: File "/home/ivan/.cache/codef00.com/edb/symbols//home/ivan/My Documents/hello.map" seems corrupt
```

and the list of symbols is empty.

The bug is caused by the fact that the file path is read with istream::operator>> that stops reading at first whitespace. This commit uses std::getline to read the line fully.