### PR TITLE
Fix build with GCC 13

### DIFF
--- a/plugins/DebuggerCore/unix/linux/FeatureDetect.cpp
+++ b/plugins/DebuggerCore/unix/linux/FeatureDetect.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "FeatureDetect.h"
 #include "edb.h"
 
+#include <cstdint>
 #include <fcntl.h>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/897890