### PR TITLE
make binary string search read proc mem in chunks

### DIFF
--- a/plugins/BinarySearcher/DialogBinaryString.cpp
+++ b/plugins/BinarySearcher/DialogBinaryString.cpp
@@ -108,7 +108,7 @@ void DialogBinaryString::doFind() {
 						}
 
 						// update progress bar every 64KB
-						if ((uint64_t(p) & 0xFFFF) == 0) {
+						if ((reinterpret_cast<uint64_t>(p) & 0xFFFF) == 0) {
 							ui.progressBar->setValue(util::percentage(i, regions.size(), p - &pages[0], region_size));
 						}
 


### PR DESCRIPTION
Instead of trying to read an entire debuggee process region at
once, read up to 4096 pages at a time. This should reduce memory
issues when running against processes that allocate huge amounts of
memory such as modern games.

In addition, slightly optimize the performance if byte alignment is on.