### PR TITLE
Fix CMP0115 warning and use default DEFAULT_PLUGIN_DIR or accept

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,7 +172,7 @@ set(edb_SRCS
 	${PROJECT_SOURCE_DIR}/include/util/Math.h
 	${PROJECT_SOURCE_DIR}/include/util/String.h
 	${PROJECT_SOURCE_DIR}/include/util/Error.h
-	${PROJECT_SOURCE_DIR}/include/version.h
+	${PROJECT_SOURCE_DIR}/include/version.h.in
 )
 
 if(TARGET_ARCH_FAMILY_X86)
@@ -260,9 +260,11 @@ if(UNIX AND TARGET_ARCH_FAMILY_X86)
 	endif()
 endif()
 
-target_compile_definitions(edb PRIVATE
-	-DDEFAULT_PLUGIN_PATH=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb\"
-)
+if (NOT DEFINED DEFAULT_PLUGIN_DIR)
+	message(STATUS "Using default value of EDB Plugin directory")
+	set(DEFAULT_PLUGIN_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb")
+endif()
+target_compile_definitions(edb PRIVATE -DDEFAULT_PLUGIN_PATH="${DEFAULT_PLUGIN_DIR}")
 
 target_link_libraries(edb
 	${CAPSTONE_LIBRARIES}


### PR DESCRIPTION
- In the new version of CMP0115 policy extension must also be provided, there is no version.h in PROJECT_SOURCE_DIRECTORY.
- Accept the DEFAULT_PLUGIN_DIR during CMAKE configure and use default value to ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/edb, if not provided.