### PR TITLE
Fix some BinaryInfo crashes

### DIFF
--- a/plugins/BinaryInfo/symbols.cpp
+++ b/plugins/BinaryInfo/symbols.cpp
@@ -174,7 +174,6 @@ the symbol is local; if uppercase, the symbol is global (external).
 
 template <class M, class Size>
 void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &symbols) {
-	Q_UNUSED(size)
 
 	using elf_addr   = typename M::elf_addr;
 	using elf_header = typename M::elf_header;
@@ -200,6 +199,10 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 
 	// collect special section addresses
 	for (const elf_shdr *section = sections_begin; section != sections_end; ++section) {
+		if (section_strings + section->sh_name < (void *)base || section_strings + section->sh_name > (void *)(base + size)) {
+			continue;
+		}
+
 		if (strcmp(&section_strings[section->sh_name], ".plt") == 0) {
 			plt_address = section->sh_addr;
 		} else if (strcmp(&section_strings[section->sh_name], ".got") == 0) {
@@ -209,6 +212,10 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 
 	// print out relocated symbols for special sections
 	for (const elf_shdr *section = sections_begin; section != sections_end; ++section) {
+		if (section_strings + section->sh_name < (void *)base || section_strings + section->sh_name > (void *)(base + size)) {
+			continue;
+		}
+			
 		elf_addr base_address = 0;
 		if (strcmp(&section_strings[section->sh_name], ".rela.plt") == 0) {
 			base_address = plt_address;

--- a/plugins/BinaryInfo/symbols.cpp
+++ b/plugins/BinaryInfo/symbols.cpp
@@ -199,7 +199,7 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 
 	// collect special section addresses
 	for (const elf_shdr *section = sections_begin; section != sections_end; ++section) {
-		if (section_strings + section->sh_name < (void *)base || section_strings + section->sh_name > (void *)(base + size)) {
+		if (section_strings + section->sh_name < reinterpret_cast<void *>(base) || section_strings + section->sh_name > reinterpret_cast<void *>(base + size)) {
 			continue;
 		}
 
@@ -212,7 +212,7 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 
 	// print out relocated symbols for special sections
 	for (const elf_shdr *section = sections_begin; section != sections_end; ++section) {
-		if (section_strings + section->sh_name < (void *)base || section_strings + section->sh_name > (void *)(base + size)) {
+		if (section_strings + section->sh_name < reinterpret_cast<void *>(base) || section_strings + section->sh_name > reinterpret_cast<void *>(base + size)) {
 			continue;
 		}
 			
@@ -229,6 +229,7 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 			continue;
 		}
 
+		auto section_entries_count = section->sh_entsize ? section->sh_size / section->sh_entsize : 0;
 		switch (section->sh_type) {
 		case SHT_RELA: {
 			elf_addr n      = 0;
@@ -238,7 +239,7 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 				break;
 			}
 
-			for (size_t i = 0; i < section->sh_size / section->sh_entsize; ++i) {
+			for (size_t i = 0; i < section_entries_count; ++i) {
 
 				const size_t sym_index = M::elf_r_sym(relocation[i].r_info);
 				const elf_shdr *linked = &sections_begin[section->sh_link];
@@ -272,7 +273,7 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 				break;
 			}
 
-			for (size_t i = 0; i < section->sh_size / section->sh_entsize; ++i) {
+			for (size_t i = 0; i < section_entries_count; ++i) {
 
 				const size_t sym_index = M::elf_r_sym(relocation[i].r_info);
 				const elf_shdr *linked = &sections_begin[section->sh_link];
@@ -309,8 +310,9 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 		case SHT_DYNSYM: {
 			auto symbol_tab = reinterpret_cast<elf_sym *>(base + section->sh_offset);
 			auto string_tab = reinterpret_cast<const char *>(base + sections_begin[section->sh_link].sh_offset);
+			auto section_entries_count = section->sh_entsize ? section->sh_size / section->sh_entsize : 0;
 
-			for (size_t i = 0; i < section->sh_size / section->sh_entsize; ++i) {
+			for (size_t i = 0; i < section_entries_count; ++i) {
 
 				const elf_shdr *related_section = nullptr;
 
@@ -345,8 +347,9 @@ void collect_symbols(const void *p, Size size, std::vector<typename M::symbol> &
 		case SHT_DYNSYM: {
 			auto symbol_tab = reinterpret_cast<elf_sym *>(base + section->sh_offset);
 			auto string_tab = reinterpret_cast<const char *>(base + sections_begin[section->sh_link].sh_offset);
+			auto section_entries_count = section->sh_entsize ? section->sh_size / section->sh_entsize : 0;
 
-			for (size_t i = 0; i < section->sh_size / section->sh_entsize; ++i) {
+			for (size_t i = 0; i < section_entries_count; ++i) {
 
 				const elf_shdr *related_section = nullptr;
 


### PR DESCRIPTION
Hello! been playing with SHT fuzzing and found a couple of crashes on broken sections.

The first crash happens when `section_strings[section->sh_name]` is not a valid address, the second one happens when trying to iterate over entries in some sections with `sh_entsize` set to 0. 
Meanwhile, those malformed files run happily in the OS itself.