### PR TITLE
CMake version managments of whole project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required (VERSION 3.1)
-project (edb 
-	LANGUAGES CXX
-	VERSION 1.3.0
-	)
+project (edb LANGUAGES CXX VERSION 1.3.0)
 
 enable_testing()
 
@@ -25,6 +22,9 @@ include("AddWarnings")
 if(TARGET_COMPILER_GCC AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5.0)
 	message(FATAL_ERROR "Your g++ version is too old. At least 5.0 is required.")
 endif()
+
+configure_file(include/version.h.in include/version.h)
+include_directories("${PROJECT_BINARY_DIR}/include")
 
 find_package(Capstone REQUIRED)
 include_directories(${CAPSTONE_INCLUDE_DIRS})

--- a/include/version.h.in
+++ b/include/version.h.in
@@ -19,8 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef VERSION_H_20061109_
 #define VERSION_H_20061109_
 
-namespace edb {
-extern const char version[];
-}
+#define EDB_VERSION_STRING "@PROJECT_VERSION@"
 
 #endif

--- a/plugins/CheckVersion/CheckVersion.cpp
+++ b/plugins/CheckVersion/CheckVersion.cpp
@@ -88,7 +88,7 @@ void CheckVersion::doCheck() {
 		connect(network_, &QNetworkAccessManager::finished, this, &CheckVersion::requestFinished);
 	}
 
-	QUrl update_url(QString("https://codef00.com/projects/debugger-latest.json?v=%1").arg(edb::version));
+	QUrl update_url(QString("https://codef00.com/projects/debugger-latest.json?v=%1").arg(EDB_VERSION_STRING));
 	QNetworkRequest request(update_url);
 
 	setProxy(update_url);

--- a/plugins/DebuggerCore/unix/linux/FeatureDetect.cpp
+++ b/plugins/DebuggerCore/unix/linux/FeatureDetect.cpp
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "FeatureDetect.h"
-#include "version.h"
+#include "edb.h"
 
 #include <fcntl.h>
 #include <iomanip>
@@ -135,7 +135,7 @@ bool detect_proc_access(bool *read_broken, bool *write_broken) {
 		}
 
 		const auto pageAlignMask = ~(sysconf(_SC_PAGESIZE) - 1);
-		const auto addr          = reinterpret_cast<uintptr_t>(&edb::version) & pageAlignMask;
+		const auto addr          = reinterpret_cast<uintptr_t>(&edb::v1::debugger_ui) & pageAlignMask;
 		file.seekp(addr);
 		if (!file) {
 			perror("failed to seek to address to read");

--- a/src/DialogAbout.cpp
+++ b/src/DialogAbout.cpp
@@ -32,5 +32,5 @@ DialogAbout::DialogAbout(QWidget *parent, Qt::WindowFlags f)
 	ui.labelVersion->setText(tr("Version: %1<br>\n"
 								"Compiled: %2<br>\n"
 								"Git Commit: <a href=\"https://github.com/eteran/edb-debugger/commit/%3\">%3</a>")
-								 .arg(edb::version, __DATE__, TOSTRING(GIT_BRANCH)));
+								 .arg(EDB_VERSION_STRING, __DATE__, TOSTRING(GIT_BRANCH)));
 }

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -96,8 +96,6 @@ bool function_symbol_base(edb::address_t address, QString *value, int *offset) {
 }
 }
 
-const char version[] = "1.3.0";
-
 namespace internal {
 
 //------------------------------------------------------------------------------
@@ -1040,7 +1038,7 @@ void register_binary_info(IBinary::create_func_ptr_t fptr) {
 // Desc: returns an integer comparable version of our current version string
 //------------------------------------------------------------------------------
 quint32 edb_version() {
-	return int_version(version);
+	return int_version(EDB_VERSION_STRING);
 }
 
 //------------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void load_plugins(const QString &directory) {
  */
 int start_debugger(const LaunchArguments &launch_args) {
 
-	qDebug() << "Starting edb version:" << edb::version;
+	qDebug() << "Starting edb version:" << EDB_VERSION_STRING;
 	qDebug("Please Report Bugs & Requests At: https://github.com/eteran/edb-debugger/issues");
 
 	edb::internal::load_function_db();
@@ -317,7 +317,7 @@ int main(int argc, char *argv[]) {
 	QApplication::setOrganizationName("codef00.com");
 	QApplication::setOrganizationDomain("codef00.com");
 	QApplication::setApplicationName("edb");
-	QApplication::setApplicationVersion(edb::version);
+	QApplication::setApplicationVersion(EDB_VERSION_STRING);
 
 	load_translations();
 
@@ -347,10 +347,10 @@ int main(int argc, char *argv[]) {
 	for (int i = 1; i < args.size(); ++i) {
 
 		if (args[i] == "--version") {
-			std::cout << "edb version: " << edb::version << std::endl;
+			std::cout << "edb version: " << EDB_VERSION_STRING << std::endl;
 			return 0;
 		} else if (args[i] == "--dump-version") {
-			std::cout << edb::version << std::endl;
+			std::cout << EDB_VERSION_STRING << std::endl;
 			return 0;
 		} else if (args[i] == "--attach") {
 			++i;


### PR DESCRIPTION
Using cmake as the central method of managing edb's version. We then use cmake to generate an appropriate version.h that can be used project-wide.