### PR TITLE
widgets/QDisassemblyView: include QPainterPath

### DIFF
--- a/src/widgets/QDisassemblyView.h
+++ b/src/widgets/QDisassemblyView.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QAbstractScrollArea>
 #include <QAbstractSlider>
 #include <QCache>
+#include <QPainterPath>
 #include <QPixmap>
 #include <QSvgRenderer>
 


### PR DESCRIPTION
Fix build failure on qt-5.15. Typical build error is:

src/widgets/QDisassemblyView.cpp:1503:17:
  error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
 1503 |    QPainterPath path;
      |                 ^~~~

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/727530