### PR TITLE
x86-generic/PlatformThread.cpp: avoid non-constant offsetof for gcc-11

### DIFF
--- a/plugins/DebuggerCore/unix/linux/arch/x86-generic/PlatformThread.cpp
+++ b/plugins/DebuggerCore/unix/linux/arch/x86-generic/PlatformThread.cpp
@@ -318,7 +318,8 @@ edb::address_t PlatformThread::instructionPointer() const {
  * @return
  */
 unsigned long PlatformThread::getDebugRegister(std::size_t n) {
-	return ptrace(PTRACE_PEEKUSER, tid_, offsetof(struct user, u_debugreg[n]), 0);
+	size_t drOffset = offsetof(struct user, u_debugreg) + n * sizeof(user::u_debugreg[0]);
+	return ptrace(PTRACE_PEEKUSER, tid_, drOffset, 0);
 }
 
 /**
@@ -328,7 +329,8 @@ unsigned long PlatformThread::getDebugRegister(std::size_t n) {
  * @return
  */
 long PlatformThread::setDebugRegister(std::size_t n, unsigned long value) {
-	return ptrace(PTRACE_POKEUSER, tid_, offsetof(struct user, u_debugreg[n]), value);
+	size_t drOffset = offsetof(struct user, u_debugreg) + n * sizeof(user::u_debugreg[0]);
+	return ptrace(PTRACE_POKEUSER, tid_, drOffset, value);
 }
 
 /**


### PR DESCRIPTION
On gcc-11 edb-debugger build fails as:

```
.../x86-generic/PlatformThread.cpp:332:79: error: 'n' is not a constant expression
  332 |         return ptrace(PTRACE_POKEUSER, tid_, offsetof(struct user, u_debugreg[n]), value);
      |                                                                               ^
```

It's a regression of gcc-11 compared to gcc-10, but it's not
clear if non-constant expressions are guaranteed to work in
general: https://gcc.gnu.org/PR95942. gcc used to accept
simple expressions, but nothing complex.

The change workarounds build failure by avoiding non-constant expression.