### PR TITLE
Show which bookmarks have breakpoints

### DIFF
--- a/include/edb.h
+++ b/include/edb.h
@@ -98,6 +98,7 @@ EDB_EXPORT void set_breakpoint_condition(address_t address, const QString &condi
 EDB_EXPORT void toggle_breakpoint(address_t address);
 
 EDB_EXPORT address_t current_data_view_address();
+EDB_EXPORT address_t instruction_pointer_address();
 
 // change what the various views show
 EDB_EXPORT bool dump_data_range(address_t address, address_t end_address, bool new_tab);

--- a/plugins/Bookmarks/BookmarkWidget.cpp
+++ b/plugins/Bookmarks/BookmarkWidget.cpp
@@ -41,6 +41,7 @@ BookmarkWidget::BookmarkWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.tableView->setModel(model_);
 
 	connect(edb::v1::debugger_ui, SIGNAL(detachEvent()), model_, SLOT(clearBookmarks()));
+	connect(edb::v1::disassembly_widget(), SIGNAL(signalUpdated()), model_, SLOT(updateList()));
 	connect(ui.buttonAdd, &QPushButton::clicked, this, &BookmarkWidget::buttonAddClicked);
 	connect(ui.buttonDel, &QPushButton::clicked, this, &BookmarkWidget::buttonDelClicked);
 	connect(ui.buttonClear, &QPushButton::clicked, this, &BookmarkWidget::buttonClearClicked);

--- a/plugins/Bookmarks/BookmarkWidget.h
+++ b/plugins/Bookmarks/BookmarkWidget.h
@@ -50,10 +50,18 @@ private:
 	void buttonAddClicked();
 	void buttonDelClicked();
 	void buttonClearClicked();
+	void toggleBreakpoint();
+	void addConditionalBreakpoint();
+
+private:
+	template <class F>
+	QAction *createAction(const QString &text, const QKeySequence &keySequence, F func);
 
 private:
 	Ui::BookmarkWidget ui;
 	BookmarksModel *model_ = nullptr;
+	QAction *toggleBreakpointAction_;
+	QAction *conditionalBreakpointAction_;
 };
 
 }

--- a/plugins/Bookmarks/BookmarksModel.cpp
+++ b/plugins/Bookmarks/BookmarksModel.cpp
@@ -68,8 +68,16 @@ QVariant BookmarksModel::data(const QModelIndex &index, int role) const {
 
 	if (role == Qt::DisplayRole) {
 		switch (index.column()) {
-		case 0:
-			return edb::v1::format_pointer(bookmark.address);
+		case 0: {
+			const QString symname = edb::v1::find_function_symbol(bookmark.address);
+			const QString address = edb::v1::format_pointer(bookmark.address);
+			
+			if (!symname.isEmpty()) {
+				return QString("%1 <%2>").arg(address, symname);
+			}
+
+			return address;
+		}
 		case 1:
 			switch (bookmark.type) {
 			case Bookmark::Code:

--- a/plugins/Bookmarks/BookmarksModel.h
+++ b/plugins/Bookmarks/BookmarksModel.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Types.h"
 #include <QAbstractItemModel>
 #include <QVector>
+#include <QIcon>
 
 namespace BookmarksPlugin {
 
@@ -88,12 +89,16 @@ public Q_SLOTS:
 	void deleteBookmark(const QModelIndex &index);
 	void setComment(const QModelIndex &index, const QString &comment);
 	void setType(const QModelIndex &index, const QString &type);
+	void updateList();
 
 public:
 	[[nodiscard]] const QVector<Bookmark> &bookmarks() const { return bookmarks_; }
 
 private:
 	QVector<Bookmark> bookmarks_;
+	QIcon breakpointIcon_;
+	QIcon currentIcon_;
+	QIcon currentBpIcon_;
 };
 
 }

--- a/src/edb.cpp
+++ b/src/edb.cpp
@@ -1304,6 +1304,20 @@ address_t current_data_view_address() {
 }
 
 //------------------------------------------------------------------------------
+// Name: instruction_pointer_address
+// Desc: Returns the address pointed to by the instruction pointer.
+//------------------------------------------------------------------------------
+address_t instruction_pointer_address() {
+	if (IProcess *process = debugger_core->process()) {
+		State state;
+		process->currentThread()->getState(&state);
+		return state.instructionPointer();
+	}
+
+	return address_t{};
+}
+
+//------------------------------------------------------------------------------
 // Name: set_status
 // Desc:
 //------------------------------------------------------------------------------


### PR DESCRIPTION
New features:
* Bookmarks now show their symbol name alongside their address, if it can be found.
* Bookmarks have the same icons beside them that addresses do in the disassembly view (breakpoint, current instruction, or both).
* While bookmark view is in focus, "B" will toggle a breakpoint at that address, and "Shift+B" will add a conditional breakpoint.

It's not all done in the optimal way, but I didn't want to change too many things outside of the Bookmark plugin (the only other change I made is a function in the `edb::v1` namespace that returns the current instruction pointer address).