### PR TITLE
WIP: Session manager update

### DIFF
--- a/include/ISessionManager.h
+++ b/include/ISessionManager.h
@@ -33,17 +33,17 @@ public:
 	virtual ~ISessionManager() = default;
 
 public:
-    virtual Result<void, SessionError> loadSession(const QString &filename) = 0;
-    virtual void saveSession(const QString &filename)                       = 0;
-    virtual QVariantList breakpoints() const                                = 0;
-    virtual QVariantList comments() const                                   = 0;
-    virtual QVariantList labels() const                                     = 0;
-    virtual void addBreakpoint(const IBreakpoint &b)                        = 0;
-    virtual void addComment(const Comment &c)                               = 0;
-    virtual void addLabel(const Label &l)                                   = 0;
-    virtual void removeBreakpoint(edb::address_t address)                   = 0;
-    virtual void removeComment(edb::address_t address)                      = 0;
-    virtual void removeLabel(edb::address_t address)                        = 0;
+	virtual Result<void, SessionError> loadSession(const QString &filename) = 0;
+	virtual void saveSession(const QString &filename)                       = 0;
+	virtual QVariantList breakpoints() const                                = 0;
+	virtual QVariantList comments() const                                   = 0;
+	virtual QVariantList labels() const                                     = 0;
+	virtual void addBreakpoint(const IBreakpoint &b)                        = 0;
+	virtual void addComment(const Comment &c)                               = 0;
+	virtual void addLabel(const Label &l)                                   = 0;
+	virtual void removeBreakpoint(edb::address_t address)                   = 0;
+	virtual void removeComment(edb::address_t address)                      = 0;
+	virtual void removeLabel(edb::address_t address)                        = 0;
 };
 
 #endif

--- a/include/ISessionManager.h
+++ b/include/ISessionManager.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef ISESSION_MANAGER_H_20200519_
 #define ISESSION_MANAGER_H_20200519_
 
+#include "IBreakpoint.h"
 #include "Status.h"
 #include "Types.h"
 
@@ -34,10 +35,13 @@ public:
 public:
     virtual Result<void, SessionError> loadSession(const QString &filename) = 0;
     virtual void saveSession(const QString &filename)                       = 0;
+    virtual QVariantList breakpoints() const                                = 0;
     virtual QVariantList comments() const                                   = 0;
     virtual QVariantList labels() const                                     = 0;
+    virtual void addBreakpoint(const IBreakpoint &b)                        = 0;
     virtual void addComment(const Comment &c)                               = 0;
     virtual void addLabel(const Label &l)                                   = 0;
+    virtual void removeBreakpoint(edb::address_t address)                   = 0;
     virtual void removeComment(edb::address_t address)                      = 0;
     virtual void removeLabel(edb::address_t address)                        = 0;
 };

--- a/include/ISessionManager.h
+++ b/include/ISessionManager.h
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2020 Victorien Molle <biche@biche.re>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ISESSION_MANAGER_H_20200519_
+#define ISESSION_MANAGER_H_20200519_
+
+#include "Status.h"
+#include "Types.h"
+
+#include <QString>
+#include <QVariant>
+
+class QString;
+class SessionError;
+
+class ISessionManager {
+public:
+	virtual ~ISessionManager() = default;
+
+public:
+    virtual Result<void, SessionError> loadSession(const QString &filename) = 0;
+    virtual void saveSession(const QString &filename)                       = 0;
+    virtual QVariantList comments() const                                   = 0;
+    virtual void addComment(const Comment &c)                               = 0;
+    virtual void removeComment(edb::address_t address)                      = 0;
+};
+
+#endif

--- a/include/ISessionManager.h
+++ b/include/ISessionManager.h
@@ -35,8 +35,11 @@ public:
     virtual Result<void, SessionError> loadSession(const QString &filename) = 0;
     virtual void saveSession(const QString &filename)                       = 0;
     virtual QVariantList comments() const                                   = 0;
+    virtual QVariantList labels() const                                     = 0;
     virtual void addComment(const Comment &c)                               = 0;
+    virtual void addLabel(const Label &l)                                   = 0;
     virtual void removeComment(edb::address_t address)                      = 0;
+    virtual void removeLabel(edb::address_t address)                        = 0;
 };
 
 #endif

--- a/include/ISymbolManager.h
+++ b/include/ISymbolManager.h
@@ -42,6 +42,7 @@ public:
 	virtual void loadSymbolFile(const QString &filename, edb::address_t base)          = 0;
 	virtual void setSymbolGenerator(ISymbolGenerator *generator)                       = 0;
 	virtual void setLabel(edb::address_t address, const QString &label)                = 0;
+    virtual void restoreLabels(const QVariantList &labels)                             = 0;
 	virtual QString findAddressName(edb::address_t address, bool prefixed = true)      = 0;
 	virtual QHash<edb::address_t, QString> labels() const                              = 0;
 	virtual QStringList files() const                                                  = 0;

--- a/include/ISymbolManager.h
+++ b/include/ISymbolManager.h
@@ -42,7 +42,7 @@ public:
 	virtual void loadSymbolFile(const QString &filename, edb::address_t base)          = 0;
 	virtual void setSymbolGenerator(ISymbolGenerator *generator)                       = 0;
 	virtual void setLabel(edb::address_t address, const QString &label)                = 0;
-    virtual void restoreLabels(const QVariantList &labels)                             = 0;
+	virtual void restoreLabels(const QVariantList &labels)                             = 0;
 	virtual QString findAddressName(edb::address_t address, bool prefixed = true)      = 0;
 	virtual QHash<edb::address_t, QString> labels() const                              = 0;
 	virtual QStringList files() const                                                  = 0;

--- a/include/Types.h
+++ b/include/Types.h
@@ -41,5 +41,8 @@ struct Comment {
 	QString comment;
 };
 
+/* Label Type */
+typedef struct Comment Label; // label treated as a comment
+
 #include "ArchTypes.h"
 #endif

--- a/include/edb.h
+++ b/include/edb.h
@@ -39,6 +39,7 @@ class IDebugEvent;
 class IDebugger;
 class IPlugin;
 class IRegion;
+class ISessionManager;
 class ISymbolManager;
 class MemoryRegions;
 class Register;
@@ -75,6 +76,9 @@ EDB_EXPORT extern QWidget *debugger_ui;
 
 // the symbol mananger
 EDB_EXPORT ISymbolManager &symbol_manager();
+
+// the session manager
+EDB_EXPORT ISessionManager &session_manager();
 
 // the memory region manager
 EDB_EXPORT MemoryRegions &memory_regions();

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(BinarySearcher)
 add_subdirectory(InstructionInspector)
 add_subdirectory(FasLoader)
 add_subdirectory(ODbgRegisterView)
+add_subdirectory(CommentsViewer)
 
 if(TARGET_ARCH_FAMILY_X86)
     add_subdirectory(HardwareBreakpoints)

--- a/plugins/CommentsViewer/CMakeLists.txt
+++ b/plugins/CommentsViewer/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 3.0)
+include("GNUInstallDirs")
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
+set(PluginName "CommentsViewer")
+
+find_package(Qt5 5.0.0 REQUIRED Widgets)
+
+add_library(${PluginName} SHARED
+	DialogCommentsViewer.cpp
+	DialogCommentsViewer.h
+	DialogCommentsViewer.ui
+	CommentsViewer.cpp
+	CommentsViewer.h
+)
+
+target_link_libraries(${PluginName} Qt5::Widgets edb)
+
+install (TARGETS ${PluginName} DESTINATION ${CMAKE_INSTALL_LIBDIR}/edb)
+
+set_property(TARGET ${PluginName} PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET ${PluginName} PROPERTY CXX_STANDARD 14)
+set_property(TARGET ${PluginName} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+set_property(TARGET ${PluginName} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})

--- a/plugins/CommentsViewer/CommentsViewer.cpp
+++ b/plugins/CommentsViewer/CommentsViewer.cpp
@@ -35,7 +35,7 @@ CommentsViewer::CommentsViewer(QObject *parent)
  * @brief CommentsViewer::~CommentsViewer
  */
 CommentsViewer::~CommentsViewer() {
-    delete dialog_;
+	delete dialog_;
 }
 
 /**
@@ -44,11 +44,11 @@ CommentsViewer::~CommentsViewer() {
  * @return
  */
 QMenu* CommentsViewer::menu(QWidget *parent) {
-    Q_ASSERT(parent);
+	Q_ASSERT(parent);
 
 	if (!menu_) {
-        menu_ = new QMenu(tr("CommentsViewer"), parent);
-        menu_->addAction(tr("&CommentsViewer"), this, SLOT(showMenu()), QKeySequence(tr("Ctrl+Alt+C")));
+		menu_ = new QMenu(tr("CommentsViewer"), parent);
+		menu_->addAction(tr("&CommentsViewer"), this, SLOT(showMenu()), QKeySequence(tr("Ctrl+Alt+C")));
 	}
 
 	return menu_;
@@ -58,11 +58,11 @@ QMenu* CommentsViewer::menu(QWidget *parent) {
  * @brief CommentsViewer::showMenu
  */
 void CommentsViewer::showMenu() {
-    if (!dialog_) {
-        dialog_ = new DialogCommentsViewer(edb::v1::debugger_ui);
-    }
+	if (!dialog_) {
+		dialog_ = new DialogCommentsViewer(edb::v1::debugger_ui);
+	}
 
-    dialog_->show();
+	dialog_->show();
 }
 
 }

--- a/plugins/CommentsViewer/CommentsViewer.cpp
+++ b/plugins/CommentsViewer/CommentsViewer.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2020 Victorien molle <biche@biche.re>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "CommentsViewer.h"
+#include "DialogCommentsViewer.h"
+#include "edb.h"
+#include <QMenu>
+
+
+namespace CommentsViewerPlugin {
+
+/**
+ * @brief CommentsViewer::CommentsViewer
+ * @param parent
+ */
+CommentsViewer::CommentsViewer(QObject *parent)
+	: QObject(parent) {
+}
+
+/**
+ * @brief CommentsViewer::~CommentsViewer
+ */
+CommentsViewer::~CommentsViewer() {
+    delete dialog_;
+}
+
+/**
+ * @brief CommentsViewer::menu
+ * @param parent
+ * @return
+ */
+QMenu* CommentsViewer::menu(QWidget *parent) {
+    Q_ASSERT(parent);
+
+	if (!menu_) {
+        menu_ = new QMenu(tr("CommentsViewer"), parent);
+        menu_->addAction(tr("&CommentsViewer"), this, SLOT(showMenu()), QKeySequence(tr("Ctrl+Alt+C")));
+	}
+
+	return menu_;
+}
+
+/**
+ * @brief CommentsViewer::showMenu
+ */
+void CommentsViewer::showMenu() {
+    if (!dialog_) {
+        dialog_ = new DialogCommentsViewer(edb::v1::debugger_ui);
+    }
+
+    dialog_->show();
+}
+
+}

--- a/plugins/CommentsViewer/CommentsViewer.h
+++ b/plugins/CommentsViewer/CommentsViewer.h
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2020 Victorien Molle <biche@biche.re>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COMMENTS_VIEWER_H_20200519_
+#define COMMENTS_VIEWER_H_20200519_
+
+#include "IPlugin.h"
+
+class QMenu;
+class QDialog;
+
+namespace CommentsViewerPlugin {
+
+class CommentsViewer : public QObject, public IPlugin {
+	Q_OBJECT
+	Q_INTERFACES(IPlugin)
+	Q_PLUGIN_METADATA(IID "edb.IPlugin/1.0")
+	Q_CLASSINFO("author", "Victorien Molle")
+	Q_CLASSINFO("email", "biche@biche.re")
+
+public:
+	explicit CommentsViewer(QObject *parent = nullptr);
+	~CommentsViewer() override;
+
+public:
+	QMenu *menu(QWidget *parent = nullptr) override;
+
+public Q_SLOTS:
+    void showMenu();
+
+private:
+	QMenu *menu_                = nullptr;
+    QPointer<QDialog> dialog_ = nullptr;
+};
+
+}
+
+#endif

--- a/plugins/CommentsViewer/CommentsViewer.h
+++ b/plugins/CommentsViewer/CommentsViewer.h
@@ -40,11 +40,11 @@ public:
 	QMenu *menu(QWidget *parent = nullptr) override;
 
 public Q_SLOTS:
-    void showMenu();
+	void showMenu();
 
 private:
 	QMenu *menu_                = nullptr;
-    QPointer<QDialog> dialog_ = nullptr;
+	QPointer<QDialog> dialog_ = nullptr;
 };
 
 }

--- a/plugins/CommentsViewer/DialogCommentsViewer.cpp
+++ b/plugins/CommentsViewer/DialogCommentsViewer.cpp
@@ -61,9 +61,9 @@ void DialogCommentsViewer::on_listView_doubleClicked(const QModelIndex &index) {
 
 	const QString s = index.data().toString();
 
-    if (const Result<edb::address_t, QString> addr = edb::v1::string_to_address(s.split(":")[0])) {
-        edb::v1::jump_to_address(*addr);
-    }
+	if (const Result<edb::address_t, QString> addr = edb::v1::string_to_address(s.split(":")[0])) {
+		edb::v1::jump_to_address(*addr);
+	}
 }
 
 /**
@@ -101,16 +101,16 @@ void DialogCommentsViewer::mnuFollowInCPU() {
  * @brief DialogCommentsViewer::showEvent
  */
 void DialogCommentsViewer::showEvent(QShowEvent*) {
-    edb::address_t addr;
-    QStringList results;
-    QVariantList comments;
+	edb::address_t addr;
+	QStringList results;
+	QVariantList comments;
 
-    comments = edb::v1::session_manager().comments();
-    for (auto it = comments.begin(); it != comments.end(); ++it) {
-        QVariantMap data = it->toMap();
-        addr = edb::v1::string_to_address(data["address"].toString()).value();
-        results << QString("%1: %2").arg(edb::v1::format_pointer(addr), data["comment"].toString());
-    }
+	comments = edb::v1::session_manager().comments();
+	for (auto it = comments.begin(); it != comments.end(); ++it) {
+		QVariantMap data = it->toMap();
+		addr = edb::v1::string_to_address(data["address"].toString()).value();
+		results << QString("%1: %2").arg(edb::v1::format_pointer(addr), data["comment"].toString());
+	}
 
 	model_->setStringList(results);
 }

--- a/plugins/CommentsViewer/DialogCommentsViewer.cpp
+++ b/plugins/CommentsViewer/DialogCommentsViewer.cpp
@@ -1,0 +1,118 @@
+/*
+Copyright (C) 2020 Victorien Molle <biche@biche.re>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DialogCommentsViewer.h"
+#include "Configuration.h"
+#include "IDebugger.h"
+#include "ISessionManager.h"
+#include "edb.h"
+
+#include <QMenu>
+#include <QSortFilterProxyModel>
+#include <QStringListModel>
+
+namespace CommentsViewerPlugin {
+
+/**
+ * @brief DialogCommentsViewer::DialogCommentsViewer
+ * @param parent
+ * @param f
+ */
+DialogCommentsViewer::DialogCommentsViewer(QWidget *parent, Qt::WindowFlags f)
+	: QDialog(parent, f) {
+
+	ui.setupUi(this);
+
+	ui.listView->setContextMenuPolicy(Qt::CustomContextMenu);
+
+	model_       = new QStringListModel(this);
+	filterModel_ = new QSortFilterProxyModel(this);
+
+	filterModel_->setFilterKeyColumn(0);
+	filterModel_->setSourceModel(model_);
+	ui.listView->setModel(filterModel_);
+	ui.listView->setUniformItemSizes(true);
+
+	connect(ui.txtSearch, &QLineEdit::textChanged, filterModel_, &QSortFilterProxyModel::setFilterFixedString);
+}
+
+/**
+ * @brief DialogCommentsViewer::on_listView_doubleClicked
+ *
+ * follows the found item in the data view
+ *
+ * @param index
+ */
+void DialogCommentsViewer::on_listView_doubleClicked(const QModelIndex &index) {
+
+	const QString s = index.data().toString();
+
+    if (const Result<edb::address_t, QString> addr = edb::v1::string_to_address(s.split(":")[0])) {
+        edb::v1::jump_to_address(*addr);
+    }
+}
+
+/**
+ * @brief DialogCommentsViewer::on_listView_customContextMenuRequested
+ * @param pos
+ */
+void DialogCommentsViewer::on_listView_customContextMenuRequested(const QPoint &pos) {
+
+	const QModelIndex index = ui.listView->indexAt(pos);
+	if (index.isValid()) {
+
+		const QString s = index.data().toString();
+
+		if (const Result<edb::address_t, QString> addr = edb::v1::string_to_address(s.split(":")[0])) {
+
+			QMenu menu;
+			QAction *const action1 = menu.addAction(tr("&Follow In Disassembly"), this, SLOT(mnuFollowInCPU()));
+			action1->setData(addr->toQVariant());
+			menu.exec(ui.listView->mapToGlobal(pos));
+		}
+	}
+}
+
+/**
+ * @brief DialogCommentsViewer::mnuFollowInCPU
+ */
+void DialogCommentsViewer::mnuFollowInCPU() {
+	if (auto action = qobject_cast<QAction *>(sender())) {
+		const edb::address_t address = action->data().toULongLong();
+		edb::v1::jump_to_address(address);
+	}
+}
+
+/**
+ * @brief DialogCommentsViewer::showEvent
+ */
+void DialogCommentsViewer::showEvent(QShowEvent*) {
+    edb::address_t addr;
+    QStringList results;
+    QVariantList comments;
+
+    comments = edb::v1::session_manager().comments();
+    for (auto it = comments.begin(); it != comments.end(); ++it) {
+        QVariantMap data = it->toMap();
+        addr = edb::v1::string_to_address(data["address"].toString()).value();
+        results << QString("%1: %2").arg(edb::v1::format_pointer(addr), data["comment"].toString());
+    }
+
+	model_->setStringList(results);
+}
+
+}

--- a/plugins/CommentsViewer/DialogCommentsViewer.h
+++ b/plugins/CommentsViewer/DialogCommentsViewer.h
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2020 Victorien molle <biche@biche.re>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DIALOG_COMMENTS_VIEWER_H_20200519
+#define DIALOG_COMMENTS_VIEWER_H_20200519
+
+#include "Types.h"
+#include "ui_DialogCommentsViewer.h"
+#include <QDialog>
+
+class QModelIndex;
+class QPoint;
+class QSortFilterProxyModel;
+class QStringListModel;
+
+namespace CommentsViewerPlugin {
+
+class DialogCommentsViewer : public QDialog {
+	Q_OBJECT
+
+public:
+	explicit DialogCommentsViewer(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+	~DialogCommentsViewer() override = default;
+
+public Q_SLOTS:
+	void on_listView_doubleClicked(const QModelIndex &index);
+	void on_listView_customContextMenuRequested(const QPoint &pos);
+
+private Q_SLOTS:
+	void mnuFollowInCPU();
+
+private:
+	void showEvent(QShowEvent *event) override;
+
+private:
+	Ui::DialogCommentsViewer ui;
+	QStringListModel *model_            = nullptr;
+	QSortFilterProxyModel *filterModel_ = nullptr;
+};
+
+}
+
+#endif

--- a/plugins/CommentsViewer/DialogCommentsViewer.ui
+++ b/plugins/CommentsViewer/DialogCommentsViewer.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <author>Victorien Molle</author>
+ <class>CommentsViewerPlugin::DialogCommentsViewer</class>
+ <widget class="QDialog" name="CommentsViewerPlugin::DialogCommentsViewer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Comments</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Found comments:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="txtSearch">
+     <property name="placeholderText">
+      <string>Filter</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListView" name="listView">
+     <property name="font">
+      <font>
+       <family>Monospace</family>
+      </font>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CommentsViewerPlugin::DialogCommentsViewer</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>195</x>
+     <y>296</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>524</x>
+     <y>256</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CommentsViewerPlugin::DialogCommentsViewer</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>121</x>
+     <y>297</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>521</x>
+     <y>311</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Breakpoint.h"
 #include "Configuration.h"
 #include "edb.h"
+#include "ISessionManager.h"
 #include <QtDebug>
 
 namespace DebuggerCorePlugin {
@@ -52,6 +53,7 @@ std::shared_ptr<IBreakpoint> DebuggerCoreBase::addBreakpoint(edb::address_t addr
 
 			auto bp               = std::make_shared<Breakpoint>(address);
 			breakpoints_[address] = bp;
+            edb::v1::session_manager().addBreakpoint(*bp);
 			return bp;
 		}
 
@@ -115,6 +117,7 @@ void DebuggerCoreBase::removeBreakpoint(edb::address_t address) {
 		auto it = breakpoints_.find(address);
 		if (it != breakpoints_.end()) {
 			breakpoints_.erase(it);
+            edb::v1::session_manager().removeBreakpoint(address);
 		}
 	}
 }

--- a/plugins/DebuggerCore/DebuggerCoreBase.cpp
+++ b/plugins/DebuggerCore/DebuggerCoreBase.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<IBreakpoint> DebuggerCoreBase::addBreakpoint(edb::address_t addr
 
 			auto bp               = std::make_shared<Breakpoint>(address);
 			breakpoints_[address] = bp;
-            edb::v1::session_manager().addBreakpoint(*bp);
+			edb::v1::session_manager().addBreakpoint(*bp);
 			return bp;
 		}
 
@@ -117,7 +117,7 @@ void DebuggerCoreBase::removeBreakpoint(edb::address_t address) {
 		auto it = breakpoints_.find(address);
 		if (it != breakpoints_.end()) {
 			breakpoints_.erase(it);
-            edb::v1::session_manager().removeBreakpoint(address);
+			edb::v1::session_manager().removeBreakpoint(address);
 		}
 	}
 }

--- a/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
+++ b/plugins/DebuggerCore/arch/x86-generic/Breakpoint.cpp
@@ -89,13 +89,15 @@ void Breakpoint::setType(TypeId type) {
  * @param type
  */
 void Breakpoint::setType(IBreakpoint::TypeId type) {
+	TypeId _type;
 	disable();
 
 	if (Type{type} >= TypeId::TYPE_COUNT) {
 		throw BreakpointCreationError();
 	}
 
-	setType(type);
+	_type = Type{type}.operator DebuggerCorePlugin::Breakpoint::TypeId();
+	setType(_type);
 }
 
 /**

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1013,7 +1013,7 @@ void Debugger::closeEvent(QCloseEvent *event) {
 	// make sure sessions still get recorded even if they just close us
 	const QString filename = sessionFilename();
 	if (!filename.isEmpty()) {
-		SessionManager::instance().saveSession(filename);
+        edb::v1::session_manager().saveSession(filename);
 	}
 
 	if (IDebugger *core = edb::v1::debugger_core) {
@@ -2829,7 +2829,7 @@ void Debugger::detachFromProcess(DetachAction kill) {
 
 	const QString filename = sessionFilename();
 	if (!filename.isEmpty()) {
-		SessionManager::instance().saveSession(filename);
+        edb::v1::session_manager().saveSession(filename);
 	}
 
 	programExecutable_.clear();
@@ -2889,11 +2889,13 @@ void Debugger::setInitialDebuggerState() {
 	const QString filename = sessionFilename();
 	if (!filename.isEmpty()) {
 
-		SessionManager &session_manager = SessionManager::instance();
+        const ISessionManager &session_manager = edb::v1::session_manager();
 
-		if (Result<void, SessionError> session_error = session_manager.loadSession(filename)) {
-			QVariantList comments_data = session_manager.comments();
-			ui.cpuView->restoreComments(comments_data);
+        if (Result<void, SessionError> session_error = edb::v1::session_manager().loadSession(filename)) {
+            QVariantList comments_data = session_manager.comments();
+            QVariantList labels_data = session_manager.labels();
+            ui.cpuView->restoreComments(comments_data);
+            edb::v1::symbol_manager().restoreLabels(labels_data);
 		} else {
 			QMessageBox::warning(
 				this,

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1013,7 +1013,7 @@ void Debugger::closeEvent(QCloseEvent *event) {
 	// make sure sessions still get recorded even if they just close us
 	const QString filename = sessionFilename();
 	if (!filename.isEmpty()) {
-        edb::v1::session_manager().saveSession(filename);
+		edb::v1::session_manager().saveSession(filename);
 	}
 
 	if (IDebugger *core = edb::v1::debugger_core) {
@@ -2829,7 +2829,7 @@ void Debugger::detachFromProcess(DetachAction kill) {
 
 	const QString filename = sessionFilename();
 	if (!filename.isEmpty()) {
-        edb::v1::session_manager().saveSession(filename);
+		edb::v1::session_manager().saveSession(filename);
 	}
 
 	programExecutable_.clear();

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -282,7 +282,7 @@ void SymbolManager::setSymbolGenerator(ISymbolGenerator *generator) {
 //       wants to call this address). And only apply to code
 //------------------------------------------------------------------------------
 void SymbolManager::setLabel(edb::address_t address, const QString &label) {
-    Label vlabel;
+	Label vlabel;
 
 	if (label.isEmpty()) {
 		labelsByName_.remove(labels_[address]);
@@ -299,18 +299,18 @@ void SymbolManager::setLabel(edb::address_t address, const QString &label) {
 
 		labels_[address]     = label;
 		labelsByName_[label] = address;
-        vlabel.address = address;
-        vlabel.comment = label;
-        edb::v1::session_manager().addLabel(vlabel);
+		vlabel.address = address;
+		vlabel.comment = label;
+		edb::v1::session_manager().addLabel(vlabel);
 	}
 }
 
 void SymbolManager::restoreLabels(const QVariantList &labels) {
-    qDebug("Restoring labels");
-    for (auto it = labels.begin(); it != labels.end(); ++it) {
-        QVariantMap data = it->toMap();
-        this->setLabel(edb::v1::string_to_address(data["address"].toString()).value(), data["label"].toString());
-    }
+	qDebug("Restoring labels");
+	for (auto it = labels.begin(); it != labels.end(); ++it) {
+		QVariantMap data = it->toMap();
+		this->setLabel(edb::v1::string_to_address(data["address"].toString()).value(), data["label"].toString());
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/src/SymbolManager.cpp
+++ b/src/SymbolManager.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "SymbolManager.h"
 #include "Configuration.h"
+#include "ISessionManager.h"
 #include "ISymbolGenerator.h"
 #include "Symbol.h"
 #include "edb.h"
@@ -281,6 +282,8 @@ void SymbolManager::setSymbolGenerator(ISymbolGenerator *generator) {
 //       wants to call this address). And only apply to code
 //------------------------------------------------------------------------------
 void SymbolManager::setLabel(edb::address_t address, const QString &label) {
+    Label vlabel;
+
 	if (label.isEmpty()) {
 		labelsByName_.remove(labels_[address]);
 		labels_.remove(address);
@@ -296,7 +299,18 @@ void SymbolManager::setLabel(edb::address_t address, const QString &label) {
 
 		labels_[address]     = label;
 		labelsByName_[label] = address;
+        vlabel.address = address;
+        vlabel.comment = label;
+        edb::v1::session_manager().addLabel(vlabel);
 	}
+}
+
+void SymbolManager::restoreLabels(const QVariantList &labels) {
+    qDebug("Restoring labels");
+    for (auto it = labels.begin(); it != labels.end(); ++it) {
+        QVariantMap data = it->toMap();
+        this->setLabel(edb::v1::string_to_address(data["address"].toString()).value(), data["label"].toString());
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/SymbolManager.h
+++ b/src/SymbolManager.h
@@ -44,7 +44,7 @@ public:
 	void loadSymbolFile(const QString &filename, edb::address_t base) override;
 	void setSymbolGenerator(ISymbolGenerator *generator) override;
 	void setLabel(edb::address_t address, const QString &label) override;
-    void restoreLabels(const QVariantList &labels) override;
+	void restoreLabels(const QVariantList &labels) override;
 	QString findAddressName(edb::address_t address, bool prefixed = true) override;
 	QHash<edb::address_t, QString> labels() const override;
 	QStringList files() const override;

--- a/src/SymbolManager.h
+++ b/src/SymbolManager.h
@@ -44,6 +44,7 @@ public:
 	void loadSymbolFile(const QString &filename, edb::address_t base) override;
 	void setSymbolGenerator(ISymbolGenerator *generator) override;
 	void setLabel(edb::address_t address, const QString &label) override;
+    void restoreLabels(const QVariantList &labels) override;
 	QString findAddressName(edb::address_t address, bool prefixed = true) override;
 	QHash<edb::address_t, QString> labels() const override;
 	QStringList files() const override;

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -208,7 +208,7 @@ ISymbolManager &symbol_manager() {
 // Desc:
 //------------------------------------------------------------------------------
 ISessionManager &session_manager() {
-    return SessionManager::instance();
+	return SessionManager::instance();
 }
 
 //------------------------------------------------------------------------------

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -39,6 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "QHexView"
 #include "QtHelper.h"
 #include "State.h"
+#include "SessionManager.h"
 #include "Symbol.h"
 #include "SymbolManager.h"
 #include "version.h"
@@ -200,6 +201,14 @@ void repaint_cpu_view() {
 ISymbolManager &symbol_manager() {
 	static SymbolManager g_SymbolManager;
 	return g_SymbolManager;
+}
+
+//------------------------------------------------------------------------------
+// Name: session_manager
+// Desc:
+//------------------------------------------------------------------------------
+ISessionManager &session_manager() {
+    return SessionManager::instance();
 }
 
 //------------------------------------------------------------------------------

--- a/src/session/SessionManager.cpp
+++ b/src/session/SessionManager.cpp
@@ -179,7 +179,7 @@ void SessionManager::loadPluginData() {
  * @return all breakpoints from the sessionData_
  */
 QVariantList SessionManager::breakpoints() const {
-    return sessionData_["breakpoints"].toList();
+	return sessionData_["breakpoints"].toList();
 }
 
 /**
@@ -195,7 +195,7 @@ QVariantList SessionManager::comments() const {
  * @return all labels from the sessionData_
  */
 QVariantList SessionManager::labels() const {
-    return sessionData_["labels"].toList();
+	return sessionData_["labels"].toList();
 }
 
 /**
@@ -203,26 +203,26 @@ QVariantList SessionManager::labels() const {
 * @param b
 */
 void SessionManager::addBreakpoint(const IBreakpoint &b) {
-    QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
+	QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
 
-    QVariantMap breakpoint;
-    breakpoint["address"] = b.address().toHexString();
-    breakpoint["enabled"] = b.enabled();
-    breakpoint["type"] = quint8(b.type());
+	QVariantMap breakpoint;
+	breakpoint["address"] = b.address().toHexString();
+	breakpoint["enabled"] = b.enabled();
+	breakpoint["type"] = quint8(b.type());
 
-    //Check if we already have an entry with the same address and overwrite it
-    auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&breakpoint](QVariant entry) {
-        QVariantMap data = entry.toMap();
-        return data["address"] == breakpoint["address"];
-    });
+	//Check if we already have an entry with the same address and overwrite it
+	auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&breakpoint](QVariant entry) {
+		QVariantMap data = entry.toMap();
+		return data["address"] == breakpoint["address"];
+	});
 
-    if (it != breakpoints_data.end()) {
-        *it = breakpoint;
-    } else {
-        breakpoints_data.push_back(breakpoint);
-    }
+	if (it != breakpoints_data.end()) {
+		*it = breakpoint;
+	} else {
+		breakpoints_data.push_back(breakpoint);
+	}
 
-    sessionData_["breakpoints"] = breakpoints_data;
+	sessionData_["breakpoints"] = breakpoints_data;
 }
 
 /**
@@ -258,27 +258,25 @@ void SessionManager::addComment(const Comment &c) {
 */
 void SessionManager::addLabel(const Label &l) {
 
-    QVariantList labels_data = sessionData_["labels"].toList();
+	QVariantList labels_data = sessionData_["labels"].toList();
 
-    QVariantMap label;
-    label["address"] = l.address.toHexString();
-    label["label"] = l.comment;
+	QVariantMap label;
+	label["address"] = l.address.toHexString();
+	label["label"] = l.comment;
 
-    qDebug() << "Add new label " << l.comment;
+	//Check if we already have an entry with the same address and overwrite it
+	auto it = std::find_if(labels_data.begin(), labels_data.end(), [&label](QVariant entry) {
+		QVariantMap data = entry.toMap();
+		return data["address"] == label["address"];
+	});
 
-    //Check if we already have an entry with the same address and overwrite it
-    auto it = std::find_if(labels_data.begin(), labels_data.end(), [&label](QVariant entry) {
-        QVariantMap data = entry.toMap();
-        return data["address"] == label["address"];
-    });
+	if (it != labels_data.end()) {
+		*it = label;
+	} else {
+		labels_data.push_back(label);
+	}
 
-    if (it != labels_data.end()) {
-        *it = label;
-    } else {
-        labels_data.push_back(label);
-    }
-
-    sessionData_["labels"] = labels_data;
+	sessionData_["labels"] = labels_data;
 }
 
 /**
@@ -286,19 +284,19 @@ void SessionManager::addLabel(const Label &l) {
 * @param address
 */
 void SessionManager::removeBreakpoint(edb::address_t address) {
-	QString hexAddressString   = address.toHexString();
-    QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
+	QString hexAddressString = address.toHexString();
+	QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
 
-    auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&hexAddressString](QVariant entry) {
+	auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&hexAddressString](QVariant entry) {
 		QVariantMap data = entry.toMap();
 		return data["address"] == hexAddressString;
 	});
 
-    if (it != breakpoints_data.end()) {
-        breakpoints_data.erase(it);
+	if (it != breakpoints_data.end()) {
+		breakpoints_data.erase(it);
 	}
 
-    sessionData_["breakpoints"] = breakpoints_data;
+	sessionData_["breakpoints"] = breakpoints_data;
 }
 
 /**
@@ -306,19 +304,19 @@ void SessionManager::removeBreakpoint(edb::address_t address) {
 * @param address
 */
 void SessionManager::removeComment(edb::address_t address) {
-    QString hexAddressString   = address.toHexString();
-    QVariantList comments_data = sessionData_["comments"].toList();
+	QString hexAddressString = address.toHexString();
+	QVariantList comments_data = sessionData_["comments"].toList();
 
-    auto it = std::find_if(comments_data.begin(), comments_data.end(), [&hexAddressString](QVariant entry) {
-        QVariantMap data = entry.toMap();
-        return data["address"] == hexAddressString;
-    });
+	auto it = std::find_if(comments_data.begin(), comments_data.end(), [&hexAddressString](QVariant entry) {
+		QVariantMap data = entry.toMap();
+		return data["address"] == hexAddressString;
+	});
 
-    if (it != comments_data.end()) {
-        comments_data.erase(it);
-    }
+	if (it != comments_data.end()) {
+		comments_data.erase(it);
+	}
 
-    sessionData_["comments"] = comments_data;
+	sessionData_["comments"] = comments_data;
 }
 
 /**
@@ -326,17 +324,17 @@ void SessionManager::removeComment(edb::address_t address) {
 * @param address
 */
 void SessionManager::removeLabel(edb::address_t address) {
-    QString hexAddressString   = address.toHexString();
-    QVariantList labels_data = sessionData_["labels"].toList();
+	QString hexAddressString = address.toHexString();
+	QVariantList labels_data = sessionData_["labels"].toList();
 
-    auto it = std::find_if(labels_data.begin(), labels_data.end(), [&hexAddressString](QVariant entry) {
-        QVariantMap data = entry.toMap();
-        return data["address"] == hexAddressString;
-    });
+	auto it = std::find_if(labels_data.begin(), labels_data.end(), [&hexAddressString](QVariant entry) {
+		QVariantMap data = entry.toMap();
+		return data["address"] == hexAddressString;
+	});
 
-    if (it != labels_data.end()) {
-        labels_data.erase(it);
-    }
+	if (it != labels_data.end()) {
+		labels_data.erase(it);
+	}
 
-    sessionData_["labels"] = labels_data;
+	sessionData_["labels"] = labels_data;
 }

--- a/src/session/SessionManager.cpp
+++ b/src/session/SessionManager.cpp
@@ -175,6 +175,14 @@ void SessionManager::loadPluginData() {
 }
 
 /**
+ * @brief SessionManager::breakpoints
+ * @return all breakpoints from the sessionData_
+ */
+QVariantList SessionManager::breakpoints() const {
+    return sessionData_["breakpoints"].toList();
+}
+
+/**
  * @brief SessionManager::comments
  * @return all comments from the sessionData_
  */
@@ -188,6 +196,33 @@ QVariantList SessionManager::comments() const {
  */
 QVariantList SessionManager::labels() const {
     return sessionData_["labels"].toList();
+}
+
+/**
+* Adds a breakpoint to the session_data
+* @param b
+*/
+void SessionManager::addBreakpoint(const IBreakpoint &b) {
+    QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
+
+    QVariantMap breakpoint;
+    breakpoint["address"] = b.address().toHexString();
+    breakpoint["enabled"] = b.enabled();
+    breakpoint["type"] = quint8(b.type());
+
+    //Check if we already have an entry with the same address and overwrite it
+    auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&breakpoint](QVariant entry) {
+        QVariantMap data = entry.toMap();
+        return data["address"] == breakpoint["address"];
+    });
+
+    if (it != breakpoints_data.end()) {
+        *it = breakpoint;
+    } else {
+        breakpoints_data.push_back(breakpoint);
+    }
+
+    sessionData_["breakpoints"] = breakpoints_data;
 }
 
 /**
@@ -247,23 +282,43 @@ void SessionManager::addLabel(const Label &l) {
 }
 
 /**
-* Removes a comment from the session_data
+* Removes a breakpoint from the session_data
 * @param address
 */
-void SessionManager::removeComment(edb::address_t address) {
+void SessionManager::removeBreakpoint(edb::address_t address) {
 	QString hexAddressString   = address.toHexString();
-	QVariantList comments_data = sessionData_["comments"].toList();
+    QVariantList breakpoints_data = sessionData_["breakpoints"].toList();
 
-	auto it = std::find_if(comments_data.begin(), comments_data.end(), [&hexAddressString](QVariant entry) {
+    auto it = std::find_if(breakpoints_data.begin(), breakpoints_data.end(), [&hexAddressString](QVariant entry) {
 		QVariantMap data = entry.toMap();
 		return data["address"] == hexAddressString;
 	});
 
-	if (it != comments_data.end()) {
-		comments_data.erase(it);
+    if (it != breakpoints_data.end()) {
+        breakpoints_data.erase(it);
 	}
 
-	sessionData_["comments"] = comments_data;
+    sessionData_["breakpoints"] = breakpoints_data;
+}
+
+/**
+* Removes a label from the session_data
+* @param address
+*/
+void SessionManager::removeComment(edb::address_t address) {
+    QString hexAddressString   = address.toHexString();
+    QVariantList comments_data = sessionData_["comments"].toList();
+
+    auto it = std::find_if(comments_data.begin(), comments_data.end(), [&hexAddressString](QVariant entry) {
+        QVariantMap data = entry.toMap();
+        return data["address"] == hexAddressString;
+    });
+
+    if (it != comments_data.end()) {
+        comments_data.erase(it);
+    }
+
+    sessionData_["comments"] = comments_data;
 }
 
 /**

--- a/src/session/SessionManager.cpp
+++ b/src/session/SessionManager.cpp
@@ -183,6 +183,14 @@ QVariantList SessionManager::comments() const {
 }
 
 /**
+ * @brief SessionManager::labels
+ * @return all labels from the sessionData_
+ */
+QVariantList SessionManager::labels() const {
+    return sessionData_["labels"].toList();
+}
+
+/**
 * Adds a comment to the session_data
 * @param c (struct in Types.h)
 */
@@ -210,6 +218,35 @@ void SessionManager::addComment(const Comment &c) {
 }
 
 /**
+* Adds a label to the session_data
+* @param l (struct in Types.h)
+*/
+void SessionManager::addLabel(const Label &l) {
+
+    QVariantList labels_data = sessionData_["labels"].toList();
+
+    QVariantMap label;
+    label["address"] = l.address.toHexString();
+    label["label"] = l.comment;
+
+    qDebug() << "Add new label " << l.comment;
+
+    //Check if we already have an entry with the same address and overwrite it
+    auto it = std::find_if(labels_data.begin(), labels_data.end(), [&label](QVariant entry) {
+        QVariantMap data = entry.toMap();
+        return data["address"] == label["address"];
+    });
+
+    if (it != labels_data.end()) {
+        *it = label;
+    } else {
+        labels_data.push_back(label);
+    }
+
+    sessionData_["labels"] = labels_data;
+}
+
+/**
 * Removes a comment from the session_data
 * @param address
 */
@@ -227,4 +264,24 @@ void SessionManager::removeComment(edb::address_t address) {
 	}
 
 	sessionData_["comments"] = comments_data;
+}
+
+/**
+* Removes a label from the session_data
+* @param address
+*/
+void SessionManager::removeLabel(edb::address_t address) {
+    QString hexAddressString   = address.toHexString();
+    QVariantList labels_data = sessionData_["labels"].toList();
+
+    auto it = std::find_if(labels_data.begin(), labels_data.end(), [&hexAddressString](QVariant entry) {
+        QVariantMap data = entry.toMap();
+        return data["address"] == hexAddressString;
+    });
+
+    if (it != labels_data.end()) {
+        labels_data.erase(it);
+    }
+
+    sessionData_["labels"] = labels_data;
 }

--- a/src/session/SessionManager.h
+++ b/src/session/SessionManager.h
@@ -40,10 +40,13 @@ public:
 public:
 	Result<void, SessionError> loadSession(const QString &filename) override;
 	void saveSession(const QString &filename) override;
+    QVariantList breakpoints() const override;
 	QVariantList comments() const override;
     QVariantList labels() const override;
+    void addBreakpoint(const IBreakpoint &b) override;
     void addComment(const Comment &c) override;
     void addLabel(const Label &l) override;
+    void removeBreakpoint(edb::address_t address) override;
     void removeComment(edb::address_t address) override;
     void removeLabel(edb::address_t address) override;
 

--- a/src/session/SessionManager.h
+++ b/src/session/SessionManager.h
@@ -19,15 +19,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef SESSION_MANAGER_H_20170928_
 #define SESSION_MANAGER_H_20170928_
 
+#include "ISessionManager.h"
 #include "SessionError.h"
-#include "Status.h"
-#include "Types.h"
 
 #include <QCoreApplication>
-#include <QString>
-#include <QVariant>
 
-class SessionManager {
+class SessionManager final : public ISessionManager {
 	Q_DECLARE_TR_FUNCTIONS(SessionManager)
 
 private:
@@ -41,11 +38,11 @@ public:
 	static SessionManager &instance();
 
 public:
-	Result<void, SessionError> loadSession(const QString &filename);
-	void saveSession(const QString &filename);
-	QVariantList comments() const;
-	void addComment(const Comment &c);
-	void removeComment(edb::address_t address);
+	Result<void, SessionError> loadSession(const QString &filename) override;
+	void saveSession(const QString &filename) override;
+	QVariantList comments() const override;
+	void addComment(const Comment &c) override;
+	void removeComment(edb::address_t address) override;
 
 private:
 	void loadPluginData();

--- a/src/session/SessionManager.h
+++ b/src/session/SessionManager.h
@@ -41,8 +41,11 @@ public:
 	Result<void, SessionError> loadSession(const QString &filename) override;
 	void saveSession(const QString &filename) override;
 	QVariantList comments() const override;
-	void addComment(const Comment &c) override;
-	void removeComment(edb::address_t address) override;
+    QVariantList labels() const override;
+    void addComment(const Comment &c) override;
+    void addLabel(const Label &l) override;
+    void removeComment(edb::address_t address) override;
+    void removeLabel(edb::address_t address) override;
 
 private:
 	void loadPluginData();

--- a/src/session/SessionManager.h
+++ b/src/session/SessionManager.h
@@ -40,15 +40,15 @@ public:
 public:
 	Result<void, SessionError> loadSession(const QString &filename) override;
 	void saveSession(const QString &filename) override;
-    QVariantList breakpoints() const override;
+	QVariantList breakpoints() const override;
 	QVariantList comments() const override;
-    QVariantList labels() const override;
-    void addBreakpoint(const IBreakpoint &b) override;
-    void addComment(const Comment &c) override;
-    void addLabel(const Label &l) override;
-    void removeBreakpoint(edb::address_t address) override;
-    void removeComment(edb::address_t address) override;
-    void removeLabel(edb::address_t address) override;
+	QVariantList labels() const override;
+	void addBreakpoint(const IBreakpoint &b) override;
+	void addComment(const Comment &c) override;
+	void addLabel(const Label &l) override;
+	void removeBreakpoint(edb::address_t address) override;
+	void removeComment(edb::address_t address) override;
+	void removeLabel(edb::address_t address) override;
 
 private:
 	void loadPluginData();

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -2096,7 +2096,7 @@ void QDisassemblyView::addComment(edb::address_t address, QString comment) {
 	Comment temp_comment = {
 		address,
 		comment};
-    edb::v1::session_manager().addComment(temp_comment);
+	edb::v1::session_manager().addComment(temp_comment);
 	comments_.insert(address, comment);
 }
 
@@ -2105,7 +2105,7 @@ void QDisassemblyView::addComment(edb::address_t address, QString comment) {
 // Desc: Removes a comment from the comment hash and returns the number of comments removed.
 //------------------------------------------------------------------------------
 int QDisassemblyView::removeComment(edb::address_t address) {
-    edb::v1::session_manager().removeComment(address);
+	edb::v1::session_manager().removeComment(address);
 	return comments_.remove(address);
 }
 

--- a/src/widgets/QDisassemblyView.cpp
+++ b/src/widgets/QDisassemblyView.cpp
@@ -2096,7 +2096,7 @@ void QDisassemblyView::addComment(edb::address_t address, QString comment) {
 	Comment temp_comment = {
 		address,
 		comment};
-	SessionManager::instance().addComment(temp_comment);
+    edb::v1::session_manager().addComment(temp_comment);
 	comments_.insert(address, comment);
 }
 
@@ -2105,7 +2105,7 @@ void QDisassemblyView::addComment(edb::address_t address, QString comment) {
 // Desc: Removes a comment from the comment hash and returns the number of comments removed.
 //------------------------------------------------------------------------------
 int QDisassemblyView::removeComment(edb::address_t address) {
-	SessionManager::instance().removeComment(address);
+    edb::v1::session_manager().removeComment(address);
 	return comments_.remove(address);
 }
 
@@ -2163,6 +2163,7 @@ void QDisassemblyView::restoreState(const QByteArray &stateBuffer) {
 		}
 	}
 }
+
 //------------------------------------------------------------------------------
 // Name: restoreComments
 // Desc:

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -82,9 +82,9 @@ public:
 	int removeComment(edb::address_t address);
 	int selectedSize() const;
 	std::shared_ptr<IRegion> region() const;
-	void addComment(edb::address_t address, QString comment);
-	void clearComments();
-	void restoreComments(QVariantList &);
+    void addComment(edb::address_t address, QString comment);
+    void clearComments();
+    void restoreComments(QVariantList &);
 	void restoreState(const QByteArray &stateBuffer);
 	void setSelectedAddress(edb::address_t address);
 
@@ -174,7 +174,7 @@ private:
 	std::vector<CapstoneEDB::Instruction> instructions_;
 	SyntaxHighlighter *highlighter_;
 	bool showAddressSeparator_;
-	QHash<edb::address_t, QString> comments_;
+    QHash<edb::address_t, QString> comments_;
 	NavigationHistory history_;
 	QSvgRenderer breakpointRenderer_;
 	QSvgRenderer currentRenderer_;

--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -82,9 +82,9 @@ public:
 	int removeComment(edb::address_t address);
 	int selectedSize() const;
 	std::shared_ptr<IRegion> region() const;
-    void addComment(edb::address_t address, QString comment);
-    void clearComments();
-    void restoreComments(QVariantList &);
+	void addComment(edb::address_t address, QString comment);
+	void clearComments();
+	void restoreComments(QVariantList &);
 	void restoreState(const QByteArray &stateBuffer);
 	void setSelectedAddress(edb::address_t address);
 
@@ -174,7 +174,7 @@ private:
 	std::vector<CapstoneEDB::Instruction> instructions_;
 	SyntaxHighlighter *highlighter_;
 	bool showAddressSeparator_;
-    QHash<edb::address_t, QString> comments_;
+	QHash<edb::address_t, QString> comments_;
 	NavigationHistory history_;
 	QSvgRenderer breakpointRenderer_;
 	QSvgRenderer currentRenderer_;


### PR DESCRIPTION
These commits enable a better support of the Session Manager by now saving:
- labels
- breakpoints

This is a WIP patch as I don't know if my code/modifications fit your needs; do not hesitate to tell me what's wrong and how I can improve this patch.

On a side note, I wanted to know if it won't be better, instead of saving the fixed address of the comment/label/breakpoint, to save the relative address of the comment/label/breakpoint with the name of the module so the restore process should correctly work even if base addresses change at each process restart (with ASLR for example). What do you think about this idea?

Thanks.